### PR TITLE
Compatibility fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ DVBCSA?=yes
 DVBCA?=no
 SATIPCLIENT?=yes
 
-CFLAGS=$(NODVBCSA) -ggdb -fPIC
-LDFLAGS=-lpthread -lrt
+CFLAGS?=$(NODVBCSA) -ggdb -fPIC
+LDFLAGS?=-lpthread -lrt
 
 OBJS=minisatip.o socketworks.o stream.o dvb.o adapter.o utils.o
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 CC?=gcc
+EMBEDDED?=no
 DVBCSA?=yes
 DVBCA?=no
 SATIPCLIENT?=yes
@@ -35,6 +36,10 @@ ifeq ($(SATIPCLIENT),yes)
 OBJS+=satipc.o
 else
 CFLAGS+=-DDISABLE_SATIPCLIENT
+endif
+
+ifeq ($(EMBEDDED),yes)
+CFLAGS+=-DNO_BACKTRACE
 endif
 
 

--- a/dvb.c
+++ b/dvb.c
@@ -425,7 +425,9 @@ int dvb_tune(int aid, transponder * tp)
 		ADD_PROP(DTV_INNER_FEC, tp->fec)
 		ADD_PROP(DTV_PILOT, tp->plts)
 		ADD_PROP(DTV_ROLLOFF, tp->ro)
+#if DVBAPIVERSION >= 0x0502
 		ADD_PROP(DTV_STREAM_ID, tp->plp)
+#endif
 
 		LOG(
 				"tuning to %d(%d) pol: %s (%d) sr:%d fec:%s delsys:%s mod:%s rolloff:%s pilot:%s, ts clear=%d, ts pol=%d",
@@ -447,7 +449,9 @@ int dvb_tune(int aid, transponder * tp)
 		ADD_PROP(DTV_GUARD_INTERVAL, tp->gi)
 		ADD_PROP(DTV_TRANSMISSION_MODE, tp->tmode)
 		ADD_PROP(DTV_HIERARCHY, HIERARCHY_AUTO)
+#if DVBAPIVERSION >= 0x0502
 		ADD_PROP(DTV_STREAM_ID, tp->plp & 0xFF)
+#endif
 
 		LOG(
 				"tuning to %d delsys: %s bw:%d inversion:%s mod:%s fec:%s guard:%s transmission: %s, ts clear = %d",
@@ -464,7 +468,9 @@ int dvb_tune(int aid, transponder * tp)
 
 		freq = freq * 1000;
 		ADD_PROP(DTV_SYMBOL_RATE, tp->sr)
+#if DVBAPIVERSION >= 0x0502
 		ADD_PROP(DTV_STREAM_ID, ((tp->ds & 0xFF) << 8) | (tp->plp & 0xFF))
+#endif
 		// valid for DD DVB-C2 devices
 
 		LOG("tuning to %d sr:%d specinv:%s delsys:%s mod:%s ts clear =%d", freq,
@@ -495,10 +501,12 @@ int dvb_tune(int aid, transponder * tp)
 			LOG_AND_RETURN(-404, "Frequency %d is not within range ", tp->freq)
 
 		freq = freq * 1000;
-		ADD_PROP(DTV_ISDBT_PARTIAL_RECEPTION, 0)
 		ADD_PROP(DTV_BANDWIDTH_HZ, tp->bw)
-//	    ADD_PROP(DTV_ISDBT_LAYERA_SEGMENT_COUNT,   1);  
-//	    ADD_PROP(DTV_ISDBT_LAYER_ENABLED,   1); 
+#if DVBAPIVERSION >= 0x0501
+		ADD_PROP(DTV_ISDBT_PARTIAL_RECEPTION, 0)
+//		ADD_PROP(DTV_ISDBT_LAYERA_SEGMENT_COUNT,   1);
+//		ADD_PROP(DTV_ISDBT_LAYER_ENABLED,   1);
+#endif
 
 		LOG("tuning to %d delsys: %s bw:%d inversion:%s , ts clear = %d", freq,
 				fe_delsys[tp->sys], tp->bw, fe_specinv[tp->inversion], bclear)
@@ -630,8 +638,10 @@ fe_delivery_system_t dvb_delsys(int aid, int fd, fe_delivery_system_t *sys)
 		switch (fe_info.type)
 		{
 		case FE_OFDM:
+#if DVBAPIVERSION >= 0x0501
 			if (fe_info.caps & FE_CAN_2G_MODULATION)
 				sys[idx++] = SYS_DVBT2;
+#endif
 
 			sys[idx++] = SYS_DVBT;
 
@@ -640,8 +650,10 @@ fe_delivery_system_t dvb_delsys(int aid, int fd, fe_delivery_system_t *sys)
 			sys[idx++] = SYS_DVBC_ANNEX_AC;
 			break;
 		case FE_QPSK:
+#if DVBAPIVERSION >= 0x0501
 			if (fe_info.caps & FE_CAN_2G_MODULATION)
 				sys[idx++] = SYS_DVBS2;
+#endif
 
 			sys[idx++] = SYS_DVBS;
 

--- a/utils.c
+++ b/utils.c
@@ -51,7 +51,7 @@
 #include "utils.h"
 #include "minisatip.h"
 
-#ifndef __mips__
+#if !defined(__mips__) && !defined(NO_BACKTRACE)
 #include <execinfo.h>
 #endif
 
@@ -387,7 +387,7 @@ void print_trace(void)
 	size_t size;
 	char **strings;
 	size_t i;
-#ifndef __mips__
+#if !defined(__mips__) && !defined(NO_BACKTRACE)
 
 	size = backtrace(array, 10);
 


### PR DESCRIPTION
minisatip currently fails to build for most embedded systems. Even when it builds, it fails to operate for DVBAPI 5.0, 5.1 and 5.2. This pull request addresses [most of] the compatibility problems.

I've tried my best to keep them as small and unobtrusive as possible, and made sure they don't change anything if the code is built for modern systems.

 - Allow the user to supply extra `CFLAGS`, and replace the default `-ggdb -fPIC`.
 - Option to disable use of `execinfo.h`, which isn't present on most embedded systems.
 - Wrap use of recent DVB flags in appropiate `#if` / `#endif`.