### PR TITLE
Logs & Headers cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,12 @@ DVBCA?=no
 SATIPCLIENT?=yes
 NETCVCLIENT?=no
 STATIC?=no
+LINUXDVB?=yes
 
 CFLAGS?=$(NODVBCSA) -ggdb -fPIC $(EXTRA_CFLAGS)
 LDFLAGS?=-lpthread -lrt $(EXTRA_LDFLAGS)
 
-OBJS=minisatip.o socketworks.o stream.o dvb.o adapter.o utils.o
+OBJS=minisatip.o socketworks.o stream.o adapter.o utils.o
 
 TABLES=no
 
@@ -46,6 +47,13 @@ CFLAGS+=-I../vdr-mcli-plugin/mcast/client -I../vdr-mcli-plugin/mcast/common `xml
 LDFLAGS+=-lmcli
 else
 CFLAGS+=-DDISABLE_NETCVCLIENT
+endif
+
+ifeq ($(LINUXDVB),yes)
+OBJS+=dvb.o
+else
+CFLAGS+=-DDISABLE_LINUXDVB
+OBJS+=dvb.o
 endif
 
 ifeq ($(EMBEDDED),yes)

--- a/README.md
+++ b/README.md
@@ -16,70 +16,72 @@ Please use https://toda.ro/forum/ for any questions.
 In order to speed up the investigation of an issue, please provide the full log and a link to the application that is not working.
 
 If you like minisatip and you want to support the development of the project please make a donation: 
-
 https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=7UWQ7FXSABUH8&item_name=minisatip&currency_code=EUR&bn=PP-DonationsBF:btn_donateCC_LG.gif:NonHostedGuest
 
 Usage:
 -------
 minisatip version 0.5.10, compiled with s2api version: 050A
 
-	minisatip [-[fgltz]] [-a x:y:z] [-b X:Y] [-c X] [-d A:C-U ] [-D device_id] [-e X-Y,Z] [-i prio] [-j A1:S1-F1[-PIN]] [-m mac] [-o oscam_host:dvbapi_port] [-p public_host] [-r remote_rtp_host] [-R document_root] [-s [DELSYS:]host[:port] [-u A1:S1-F1[-PIN]] [-w http_server[:port]] [-x http_port] [-X xml_path] [-y rtsp_port] 
+	./minisatip [-[fgltz]] [-a x:y:z] [-b X:Y] [-c X] [-d A:C-U ] [-D device_id] [-e X-Y,Z] [-i prio] \ 
+	[-j A1:S1-F1[-PIN]] [-m mac] [-o oscam_host:dvbapi_port] [-p public_host] [-r remote_rtp_host] \ 
+	[-R document_root] [-s [DELSYS:]host[:port] [-u A1:S1-F1[-PIN]] [-w http_server[:port]] \ 
+	[-x http_port] [-X xml_path] [-y rtsp_port] 
 
 Help
 ------- 
--a x:y:z simulate x DVB-S2, y DVB-T2 and z DVB-C adapters on this box (0 means auto-detect)
+* -a x:y:z simulate x DVB-S2, y DVB-T2 and z DVB-C adapters on this box (0 means auto-detect)
 	eg: -a 1:2:3  
 	- it will report 1 dvb-s2 device, 2 dvb-t2 devices and 3 dvb-c devices 
 
--b --buffers X:Y : set the app adapter buffer to X Bytes (default: 25004) and set the kernel DVB buffer to Y Bytes (default: 5775360) - both multiple of 188
+* -b --buffers X:Y : set the app adapter buffer to X Bytes (default: 25004) and set the kernel DVB buffer to Y Bytes (default: 5775360) - both multiple of 188
 	eg: -b 18800:18988
 
--c X: bandwidth capping for the output to the network [default: unlimited]
+* -c X: bandwidth capping for the output to the network [default: unlimited]
 	eg: -c 2048  (does not allow minisatip to send more than 2048KB/s to all remote servers)
 
--d --diseqc ADAPTER1:COMMITED1-UNCOMMITED1[,ADAPTER2:COMMITED2-UNCOMMITED2[,...]
+* -d --diseqc ADAPTER1:COMMITED1-UNCOMMITED1[,ADAPTER2:COMMITED2-UNCOMMITED2[,...]
 	The first argument is the adapter number, second is the number of commited packets to send to a Diseqc 1.0 switch, third the number of uncommited commands to sent to a Diseqc 1.1 switch
 	The higher number between the commited and uncommited will be sent first.
 	eg: -d 0:1-0  (which is the default for each adapter).
 
--D --device-id DVC_ID: specify the device id (in case there are multiple SAT>IP servers in the network)
+* -D --device-id DVC_ID: specify the device id (in case there are multiple SAT>IP servers in the network)
  	eg: -D 4 
 
--Y --delsys ADAPTER1:DELIVERY_SYSTEM1[,ADAPTER2:DELIVERY_SYSTEM2[,..]] - specify the delivery system of the adapters	
-    eg: --delsys 1:dvbt,2:dvbs
-    - specifies adapter 1 as a DVBT device, adapter 2 as DVB-S, which overrides the system detection of the adapter
+* -Y --delsys ADAPTER1:DELIVERY_SYSTEM1[,ADAPTER2:DELIVERY_SYSTEM2[,..]] - specify the delivery system of the adapters	
+	eg: --delsys 1:dvbt,2:dvbs
+	- specifies adapter 1 as a DVBT device, adapter 2 as DVB-S, which overrides the system detection of the adapter
 
--e --enable-adapters list_of_enabled adapters: enable only specified adapters
+* -e --enable-adapters list_of_enabled adapters: enable only specified adapters
 	eg: -e 0-2,5,7 (no spaces between parameters)
 	- keep in mind that the first adapters are the local ones starting with 0 after that are the satip adapters 
 	if you have 3 local dvb cards 0-2 will be the local adapters, 3,4, ... will be the satip servers specified with argument -s
 
--f  foreground, otherwise run in background
+* -f  foreground, otherwise run in background
 
--g use syslog instead stdout for logging, multiple -g - print to stderr as well
+* -g use syslog instead stdout for logging, multiple -g - print to stderr as well
 
--i --priority prio: set the process priority to prio (-10 increases the priority by 10)
+* -i --priority prio: set the process priority to prio (-10 increases the priority by 10)
 
--l increases the verbosity (you can use multiple -l), logging to stdout in foreground mode or in /tmp/log when a daemon
+* -l increases the verbosity (you can use multiple -l), logging to stdout in foreground mode or in /tmp/log when a daemon
 	eg: -l -l -l
 
--m xx: simulate xx as local mac address, generates UUID based on mac
+* -m xx: simulate xx as local mac address, generates UUID based on mac
 	-m 001122334455 
 
--o --dvbapi host:port - specify the hostname and port for the dvbapi server (oscam) 
+* -o --dvbapi host:port - specify the hostname and port for the dvbapi server (oscam) 
 	eg: -o 192.168.9.9:9000 
 	192.168.9.9 is the host where oscam is running and 9000 is the port configured in dvbapi section in oscam.conf
 
--p url: specify playlist url using X_SATIPM3U header 
+* -p url: specify playlist url using X_SATIPM3U header 
 	eg: -p http://192.168.2.3:8080/playlist
 	- this will add X_SATIPM3U tag into the satip description xml
 
--r --remote-rtp  remote_rtp_host: send the rtp stream to remote_rtp_host instead of the ip the connection comes from
+* -r --remote-rtp  remote_rtp_host: send the rtp stream to remote_rtp_host instead of the ip the connection comes from
  	eg: -r 192.168.7.9
  
--R --document-root directory: document root for the minisatip web page and images
+* -R --document-root directory: document root for the minisatip web page and images
 
--s --satip-servers DELSYS:host:port - specify the remote satip host and port with delivery system DELSYS, it is possible to use multiple -s 
+* -s --satip-servers DELSYS:host:port - specify the remote satip host and port with delivery system DELSYS, it is possible to use multiple -s 
 	DELSYS - can be one of: dvbs, dvbs2, dvbt, dvbt2, dvbc, dvbc2, isdbt, atsc, dvbcb ( - DVBC_ANNEX_B ) [default: dvbs2]
 	host - the server of the satip server
 	port - rtsp port for the satip server [default: 554]
@@ -88,37 +90,37 @@ Help
 	- specifies 1 dvbt satip server  with address 192.168.1.3:554
 	- specifies 1 dvbc satip server  with address 192.168.1.4:554
 
--S --slave ADAPTER1,ADAPTER2-ADAPTER4[,..] - specify slave adapters	
-    Allows specifying bonded adapters (multiple adapters connected with a splitter to the same LNB)
-    Only one adapter needs to be master all others needs to have this parameter specified
-    eg: -S 1-2
-    - specifies adapter 1 to 2 as slave, in this case adapter 0 can be the master that controls the LNB
+* -S --slave ADAPTER1,ADAPTER2-ADAPTER4[,..] - specify slave adapters	
+	Allows specifying bonded adapters (multiple adapters connected with a splitter to the same LNB)
+	Only one adapter needs to be master all others needs to have this parameter specified
+	eg: -S 1-2
+	- specifies adapter 1 to 2 as slave, in this case adapter 0 can be the master that controls the LNB
 
--t --cleanpsi clean the PSI from all CA information, the client will see the channel as clear if decrypted successfully
+* -t --cleanpsi clean the PSI from all CA information, the client will see the channel as clear if decrypted successfully
 
--T --threads: enables/disable multiple threads (reduces memory consumptions) (default: ENABLED)
+* -T --threads: enables/disable multiple threads (reduces memory consumptions) (default: ENABLED)
 
--u --unicable unicable_string: defines the unicable adapters (A) and their slot (S), frequency (F) and optionally the PIN for the switch:
+* -u --unicable unicable_string: defines the unicable adapters (A) and their slot (S), frequency (F) and optionally the PIN for the switch:
 	The format is: A1:S1-F1[-PIN][,A2:S2-F2[-PIN][,...]]
 	eg: 2:0-1284[-1111]
 
--j --jess jess_string - same format as -u 
+* -j --jess jess_string - same format as -u 
 
--w --http-host http_server[:port]: specify the host and the port (if not 80) where the xml file can be downloaded from [default: default_local_ip_address:8080] 
+* -w --http-host http_server[:port]: specify the host and the port (if not 80) where the xml file can be downloaded from [default: default_local_ip_address:8080] 
 	eg: -w 192.168.1.1:8080 
 
--x --http-port port: port for listening on http [default: 8080]
+* -x --http-port port: port for listening on http [default: 8080]
 	eg: -x 9090 
 
--X --xml PATH: the path to the xml that is provided as part of the satip protocol	
-    by default desc.xml is provided by minisatip without needing an additional file, 
-    however satip.xml is included if it needs to be customized
+* -X --xml PATH: the path to the xml that is provided as part of the satip protocol	
+	by default desc.xml is provided by minisatip without needing an additional file, 
+	however satip.xml is included if it needs to be customized
 
--y --rtsp-port rtsp_port: port for listening for rtsp requests [default: 554]
+* -y --rtsp-port rtsp_port: port for listening for rtsp requests [default: 554]
 	eg: -y 5544 
 	- changing this to a port > 1024 removes the requirement for minisatip to run as root
 
--z --check-signal force to get signal from the DVB hardware every 200ms (use with care, only when needed)
+* -z --check-signal force to get signal from the DVB hardware every 200ms (use with care, only when needed)
 	- retrieving signal could take sometimes more than 200ms which could impact the rtp stream, using it only when you need to adjust your dish
 
 Examples:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,134 @@
+# Welcome to Minisatip
+
+Minisatip is a multi-threaded satip server version 1.2 that runs under Linux and it was tested with DVB-S, DVB-S2, DVB-T, DVB-T2, DVB-C, DVB-C2, ATSC and ISDB-T cards.
+
+The protocol specification can be found at: satip.info/sites/satip/files/resource/satip_specification_version_1_2_2.pdf
+It is very lightweight (designed for embedded systems with memory and processing constrains), does not need any additional libraries for basic functionality and can be used by existing satip clients like: Tvheadend, DVBViewer, vdr, VideoLAN or Android/iOS applications. Minisatip can act as a satip client as well in order to connect to satip servers from different networks.
+
+The application is designed to stream the requested data to multiple clients (even with one dvb card) in the same time while opening different pids.
+
+It is tested on x86_64, x86, ARM and MIPS platforms and it requires DVBAPI 5. Supported protocols are RTSP (both tcp and udp), HTTP (port 8080) and SSDP (as specified in the SAT>IP documentation). On top of that, it supports dvbapi protocol implemented by oscam (requires dvbcsa library) to decrypt channels using an official subscription and support dvbca protocol (requires dvben50221 library) for dvb cards with CA hardware. In order to enable/disable features, please edit the Makefile. 
+
+Contact
+-------
+Please use https://toda.ro/forum/ for any questions.
+
+In order to speed up the investigation of an issue, please provide the full log and a link to the application that is not working.
+
+If you like minisatip and you want to support the development of the project please make a donation: 
+
+https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=7UWQ7FXSABUH8&item_name=minisatip&currency_code=EUR&bn=PP-DonationsBF:btn_donateCC_LG.gif:NonHostedGuest
+
+Usage:
+-------
+minisatip version 0.5.10, compiled with s2api version: 050A
+
+	minisatip [-[fgltz]] [-a x:y:z] [-b X:Y] [-c X] [-d A:C-U ] [-D device_id] [-e X-Y,Z] [-i prio] [-j A1:S1-F1[-PIN]] [-m mac] [-o oscam_host:dvbapi_port] [-p public_host] [-r remote_rtp_host] [-R document_root] [-s [DELSYS:]host[:port] [-u A1:S1-F1[-PIN]] [-w http_server[:port]] [-x http_port] [-X xml_path] [-y rtsp_port] 
+
+Help
+------- 
+-a x:y:z simulate x DVB-S2, y DVB-T2 and z DVB-C adapters on this box (0 means auto-detect)
+	eg: -a 1:2:3  
+	- it will report 1 dvb-s2 device, 2 dvb-t2 devices and 3 dvb-c devices 
+
+-b --buffers X:Y : set the app adapter buffer to X Bytes (default: 25004) and set the kernel DVB buffer to Y Bytes (default: 5775360) - both multiple of 188
+	eg: -b 18800:18988
+
+-c X: bandwidth capping for the output to the network [default: unlimited]
+	eg: -c 2048  (does not allow minisatip to send more than 2048KB/s to all remote servers)
+
+-d --diseqc ADAPTER1:COMMITED1-UNCOMMITED1[,ADAPTER2:COMMITED2-UNCOMMITED2[,...]
+	The first argument is the adapter number, second is the number of commited packets to send to a Diseqc 1.0 switch, third the number of uncommited commands to sent to a Diseqc 1.1 switch
+	The higher number between the commited and uncommited will be sent first.
+	eg: -d 0:1-0  (which is the default for each adapter).
+
+-D --device-id DVC_ID: specify the device id (in case there are multiple SAT>IP servers in the network)
+ 	eg: -D 4 
+
+-Y --delsys ADAPTER1:DELIVERY_SYSTEM1[,ADAPTER2:DELIVERY_SYSTEM2[,..]] - specify the delivery system of the adapters	
+    eg: --delsys 1:dvbt,2:dvbs
+    - specifies adapter 1 as a DVBT device, adapter 2 as DVB-S, which overrides the system detection of the adapter
+
+-e --enable-adapters list_of_enabled adapters: enable only specified adapters
+	eg: -e 0-2,5,7 (no spaces between parameters)
+	- keep in mind that the first adapters are the local ones starting with 0 after that are the satip adapters 
+	if you have 3 local dvb cards 0-2 will be the local adapters, 3,4, ... will be the satip servers specified with argument -s
+
+-f  foreground, otherwise run in background
+
+-g use syslog instead stdout for logging, multiple -g - print to stderr as well
+
+-i --priority prio: set the process priority to prio (-10 increases the priority by 10)
+
+-l increases the verbosity (you can use multiple -l), logging to stdout in foreground mode or in /tmp/log when a daemon
+	eg: -l -l -l
+
+-m xx: simulate xx as local mac address, generates UUID based on mac
+	-m 001122334455 
+
+-o --dvbapi host:port - specify the hostname and port for the dvbapi server (oscam) 
+	eg: -o 192.168.9.9:9000 
+	192.168.9.9 is the host where oscam is running and 9000 is the port configured in dvbapi section in oscam.conf
+
+-p url: specify playlist url using X_SATIPM3U header 
+	eg: -p http://192.168.2.3:8080/playlist
+	- this will add X_SATIPM3U tag into the satip description xml
+
+-r --remote-rtp  remote_rtp_host: send the rtp stream to remote_rtp_host instead of the ip the connection comes from
+ 	eg: -r 192.168.7.9
+ 
+-R --document-root directory: document root for the minisatip web page and images
+
+-s --satip-servers DELSYS:host:port - specify the remote satip host and port with delivery system DELSYS, it is possible to use multiple -s 
+	DELSYS - can be one of: dvbs, dvbs2, dvbt, dvbt2, dvbc, dvbc2, isdbt, atsc, dvbcb ( - DVBC_ANNEX_B ) [default: dvbs2]
+	host - the server of the satip server
+	port - rtsp port for the satip server [default: 554]
+	eg: -s 192.168.1.2 -s dvbt:192.168.1.3:554 -s dvbc:192.168.1.4
+	- specifies 1 dvbs2 (and dvbs)satip server with address 192.168.1.2:554
+	- specifies 1 dvbt satip server  with address 192.168.1.3:554
+	- specifies 1 dvbc satip server  with address 192.168.1.4:554
+
+-S --slave ADAPTER1,ADAPTER2-ADAPTER4[,..] - specify slave adapters	
+    Allows specifying bonded adapters (multiple adapters connected with a splitter to the same LNB)
+    Only one adapter needs to be master all others needs to have this parameter specified
+    eg: -S 1-2
+    - specifies adapter 1 to 2 as slave, in this case adapter 0 can be the master that controls the LNB
+
+-t --cleanpsi clean the PSI from all CA information, the client will see the channel as clear if decrypted successfully
+
+-T --threads: enables/disable multiple threads (reduces memory consumptions) (default: ENABLED)
+
+-u --unicable unicable_string: defines the unicable adapters (A) and their slot (S), frequency (F) and optionally the PIN for the switch:
+	The format is: A1:S1-F1[-PIN][,A2:S2-F2[-PIN][,...]]
+	eg: 2:0-1284[-1111]
+
+-j --jess jess_string - same format as -u 
+
+-w --http-host http_server[:port]: specify the host and the port (if not 80) where the xml file can be downloaded from [default: default_local_ip_address:8080] 
+	eg: -w 192.168.1.1:8080 
+
+-x --http-port port: port for listening on http [default: 8080]
+	eg: -x 9090 
+
+-X --xml PATH: the path to the xml that is provided as part of the satip protocol	
+    by default desc.xml is provided by minisatip without needing an additional file, 
+    however satip.xml is included if it needs to be customized
+
+-y --rtsp-port rtsp_port: port for listening for rtsp requests [default: 554]
+	eg: -y 5544 
+	- changing this to a port > 1024 removes the requirement for minisatip to run as root
+
+-z --check-signal force to get signal from the DVB hardware every 200ms (use with care, only when needed)
+	- retrieving signal could take sometimes more than 200ms which could impact the rtp stream, using it only when you need to adjust your dish
+
+Examples:
+-------
+- In order to listen to a radio after minisatip is started open the following URL in your favourite media player:
+	- on Hotbird 13E: "http://MINISATIP_HOST:8080/?msys=dvbs&freq=11623&pol=v&sr=27500&pids=0,10750,254"
+	- Astra 19.2E: "http://MINISATIP_HOST:8080/?msys=dvbs&freq=12266&pol=h&sr=27500&pids=0,851"	
+
+- Television FTA programs:
+	- Astra 19.2E, Kika HD: "rtsp://MINISATIP_HOST:554/?src=1&freq=11347&pol=v&ro=0.35&msys=dvbs2&mtype=8psk&plts=on&sr=22000&fec=23&pids=0,17,18,6600,6610,6620,6630"
+
+- msys can be one of: dvbs, dvbs2, dvbt, dvbt2, dvbc, dvbc2, atsc, isdbt, dvbcb ( - DVBC_ANNEX_B )
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Minisatip is a multi-threaded satip server version 1.2 that runs under Linux and it was tested with DVB-S, DVB-S2, DVB-T, DVB-T2, DVB-C, DVB-C2, ATSC and ISDB-T cards.
 
-The protocol specification can be found at: satip.info/sites/satip/files/resource/satip_specification_version_1_2_2.pdf
+The protocol specification can be found at: 
+http://satip.info/sites/satip/files/resource/satip_specification_version_1_2_2.pdf
 It is very lightweight (designed for embedded systems with memory and processing constrains), does not need any additional libraries for basic functionality and can be used by existing satip clients like: Tvheadend, DVBViewer, vdr, VideoLAN or Android/iOS applications. Minisatip can act as a satip client as well in order to connect to satip servers from different networks.
 
 The application is designed to stream the requested data to multiple clients (even with one dvb card) in the same time while opening different pids.
@@ -30,29 +31,29 @@ minisatip version 0.5.10, compiled with s2api version: 050A
 Help
 ------- 
 * -a x:y:z simulate x DVB-S2, y DVB-T2 and z DVB-C adapters on this box (0 means auto-detect)
-	eg: -a 1:2:3  
+	* eg: -a 1:2:3  
 	- it will report 1 dvb-s2 device, 2 dvb-t2 devices and 3 dvb-c devices 
 
 * -b --buffers X:Y : set the app adapter buffer to X Bytes (default: 25004) and set the kernel DVB buffer to Y Bytes (default: 5775360) - both multiple of 188
-	eg: -b 18800:18988
+	* eg: -b 18800:18988
 
 * -c X: bandwidth capping for the output to the network [default: unlimited]
-	eg: -c 2048  (does not allow minisatip to send more than 2048KB/s to all remote servers)
+	* eg: -c 2048  (does not allow minisatip to send more than 2048KB/s to all remote servers)
 
 * -d --diseqc ADAPTER1:COMMITED1-UNCOMMITED1[,ADAPTER2:COMMITED2-UNCOMMITED2[,...]
-	The first argument is the adapter number, second is the number of commited packets to send to a Diseqc 1.0 switch, third the number of uncommited commands to sent to a Diseqc 1.1 switch
+	* The first argument is the adapter number, second is the number of commited packets to send to a Diseqc 1.0 switch, third the number of uncommited commands to sent to a Diseqc 1.1 switch
 	The higher number between the commited and uncommited will be sent first.
 	eg: -d 0:1-0  (which is the default for each adapter).
 
 * -D --device-id DVC_ID: specify the device id (in case there are multiple SAT>IP servers in the network)
- 	eg: -D 4 
+ 	* eg: -D 4 
 
 * -Y --delsys ADAPTER1:DELIVERY_SYSTEM1[,ADAPTER2:DELIVERY_SYSTEM2[,..]] - specify the delivery system of the adapters	
-	eg: --delsys 1:dvbt,2:dvbs
+	* eg: --delsys 1:dvbt,2:dvbs
 	- specifies adapter 1 as a DVBT device, adapter 2 as DVB-S, which overrides the system detection of the adapter
 
 * -e --enable-adapters list_of_enabled adapters: enable only specified adapters
-	eg: -e 0-2,5,7 (no spaces between parameters)
+	* eg: -e 0-2,5,7 (no spaces between parameters)
 	- keep in mind that the first adapters are the local ones starting with 0 after that are the satip adapters 
 	if you have 3 local dvb cards 0-2 will be the local adapters, 3,4, ... will be the satip servers specified with argument -s
 
@@ -63,26 +64,26 @@ Help
 * -i --priority prio: set the process priority to prio (-10 increases the priority by 10)
 
 * -l increases the verbosity (you can use multiple -l), logging to stdout in foreground mode or in /tmp/log when a daemon
-	eg: -l -l -l
+	* eg: -l -l -l
 
 * -m xx: simulate xx as local mac address, generates UUID based on mac
-	-m 001122334455 
+	* eg: -m 001122334455 
 
 * -o --dvbapi host:port - specify the hostname and port for the dvbapi server (oscam) 
-	eg: -o 192.168.9.9:9000 
+	* eg: -o 192.168.9.9:9000 
 	192.168.9.9 is the host where oscam is running and 9000 is the port configured in dvbapi section in oscam.conf
 
 * -p url: specify playlist url using X_SATIPM3U header 
-	eg: -p http://192.168.2.3:8080/playlist
+	* eg: -p http://192.168.2.3:8080/playlist
 	- this will add X_SATIPM3U tag into the satip description xml
 
 * -r --remote-rtp  remote_rtp_host: send the rtp stream to remote_rtp_host instead of the ip the connection comes from
- 	eg: -r 192.168.7.9
+ 	* eg: -r 192.168.7.9
  
 * -R --document-root directory: document root for the minisatip web page and images
 
 * -s --satip-servers DELSYS:host:port - specify the remote satip host and port with delivery system DELSYS, it is possible to use multiple -s 
-	DELSYS - can be one of: dvbs, dvbs2, dvbt, dvbt2, dvbc, dvbc2, isdbt, atsc, dvbcb ( - DVBC_ANNEX_B ) [default: dvbs2]
+	* DELSYS - can be one of: dvbs, dvbs2, dvbt, dvbt2, dvbc, dvbc2, isdbt, atsc, dvbcb ( - DVBC_ANNEX_B ) [default: dvbs2]
 	host - the server of the satip server
 	port - rtsp port for the satip server [default: 554]
 	eg: -s 192.168.1.2 -s dvbt:192.168.1.3:554 -s dvbc:192.168.1.4
@@ -91,7 +92,7 @@ Help
 	- specifies 1 dvbc satip server  with address 192.168.1.4:554
 
 * -S --slave ADAPTER1,ADAPTER2-ADAPTER4[,..] - specify slave adapters	
-	Allows specifying bonded adapters (multiple adapters connected with a splitter to the same LNB)
+	* Allows specifying bonded adapters (multiple adapters connected with a splitter to the same LNB)
 	Only one adapter needs to be master all others needs to have this parameter specified
 	eg: -S 1-2
 	- specifies adapter 1 to 2 as slave, in this case adapter 0 can be the master that controls the LNB
@@ -101,23 +102,23 @@ Help
 * -T --threads: enables/disable multiple threads (reduces memory consumptions) (default: ENABLED)
 
 * -u --unicable unicable_string: defines the unicable adapters (A) and their slot (S), frequency (F) and optionally the PIN for the switch:
-	The format is: A1:S1-F1[-PIN][,A2:S2-F2[-PIN][,...]]
+	* The format is: A1:S1-F1[-PIN][,A2:S2-F2[-PIN][,...]]
 	eg: 2:0-1284[-1111]
 
 * -j --jess jess_string - same format as -u 
 
 * -w --http-host http_server[:port]: specify the host and the port (if not 80) where the xml file can be downloaded from [default: default_local_ip_address:8080] 
-	eg: -w 192.168.1.1:8080 
+	* eg: -w 192.168.1.1:8080 
 
 * -x --http-port port: port for listening on http [default: 8080]
-	eg: -x 9090 
+	* eg: -x 9090 
 
 * -X --xml PATH: the path to the xml that is provided as part of the satip protocol	
-	by default desc.xml is provided by minisatip without needing an additional file, 
+	* by default desc.xml is provided by minisatip without needing an additional file, 
 	however satip.xml is included if it needs to be customized
 
 * -y --rtsp-port rtsp_port: port for listening for rtsp requests [default: 554]
-	eg: -y 5544 
+	* eg: -y 5544 
 	- changing this to a port > 1024 removes the requirement for minisatip to run as root
 
 * -z --check-signal force to get signal from the DVB hardware every 200ms (use with care, only when needed)

--- a/adapter.c
+++ b/adapter.c
@@ -53,10 +53,12 @@ void find_adapters()
 	if (init_find_adapter == 1)
 		return;
 	init_find_adapter = 1;
+#ifndef DISABLE_LINUXDVB
 	find_dvb_adapter(a);
+#endif
 #ifndef DISABLE_SATIPCLIENT
 	find_satip_adapter(a);
-#endif 
+#endif
 #ifndef DISABLE_NETCVCLIENT
 	find_netcv_adapter(a);
 #endif

--- a/adapter.h
+++ b/adapter.h
@@ -1,7 +1,6 @@
 #ifndef ADAPTER_H
 #define ADAPTER_H
 #include "minisatip.h"
-#include <linux/dvb/frontend.h>
 #include "dvb.h"
 
 typedef struct ca_device ca_device_t;

--- a/ca.c
+++ b/ca.c
@@ -35,9 +35,6 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <net/if.h>
-#include <linux/dvb/frontend.h>
-#include <linux/dvb/dmx.h>
-#include <linux/dvb/ca.h>
 #include <fcntl.h>
 #include <ctype.h>
 

--- a/dvb.c
+++ b/dvb.c
@@ -34,8 +34,6 @@
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <net/if.h>
-#include <linux/dvb/frontend.h>
-#include <linux/dvb/dmx.h>
 #include <fcntl.h>
 #include <ctype.h>
 #include "dvb.h"

--- a/dvb.c
+++ b/dvb.c
@@ -42,13 +42,6 @@
 #include "ca.h"
 #include "utils.h"
 
-extern struct struct_opts opts;
-
-struct diseqc_cmd
-{
-	struct dvb_diseqc_master_cmd cmd;
-	uint32_t wait;
-};
 
 char *fe_pilot[] =
 { "on", "off", " ", //auto
@@ -114,6 +107,17 @@ make_func(tmode);
 make_func(gi);
 make_func(specinv);
 make_func(pol);
+
+#ifndef DISABLE_LINUXDVB
+
+extern struct struct_opts opts;
+
+struct diseqc_cmd
+{
+	struct dvb_diseqc_master_cmd cmd;
+	uint32_t wait;
+};
+
 
 int dvb_open_device(adapter *ad)
 {
@@ -690,6 +694,8 @@ fe_delivery_system_t dvb_delsys(int aid, int fd, fe_delivery_system_t *sys)
 
 }
 
+#endif  // #ifndef DISABLE_LINUXDVB
+
 #define INVALID_URL(a) {LOG(a);return 0;}
 char def_pids[100];
 
@@ -897,6 +903,18 @@ void copy_dvb_parameters(transponder * s, transponder * d)
 			d->x_pmt ? d->x_pmt : "NULL");
 }
 
+#ifdef DISABLE_LINUXDVB
+void get_signal(int fd, fe_status_t * status, uint32_t * ber,
+		uint16_t * strength, uint16_t * snr)
+{ return; }
+
+int get_signal_new(int fd, fe_status_t * status, uint32_t * ber,
+		uint16_t * strength, uint16_t * snr)
+{ return -1; }
+#endif  // #ifdef DISABLE_LINUXDVB
+
+#ifndef DISABLE_LINUXDVB
+
 void get_signal(int fd, fe_status_t * status, uint32_t * ber,
 		uint16_t * strength, uint16_t * snr)
 {
@@ -1047,3 +1065,4 @@ void find_dvb_adapter(adapter **a)
 			a[na]->pa = a[na]->fn = -1;
 }
 
+#endif  // #ifndef DISABLE_LINUXDVB

--- a/dvb.h
+++ b/dvb.h
@@ -1,14 +1,138 @@
 #ifndef DVB_H
 #define DVB_H
+
+#ifdef DISABLE_LINUXDVB
+#include <linux/types.h>
+#include <time.h>
+#define DVBAPIVERSION 0x0500
+#define LOGDVBAPIVERSION 0x0000
+#endif
+
+#ifndef DISABLE_LINUXDVB
 #include <linux/dvb/frontend.h>
 #include <linux/dvb/dmx.h>
 #include <linux/dvb/ca.h>
 #include <linux/dvb/version.h>
-
 #define DVBAPIVERSION (DVB_API_VERSION << 8 | DVB_API_VERSION_MINOR)
+#define LOGDVBAPIVERSION DVBAPIVERSION
+#endif
+
 #if DVBAPIVERSION < 0x0500
 #error minisatip requires Linux DVB driver API version 5.0 or higher!
 #endif
+
+
+#ifdef DISABLE_LINUXDVB
+typedef enum fe_delivery_system {
+        SYS_UNDEFINED,
+        SYS_DVBC_ANNEX_AC,
+        SYS_DVBC_ANNEX_B,
+        SYS_DVBT,
+        SYS_DSS,
+        SYS_DVBS,
+        SYS_DVBS2,
+        SYS_DVBH,
+        SYS_ISDBT,
+        SYS_ISDBS,
+        SYS_ISDBC,
+        SYS_ATSC,
+        SYS_ATSCMH,
+        SYS_DMBTH,
+        SYS_CMMB,
+        SYS_DAB,
+        SYS_DVBT2,
+        SYS_TURBO,
+} fe_delivery_system_t;
+typedef enum fe_status {
+        FE_HAS_SIGNAL   = 0x01,
+        FE_HAS_CARRIER  = 0x02,
+        FE_HAS_VITERBI  = 0x04,
+        FE_HAS_SYNC     = 0x08,
+        FE_HAS_LOCK     = 0x10,
+        FE_TIMEDOUT     = 0x20,
+        FE_REINIT       = 0x40
+} fe_status_t;
+typedef enum fe_code_rate {
+        FEC_NONE = 0,
+        FEC_1_2,
+        FEC_2_3,
+        FEC_3_4,
+        FEC_4_5,
+        FEC_5_6,
+        FEC_6_7,
+        FEC_7_8,
+        FEC_8_9,
+        FEC_AUTO,
+        FEC_3_5,
+        FEC_9_10,
+} fe_code_rate_t;
+typedef enum fe_rolloff {
+        ROLLOFF_35,
+        ROLLOFF_20,
+        ROLLOFF_25,
+        ROLLOFF_AUTO,
+} fe_rolloff_t;
+typedef enum fe_pilot {
+        PILOT_ON,
+        PILOT_OFF,
+        PILOT_AUTO,
+} fe_pilot_t;
+typedef enum fe_bandwidth {
+        BANDWIDTH_8_MHZ,
+        BANDWIDTH_7_MHZ,
+        BANDWIDTH_6_MHZ,
+        BANDWIDTH_AUTO,
+        BANDWIDTH_5_MHZ,
+        BANDWIDTH_10_MHZ,
+        BANDWIDTH_1_712_MHZ,
+} fe_bandwidth_t;
+typedef enum fe_guard_interval {
+        GUARD_INTERVAL_1_32,
+        GUARD_INTERVAL_1_16,
+        GUARD_INTERVAL_1_8,
+        GUARD_INTERVAL_1_4,
+        GUARD_INTERVAL_AUTO,
+        GUARD_INTERVAL_1_128,
+        GUARD_INTERVAL_19_128,
+        GUARD_INTERVAL_19_256,
+} fe_guard_interval_t;
+typedef enum fe_spectral_inversion {
+        INVERSION_OFF,
+        INVERSION_ON,
+        INVERSION_AUTO
+} fe_spectral_inversion_t;
+typedef enum fe_transmit_mode {
+        TRANSMISSION_MODE_2K,
+        TRANSMISSION_MODE_8K,
+        TRANSMISSION_MODE_AUTO,
+        TRANSMISSION_MODE_4K,
+        TRANSMISSION_MODE_1K,
+        TRANSMISSION_MODE_16K,
+        TRANSMISSION_MODE_32K,
+} fe_transmit_mode_t;
+typedef enum fe_type {
+        FE_QPSK,
+        FE_QAM,
+        FE_OFDM,
+        FE_ATSC
+} fe_type_t;
+typedef enum fe_modulation {
+        QPSK,
+        QAM_16,
+        QAM_32,
+        QAM_64,
+        QAM_128,
+        QAM_256,
+        QAM_AUTO,
+        VSB_8,
+        VSB_16,
+        PSK_8,
+        APSK_16,
+        APSK_32,
+        DQPSK,
+} fe_modulation_t;
+#endif
+
 
 #if DVBAPIVERSION < 0x0505
 #define DTV_ENUM_DELSYS 44
@@ -86,17 +210,19 @@ typedef struct struct_transponder
 
 #define MAX_PIDS 64
 
+#ifndef DISABLE_LINUXDVB
 //int tune_it(int fd_frontend, unsigned int freq, unsigned int srate, char pol, int tone, fe_spectral_inversion_t specInv, unsigned char diseqc,fe_modulation_t modulation,fe_code_rate_t HP_CodeRate,fe_transmit_mode_t TransmissionMode,fe_guard_interval_t guardInterval, fe_bandwidth_t bandwidth);
 int tune_it_s2 (int fd_frontend, transponder * tp);
 
 fe_delivery_system_t dvb_delsys (int aid, int fd, fe_delivery_system_t *sys);
-int detect_dvb_parameters (char *s, transponder * tp);
-void init_dvb_parameters (transponder * tp);
-void copy_dvb_parameters (transponder * s, transponder * d);
+#endif
 void get_signal (int fd, fe_status_t * status, uint32_t * ber,
 	uint16_t * strength, uint16_t * snr);
 int get_signal_new (int fd, fe_status_t * status, uint32_t * ber,
 	uint16_t * strength, uint16_t * snr);
+int detect_dvb_parameters (char *s, transponder * tp);
+void init_dvb_parameters (transponder * tp);
+void copy_dvb_parameters (transponder * s, transponder * d);
 
 char *get_pilot(int i);
 char *get_rolloff(int i);
@@ -107,5 +233,6 @@ char *get_tmode(int i);
 char *get_gi(int i);
 char *get_specinv(int i);
 char *get_pol(int i);
+
 
 #endif							 /*  */

--- a/dvb.h
+++ b/dvb.h
@@ -1,6 +1,8 @@
 #ifndef DVB_H
 #define DVB_H
 #include <linux/dvb/frontend.h>
+#include <linux/dvb/dmx.h>
+#include <linux/dvb/ca.h>
 #include <linux/dvb/version.h>
 
 #define DVBAPIVERSION (DVB_API_VERSION << 8 | DVB_API_VERSION_MINOR)

--- a/dvbapi.c
+++ b/dvbapi.c
@@ -36,9 +36,6 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <net/if.h>
-#include <linux/dvb/frontend.h>
-#include <linux/dvb/dmx.h>
-#include <linux/dvb/ca.h>
 #include <fcntl.h>
 #include <ctype.h>
 #include "utils.h"

--- a/minisatip.c
+++ b/minisatip.c
@@ -561,8 +561,9 @@ int read_rtsp(sockets * s)
 	rlen = s->rlen;
 	s->rlen = 0;
 
-	LOG("read RTSP (from handle %d sock_id %d, len: %d, sid %d):\n%s", s->sock,
-			s->id, s->rlen, s->sid, s->buf);
+	LOG("read RTSP (from handle %d sock_id %d, len: %d, sid %d):", s->sock,
+			s->id, s->rlen, s->sid);
+	LOGL(3, "%s", s->buf);
 
 	if ((s->type != TYPE_HTTP)
 			&& (strncasecmp((const char*) s->buf, "GET", 3) == 0))
@@ -806,7 +807,8 @@ int read_http(sockets * s)
 
 	s->rlen = 0;
 
-	LOG("read HTTP from %d sid: %d: %s", s->sock, s->sid, s->buf);
+	LOG("read HTTP from %d sid: %d: ", s->sock, s->sid);
+	LOGL(3, "%s", s->buf);
 
 	split(arg, (char*) s->buf, 50, ' ');
 //      LOG("args: %s -> %s -> %s",arg[0],arg[1],arg[2]);

--- a/minisatip.c
+++ b/minisatip.c
@@ -126,7 +126,7 @@ void print_version(int use_log)
 {
 	char buf[200];
 	sprintf(buf, "%s version %s, compiled with s2api version: %04X", app_name,
-			version, DVBAPIVERSION);
+			version, LOGDVBAPIVERSION);
 	if (!use_log)
 		puts(buf);
 	else

--- a/minisatip.c
+++ b/minisatip.c
@@ -1248,7 +1248,7 @@ http_response(sockets *s, int rc, char *ah, char *desc, int cseq, int lr)
 	LOG("reply -> %d (%s:%d) CL:%d [sock_id %d]:", s->sock,
 			get_socket_rhost(s->id, ra, sizeof(ra)), get_socket_rport(s->id),
 			lr, s->id);
-	LOGL(2, "%s", resp);
+	LOGL(3, "%s", resp);
 	send(s->sock, resp, strlen(resp), MSG_NOSIGNAL);
 	if (binary)
 		send(s->sock, desc, lr, MSG_NOSIGNAL);

--- a/minisatip.h
+++ b/minisatip.h
@@ -35,7 +35,7 @@ struct struct_opts
 	char *http_host;			 //http-server host
 	char *disc_host;			 //discover host
 	char mac[13];
-	unsigned int log, slog, start_rtp, http_port;
+	unsigned int log, slog, log_mute, start_rtp, http_port;
 	int timeout_sec;
 	int force_sadapter, force_tadapter, force_cadapter;
 	int daemon;

--- a/satipc.c
+++ b/satipc.c
@@ -35,9 +35,6 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <net/if.h>
-#include <linux/dvb/frontend.h>
-#include <linux/dvb/dmx.h>
-#include <linux/dvb/ca.h>
 #include <fcntl.h>
 #include <ctype.h>
 #include <string.h>

--- a/stream.c
+++ b/stream.c
@@ -34,8 +34,6 @@
 #include <sys/ioctl.h>
 #include <net/if.h>
 #include <string.h>
-#include <linux/dvb/frontend.h>
-#include <linux/dvb/dmx.h>
 #include <poll.h>
 #include <fcntl.h>
 

--- a/tables.c
+++ b/tables.c
@@ -36,11 +36,9 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <net/if.h>
-#include <linux/dvb/frontend.h>
-#include <linux/dvb/dmx.h>
-#include <linux/dvb/ca.h>
 #include <fcntl.h>
 #include <ctype.h>
+#include "dvb.h"
 #include "dvbapi.h"
 #include "tables.h"
 #include "ca.h"

--- a/utils.c
+++ b/utils.c
@@ -37,9 +37,6 @@
 #include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <net/if.h>
-#include <linux/dvb/frontend.h>
-#include <linux/dvb/dmx.h>
-#include <linux/dvb/ca.h>
 #include <fcntl.h>
 #include <ctype.h>
 #include <signal.h>
@@ -48,6 +45,7 @@
 #include <syslog.h>
 #include <stdarg.h>
 #include <sys/mman.h>
+#include "dvb.h"
 #include "utils.h"
 #include "minisatip.h"
 

--- a/utils.h
+++ b/utils.h
@@ -105,6 +105,7 @@ int add_new_lock(void **arr, int count, int size, SMutex *mutex);
 //#define LOG(a,...) {opts.last_log=a;if(opts.log){printf(CC([%s]:\x20,a,\n),get_current_timestamp_log(),##__VA_ARGS__);fflush(stdout);};}
 #define LOG(a,...) { _log(1,__FILE__,__LINE__,a, ##__VA_ARGS__);}
 #define LOGL(level,a,...) { if(level<=opts.log)_log(level,__FILE__,__LINE__,a, ##__VA_ARGS__);}
+#define LOGLM(level,a,...) { if((!opts.log_mute&&level<=opts.log))_log(level,__FILE__,__LINE__,a, ##__VA_ARGS__);}
 
 #define FAIL(a,...) {LOGL(0,a,##__VA_ARGS__);unlink(pid_file);exit(1);}
 #define LOG_AND_RETURN(rc,a,...) {LOG(a,##__VA_ARGS__);return rc;}


### PR DESCRIPTION
Hi @catalinii ,

I'm doing some of the changes suggested in #205 .

Also, I try to enable compatibility with systems without Linux-DVB support (in the kernel). As the satip-client mode is starting to work, then I like to enable support for systems without DVB drivers. Now, I'm working on compile without native DVB headers.

Please, can you commit my changes?
Thank you!
