### PR TITLE
Prevent emitting malformed responses

### DIFF
--- a/minisatip.c
+++ b/minisatip.c
@@ -1260,7 +1260,7 @@ void http_response(sockets *s, int rc, char *ah, char *desc, int cseq, int lr)
 	else
 		proto = "RTSP";
 
-	if (!ah)
+	if (!ah || !ah[0])
 		ah = public;
 	if (!desc)
 		desc = "";


### PR DESCRIPTION
Simple patch to `http_response`, prevents minisatip from sending a bad HTTP response when `ah` is the empty string.

I discovered this while trying to serve CSS with minisatip, the browser got this:

~~~
HTTP/1.0 200 OK
Date: Thu, Jan 1 00:01:08 1970 GMT

Server: minisatip/0.4.1
Content-Length: 4876

[content]
~~~