### PR TITLE
Correct ad_pol symbol

### DIFF
--- a/adapter.c
+++ b/adapter.c
@@ -1570,7 +1570,7 @@ _symbols adapters_sym[] =
 				snr) },
 		{ "ad_ber", VAR_AARRAY_UINT16, a, 1, MAX_ADAPTERS, offsetof(adapter,
 				ber) },
-		{ "ad_pol", VAR_AARRAY_INT8, a, 1, MAX_ADAPTERS, offsetof(adapter,
+		{ "ad_pol", VAR_AARRAY_INT, a, 1, MAX_ADAPTERS, offsetof(adapter,
 				tp.pol) },
 		{ "ad_sr", VAR_AARRAY_INT, a, 1. / 1000, MAX_ADAPTERS, offsetof(adapter,
 				tp.sr) },


### PR DESCRIPTION
I saw that minisatip was always reporting polarity 0 on the status page.

The problem is that the symbol is an `INT8`, while `tp.pol` is an `int` not a `char`.
Since it was running in a big endian architecture, it only read the first byte, which was always 0...