### PR TITLE
sockets_del_for_sid() must be called from close_stream()

### DIFF
--- a/socketworks.c
+++ b/socketworks.c
@@ -850,15 +850,15 @@ get_current_timestamp_log(void)
 	return date_str;
 }
 
-int sockets_del_for_sid(int ad)
+int sockets_del_for_sid(int sid)
 {
 	int i;
 	sockets *ss;
-	if (ad < 0)
+	if (sid < 0)
 		return 0;
 	for (i = 0; i < MAX_SOCKS; i++)
-		if ((ss = get_sockets(i)) && ss->sid >= 0 && ss->type != TYPE_DVR
-				&& ss->sid == ad)
+		if ((ss = get_sockets(i)) && ss->sid >= 0 && ss->type == TYPE_RTSP
+				&& ss->sid == sid)
 		{
 			ss->timeout_ms = 1;	//trigger close of the socket after this operation ends, otherwise we might close an socket on which we run action
 			ss->sid = -1;// make sure the stream is not closed in the future to prevent closing the stream created by another socket

--- a/stream.c
+++ b/stream.c
@@ -306,7 +306,6 @@ int close_stream(int i)
 		close(sid->rsock);
 	sid->rsock = -1;
 
-//	sockets_del_for_sid (i);
 	/*  if(sid->pids)free(sid->pids);
 	 if(sid->apids)free(sid->apids);
 	 if(sid->dpids)free(sid->dpids);
@@ -330,6 +329,8 @@ int close_stream(int i)
 
 	if (ad >= 0)
 		close_adapter_for_stream(i, ad);
+
+	sockets_del_for_sid (i);
 
 	mutex_unlock(&st_mutex);
 	LOG("closed stream %d", i);


### PR DESCRIPTION
I analyzed a wrong socket usage when client (tvheadend) changed too
quickly RTSP connections and an old RTSP incoming socket closed
wronly new RTSP connection.

TODO: Check mutex locking.