### PR TITLE
Mutex fixes

### DIFF
--- a/dvbapi.c
+++ b/dvbapi.c
@@ -975,7 +975,6 @@ int keys_del(int i)
 	enabledKeys = ek;
 	if (!ek && sock > 0)
 		TEST_WRITE(write(sock, buf, sizeof(buf)));
-	mutex_destroy(&k->mutex);
 	return 0;
 }
 
@@ -1067,6 +1066,18 @@ void dvbapi_delete_keys_for_adapter(int aid)
 	for (i = 0; i < MAX_KEYS; i++)
 		if ((k = get_key(i)) && k->adapter == aid)
 			keys_del(i);
+}
+
+void free_all_keys(void)
+{
+	SKey *k;
+	for (i = 0; i < MAX_KEYS; i++) {
+		if (key[i]) {
+			mutex_destroy(&key[i]->mutex);
+			free(key[i]);
+		}
+	}
+	mutex_destroy(&keys_mutex);
 }
 
 _symbols dvbapi_sym[] =

--- a/dvbapi.h
+++ b/dvbapi.h
@@ -124,5 +124,7 @@ void unregister_dvbapi();
 void send_client_info(sockets *s);
 int set_algo(SKey *k, int algo, int mode);
 
+void free_all_keys();
+
 #endif
 #endif

--- a/socketworks.c
+++ b/socketworks.c
@@ -462,15 +462,16 @@ int sockets_del(int sock)
 	if (sock < 0 || sock > MAX_SOCKS || !s[sock] || !s[sock]->enabled)
 		return 0;
 
+	mutex_lock(&s_mutex);
 	ss = s[sock];
 	mutex_lock(&ss->mutex);
 	if (!ss->enabled)
 	{
 		mutex_unlock(&ss->mutex);
+		mutex_unlock(&s_mutex);
 		return 0;
 
 	}
-	mutex_lock(&s_mutex);
 	ss->enabled = 0;
 	so = ss->sock;
 	ss->sock = -1;			 // avoid infinite loop
@@ -492,7 +493,7 @@ int sockets_del(int sock)
 	ss->lock = NULL;
 	LOG("sockets_del: %d Last open socket is at index %d current_handle %d",
 			sock, i, so);
-	mutex_destroy(&ss->mutex);
+	mutex_unlock(&ss->mutex);
 	mutex_unlock(&s_mutex);
 	return 0;
 }
@@ -878,6 +879,7 @@ void set_socket_buffer(int sid, unsigned char *buf, int len)
 
 void free_all_streams();
 void free_all_adapters();
+void free_all_keys();
 
 void free_all()
 {
@@ -887,12 +889,17 @@ void free_all()
 	{
 		if (s[i] && s[i]->enabled)
 			sockets_del(i);
-		if (s[i])
+		if (s[i]) {
+			mutex_destroy(&s[i]->mutex);
 			free(s[i]);
+		}
 		s[i] = NULL;
 	}
 	free_all_streams();
 	free_all_adapters();
+#ifndef DISABLE_DVBAPI
+	free_all_keys();
+#endif
 }
 
 void set_socket_send_buffer(int sock, int len)

--- a/stream.c
+++ b/stream.c
@@ -290,14 +290,15 @@ int close_stream(int i)
 		return 0;
 
 	sid = st[i];
+	mutex_lock(&st_mutex);
 	mutex_lock(&sid->mutex);
 	if (!sid->enabled)
 	{
 		adapter_unlock(sid->adapter);
 		mutex_unlock(&sid->mutex);
+		mutex_unlock(&st_mutex);
 		return 0;
 	}
-	mutex_lock(&st_mutex);
 	sid->enabled = 0;
 	sid->timeout = 0;
 	ad = sid->adapter;
@@ -312,7 +313,6 @@ int close_stream(int i)
 	 if(sid->buf)free(sid->buf);
 	 sid->pids = sid->apids = sid->dpids = sid->buf = NULL;
 	 */
-	mutex_destroy(&sid->mutex);
 
 	if (sid->rtcp_sock > 0 || sid->rtcp > 0)
 	{
@@ -332,6 +332,7 @@ int close_stream(int i)
 
 	sockets_del_for_sid (i);
 
+	mutex_unlock(&sid->mutex);
 	mutex_unlock(&st_mutex);
 	LOG("closed stream %d", i);
 	return 0;
@@ -1125,8 +1126,10 @@ void free_all_streams()
 
 	for (i = 0; i < MAX_STREAMS; i++)
 	{
-		if (st[i])
+		if (st[i]) {
+			mutex_destroy(&st[i]->mutex);
 			free1(st[i]);
+		}
 		st[i] = NULL;
 
 	}

--- a/utils.c
+++ b/utils.c
@@ -1109,8 +1109,8 @@ int add_new_lock(void **arr, int count, int size, SMutex *mutex)
 					LOG_AND_RETURN(-1,
 							"Could not allocate memory for %p index %d", arr, i);
 				memset(sa[i], 0, size);
+				mutex_init(&sa[i]->mutex);
 			}
-			mutex_init(&sa[i]->mutex);
 			mutex_lock(&sa[i]->mutex);
 			sa[i]->enabled = 1;
 			mutex_unlock(mutex);


### PR DESCRIPTION
It's not a good idea to call pthread_mutex_destroy() when mutex can be
used in another thread (deadlocks, crashes).
