### PR TITLE
Changes in the axe version of minisatip

### DIFF
--- a/adapter.c
+++ b/adapter.c
@@ -1056,6 +1056,18 @@ get_adapter1(int aid, char *file, int line)
 	return a[aid];
 }
 
+adapter *
+get_configured_adapter1(int aid, char *file, int line)
+{
+	if (aid < 0 || aid >= MAX_ADAPTERS || !a[aid] || disabled[aid])
+	{
+		LOG("%s:%d: get_configured_adapter returns NULL for adapter_id %d",
+						file, line, aid);
+		return NULL;
+	}
+	return a[aid];
+}
+
 char* get_stream_pids(int s_id, char *dest, int max_size);
 char *
 describe_adapter(int sid, int aid, char *dad, int ld)

--- a/adapter.h
+++ b/adapter.h
@@ -139,6 +139,7 @@ int update_pids(int aid);
 int tune(int aid, int sid);
 SPid *find_pid(int aid, int p);
 adapter * get_adapter1(int aid, char *file, int line);
+adapter * get_configured_adapter1(int aid, char *file, int line);
 char *describe_adapter(int sid, int aid, char *dad, int ld);
 void dump_pids(int aid);
 void sort_pids(int aid);
@@ -165,6 +166,7 @@ int signal_thread(sockets *s);
 int compare_tunning_parameters(int aid, transponder * tp);
 
 #define get_adapter(a) get_adapter1(a, __FILE__, __LINE__)
+#define get_configured_adapter(a) get_configured_adapter1(a, __FILE__, __LINE__)
 #define get_adapter_nw(aid) ((aid >= 0 && aid < MAX_ADAPTERS && a[aid] && a[aid]->enabled)?a[aid]:NULL)
 
 #define adapter_lock(a) adapter_lock1(__FILE__,__LINE__,a)

--- a/axe.c
+++ b/axe.c
@@ -213,11 +213,8 @@ static inline int extra_quattro(int input, int diseqc, int *equattro)
 adapter *use_adapter(int input)
 {
 	int input2 = input < 4 ? input : -1;
-	adapter *ad = get_adapter(input2);
+	adapter *ad = get_configured_adapter(input2);
 	char buf[32];
-	if(!ad)
-		init_hw(input2);
-	ad = get_adapter(input2);
 	if (ad) {
 		if (ad->fe2 <= 0) {
 			sprintf (buf, "/dev/axe/frontend-%d", input);
@@ -287,7 +284,7 @@ int axe_setup_switch(adapter *ad)
 					pos = absolute_table[diseqc][aid];
 					if (pos <= 0) continue;
 					pos--;
-					ad2 = get_adapter(aid);
+					ad2 = get_configured_adapter(aid);
 					if (!ad2) continue;
 					if (ad2->fe2 <= 0) continue;
 					if ((ad2->axe_used & ~(1 << ad->id)) == 0) continue;
@@ -300,7 +297,7 @@ int axe_setup_switch(adapter *ad)
 						pos = absolute_table[diseqc][aid];
 						if (pos <= 0) continue;
 						pos--;
-						ad2 = get_adapter(aid);
+						ad2 = get_configured_adapter(aid);
 						if (!ad2) continue;
 						LOGL(3, "axe: checking %d used 0x%x in %d", ad->id, ad2->axe_used, ad2->id);
 						if (ad2->axe_used & ~(1 << ad->id)) continue;
@@ -327,7 +324,7 @@ int axe_setup_switch(adapter *ad)
 				}
 				if (adm->old_pol >= 0) {
 					for (aid = 0; aid < 4; aid++) {
-						ad2 = get_adapter(aid);
+						ad2 = get_configured_adapter(aid);
 						if (!ad2 || ad2->fe2 <= 0 || ad == ad2) continue;
 						if (ad2->slave && ad2->slave - 1 != adm->pa) continue;
 						if (!ad2->slave && ad2 != adm) continue;
@@ -408,7 +405,7 @@ int axe_setup_switch(adapter *ad)
 
 axe:
 	for (aid = 0; aid < 4; aid++) {
-		ad2 = get_adapter(aid);
+		ad2 = get_configured_adapter(aid);
 		if (ad2)
 			LOGL(3, "axe_fe: used[%d] = 0x%x, pol=%d, hiband=%d, diseqc=%d",
 								aid, ad2->axe_used, ad2->old_pol, ad2->old_hiband, ad2->old_diseqc);
@@ -757,7 +754,7 @@ char *get_axe_coax(int aid, char *dest, int max_size)
 		return dest;
 
 	for (i = 0; i < 4; i++) {
-		ad = get_adapter(i);
+		ad = get_configured_adapter(i);
 		if (ad && ad->axe_used & (1<<aid))
 			len += snprintf(dest + len, max_size - len, "LNB%d,", i + 1);
 	}

--- a/axe.c
+++ b/axe.c
@@ -481,7 +481,7 @@ fe_delivery_system_t axe_delsys(int aid, int fd, fe_delivery_system_t *sys)
 void axe_get_signal(adapter *ad)
 {
 	uint16_t strength = 0, snr = 0;
-	uint32_t status = 0, ber = 0;
+	uint32_t status = 0, ber = 0, tmp;
 	get_signal(ad->fe, &status, &ber, &strength, &snr);
 
 	if (ad->max_strength <= strength)
@@ -492,9 +492,12 @@ void axe_get_signal(adapter *ad)
 	strength = strength * 240 / 24000;
 	if (strength > 240)
 		strength = 240;
-	snr = snr * 15 / 54000;
-	if (snr > 15)
-		snr = 15;
+	tmp = (uint32_t)snr * 255 / 54000;
+	if (tmp > 255)
+		tmp = 255;
+	if (tmp <= 15)
+		tmp = 0;
+	snr = tmp;
 	// keep the assignment at the end for the signal thread to get the right values as no locking is done on the adapter
 	ad->snr = snr;
 	ad->strength = strength;

--- a/minisatip.c
+++ b/minisatip.c
@@ -72,7 +72,7 @@ static const struct option long_options[] =
 	{ "jess", required_argument, NULL, 'j' },
 	{ "diseqc", required_argument, NULL, 'd' },
 	{ "diseqc-timing", required_argument, NULL, 'q' },
-	{"nopm", required_argument, NULL, 'Z'},
+	{ "nopm", required_argument, NULL, 'Z' },
 #ifndef DISABLE_DVBAPI
 	{ "dvbapi", required_argument, NULL, 'o' },
 #endif
@@ -473,7 +473,6 @@ void set_options(int argc, char *argv[])
 #endif
 
 #ifdef AXE
-	opts.nopm = 1;
 	opts.no_threads = 1;
 	opts.axe_skippkt = 35;
 	opts.document_root = "/usr/share/minisatip/html";

--- a/minisatip.h
+++ b/minisatip.h
@@ -93,6 +93,6 @@ struct struct_opts
 int ssdp_discovery (sockets * s);
 int becomeDaemon ();
 int readBootID();
-void http_response (sockets *s, int rc, char *ah, char *desc, int cseq, int lr);
+void http_response (sockets *s, int rc, char *ah, char *desc, int cseq, int lr, int end);
 
 #endif

--- a/minisatip.h
+++ b/minisatip.h
@@ -49,6 +49,8 @@ struct struct_opts
 	int dvr_buffer;
 	int adapter_buffer;
 	int output_buffer;
+	int udp_threshold;
+	int tcp_threshold;
 	int force_scan;
 	int clean_psi;
 	int file_line;

--- a/socketworks.c
+++ b/socketworks.c
@@ -1178,7 +1178,7 @@ int alloc_snpacket(SNPacket *p, int len)
 int sockets_writev(int sock_id, struct iovec *iov, int iovcnt)
 {
 	int rv = 0, i, pos = 0, len;
-	unsigned char tmpbuf[1500];
+	unsigned char tmpbuf[(STREAMS_BUFFER*3)/2];
 	struct iovec tmpiov;
 	sockets *s = get_sockets(sock_id);
 	if(!s)
@@ -1197,7 +1197,8 @@ int sockets_writev(int sock_id, struct iovec *iov, int iovcnt)
 		{
 			for(i=0; i<iovcnt; i++)
 			{
-				memcpy(tmpbuf + pos, iov[i].iov_base, iov[i].iov_len);
+				if (rv < pos + iov[i].iov_len)
+					memcpy(tmpbuf + pos, iov[i].iov_base, iov[i].iov_len);
 				pos += iov[i].iov_len;
 			}
 			LOGL(3, "incomplete write it %d, setting the buffer at offset %d and length %d from %d", s->iteration, rv, len - rv, len);

--- a/socketworks.h
+++ b/socketworks.h
@@ -17,6 +17,7 @@ typedef struct struct_sockets {
 	char enabled;
 	SMutex mutex;
 	int sock;		// socket - <0 for invalid/not used, 0 for end of the list
+	int nonblock;		// non-blocking i/o mode
 	struct sockaddr_in sa;//remote address - set on accept or recvfrom on udp sockets
 	socket_action action;
 	socket_action close;
@@ -51,7 +52,8 @@ typedef struct struct_sockets {
 #define TYPE_RTSP 4
 #define TYPE_DVR 5
 #define TYPE_RTCP 6
-#define TYPE_CONNECT 256 // support for non blocking connect -> when it is connected call write with s->rlen 0
+#define TYPE_NONBLOCK 256 // support for non blocking i/o mode
+#define TYPE_CONNECT 512 // support for non blocking connect -> when it is connected call write with s->rlen 0
 
 #define MAX_HOST 50
 #define SOCK_TIMEOUT -2
@@ -90,6 +92,7 @@ void set_socket_thread(int s_id, pthread_t tid);
 pthread_t get_socket_thread(int s_id);
 int tcp_listen(char *addr, int port);
 int connect_local_socket(char *file, int blocking);
+int set_linux_socket_nonblock(int sockfd);
 int set_linux_socket_timeout(int sockfd);
 int sockets_writev(int sock_id, struct iovec *iov, int iovcnt);
 int sockets_write(int sock_id, void *buf, int len);

--- a/socketworks.h
+++ b/socketworks.h
@@ -31,6 +31,7 @@ typedef struct struct_sockets {
 	int lbuf;
 	int rlen;
 	int timeout_ms;
+	int timeout_ms_wrwait;
 	int id;				 // socket id
 	int iteration;
 	int err;

--- a/stream.c
+++ b/stream.c
@@ -380,6 +380,9 @@ int decode_transport(sockets * s, char *arg, char *default_rtp, int start_rtp)
 			sid->rsock = s->sock;
 			sid->rsock_id = s->id;
 			memcpy(&sid->sa, &s->sa, sizeof(s->sa));
+			if (!set_linux_socket_nonblock(s->sock))
+				s->nonblock = 1;
+			set_socket_send_buffer(s->sock, opts.output_buffer);
 			return 0;
 		}
 

--- a/stream.c
+++ b/stream.c
@@ -1016,7 +1016,7 @@ int read_dmx(sockets * s)
 	if (s->rlen == s->lbuf)
 		send = 1;
 
-	if (s->rtime - ad->rtime > 100) // force flush every 100ms
+	if (s->rtime - ad->rtime > 50) // force flush every 50ms
 		send = 1;
 
 	if(ad && ad->wait_new_stream && (s->rtime - ad->tune_time < 50) ) // check new transponder

--- a/stream.h
+++ b/stream.h
@@ -7,12 +7,17 @@
 
 #define MAX_STREAMS 100
 #define DVB_FRAME 188
-#define STREAMS_BUFFER 7*DVB_FRAME
+#define TCP_RTP_CHUNKS 20
+#define UDP_STREAMS_BUFFER (7 * DVB_FRAME)
+#define TCP_STREAMS_BUFFER (TCP_RTP_CHUNKS * UDP_STREAMS_BUFFER)
+#define STREAMS_BUFFER TCP_STREAMS_BUFFER
 
 #define STREAM_HTTP 1
 #define STREAM_RTSP_UDP 2
 #define STREAM_RTSP_TCP 3
-#define MAX_PACK 7				 // maximum rtp packets to buffer
+#define UDP_MAX_PACK 7 // maximum udp rtp packets to buffer
+#define TCP_MAX_PACK (TCP_RTP_CHUNKS * UDP_MAX_PACK)
+#define MAX_PACK TCP_MAX_PACK
 #define LEN_PIDS (MAX_PIDS * 5 + 1)
 
 typedef struct struct_streams

--- a/utils.c
+++ b/utils.c
@@ -472,7 +472,7 @@ extern int run_loop;
 
 void posix_signal_handler(int sig, siginfo_t * siginfo, ucontext_t * ctx)
 {
-	int sp = 0, ip = 0;
+	uint64_t sp = 0, ip = 0;
 
 	if (sig == SIGINT)
 	{
@@ -481,6 +481,10 @@ void posix_signal_handler(int sig, siginfo_t * siginfo, ucontext_t * ctx)
 	}
 #ifdef __mips__
 	sp = ctx->uc_mcontext.gregs[29];
+	ip = ctx->uc_mcontext.pc;
+#endif
+#ifdef __sh__
+	sp = ctx->uc_mcontext.pr;
 	ip = ctx->uc_mcontext.pc;
 #endif
 	printf("RECEIVED SIGNAL %d - SP=%lX IP=%lX\n", sig, (long unsigned int) sp,

--- a/utils.c
+++ b/utils.c
@@ -892,10 +892,10 @@ void process_file(void *sock, char *s, int len, char *ctype)
 		{
 			if (respond)
 			{
-				http_response(so, 200, ctype, "", 0, 0); // sending back the response without Content-Length
+				http_response(so, 200, ctype, "", 0, 0, 0); // sending back the response without Content-Length
 				respond = 0;
 			}
-			rv = write(so->sock, outp, io);
+			rv = sockets_write(so->id, outp, io);
 			outp[io] = 0;
 			LOG("%s", outp);
 			io = 0;
@@ -903,11 +903,11 @@ void process_file(void *sock, char *s, int len, char *ctype)
 	}
 	outp[io] = 0;
 	if (respond)
-		http_response(so, 200, ctype, outp, 0, 0); // sending back the response with Content-Length if output < 8192
+		http_response(so, 200, ctype, outp, 0, 0, 0); // sending back the response with Content-Length if output < 8192
 	else
 	{
 		strcpy(outp + io, "\r\n\r\n");
-		rv = write(so->sock, outp, io + 4);
+		rv = sockets_write(so->id, outp, io + 4);
 		outp[io] = 0;
 		LOG("%s", outp);
 	}


### PR DESCRIPTION
The RTP TCP data buffer change is obvious and it reduces the writev() kernel syscalls. I'm not sure if all clients are fine with it, but while RTP TCP data transfer mode is not in the specification, I think that the open source implementation will adopt. Also, users may decrease the defines in stream.h on demand.

EDIT: Added a big patch which sets the RTSP socket to the non-blocking mode when RTP/AVP/TCP mode is activated and fixed bunch of mistakes in the buffer code when the kernel is not able to queue more data for the TCP socket. 