### PR TITLE
implement diseqc-multi

### DIFF
--- a/adapter.c
+++ b/adapter.c
@@ -65,6 +65,7 @@ adapter *adapter_alloc()
 {
 	adapter *ad = malloc1(sizeof(adapter));
 	memset(ad, 0, sizeof(adapter));
+
 	/* diseqc setup */
 	ad->diseqc_param.fast = opts.diseqc_fast;
 	ad->diseqc_param.committed_no = opts.diseqc_committed_no;
@@ -84,13 +85,13 @@ adapter *adapter_alloc()
 	ad->old_pol = -1;
 	ad->dmx_source = -1;
 	ad->slow_dev = opts.nopm;
-	/* LOF setup */
+	ad->diseqc_multi = opts.diseqc_multi;
 
+	/* LOF setup */
 	ad->diseqc_param.lnb_low = opts.lnb_low;
 	ad->diseqc_param.lnb_high = opts.lnb_high;
 	ad->diseqc_param.lnb_circular = opts.lnb_circular;
 	ad->diseqc_param.lnb_switch = opts.lnb_switch;
-
 
 	return ad;
 }
@@ -1333,6 +1334,51 @@ void set_diseqc_adapters(char *o)
 	}
 }
 
+void set_diseqc_multi(char *o)
+{
+	int i, la, a_id, position;
+	char buf[100], *arg[20], *sep1;
+	adapter *ad;
+	strncpy(buf, o, sizeof(buf));
+	la = split(arg, buf, sizeof(arg), ',');
+	for (i = 0; i < la; i++)
+	{
+		if (arg[i] && arg[i][0] == '*')
+		{
+			ad = NULL;
+			a_id = -1;
+		}
+		else
+		{
+			a_id = map_intd(arg[i], NULL, -1);
+			if (a_id < 0 || a_id >= MAX_ADAPTERS)
+				continue;
+
+			if (!a[a_id])
+				a[a_id] = adapter_alloc();
+			ad = a[a_id];
+		}
+
+		sep1 = strchr(arg[i], ':');
+
+		if (!sep1)
+			continue;
+		position = map_intd(sep1 + 1, NULL, -1);
+		if (position < 0)
+			continue;
+		if (ad)
+		{
+			ad->diseqc_multi = position;
+		}
+		else
+		{
+			opts.diseqc_multi = position;
+		}
+		LOGL(0,
+							"Setting diseqc multi adapter %d position %d",
+							a_id, position);
+	}
+}
 
 void set_lnb_adapters(char *o)
 {

--- a/adapter.h
+++ b/adapter.h
@@ -99,6 +99,7 @@ typedef struct struct_adapter
 	uint16_t strength, snr, max_strength, max_snr;
 	uint32_t pid_err, dec_err; // detect pids received but not part of any stream, decrypt errors
 	diseqc diseqc_param;
+	int diseqc_multi;
 	int old_diseqc;
 	int old_hiband;
 	int old_pol;
@@ -147,6 +148,7 @@ void enable_adapters(char *o);
 void set_unicable_adapters(char *o, int type);
 void set_diseqc_adapters(char *o);
 void set_diseqc_timing(char *o);
+void set_diseqc_multi(char *o);
 void set_slave_adapters(char *o);
 void set_nopm_adapters(char *o);
 void set_adapter_dmxsource(char *o);

--- a/axe.c
+++ b/axe.c
@@ -341,7 +341,7 @@ int axe_setup_switch(adapter *ad)
 				input = master;
 				if (!tune_check(adm, pol, hiband, diseqc)) {
 					send_diseqc(adm, adm->fe2, diseqc, adm->old_diseqc != diseqc,
-																	pol, hiband, &tp->diseqc_param);
+						    pol, hiband, &tp->diseqc_param);
 					adm->old_pol = pol;
 					adm->old_hiband = hiband;
 					adm->old_diseqc = diseqc;

--- a/dvb.c
+++ b/dvb.c
@@ -417,6 +417,11 @@ int send_diseqc(adapter *ad, int fd, int pos, int pos_change, int pol, int hiban
 		{ 0xe0, 0x10, 0x39, 0xf0, 0x00, 0x00 }, 4
 	};
 
+	if (pos_change && ad->diseqc_multi >= 0 && pos != ad->diseqc_multi) {
+		send_diseqc(ad, fd, ad->diseqc_multi, 1, pol, hiband, d);
+		pos_change = 1;
+	}
+
 	if (uncommitted_no > committed_no)
 		uncommitted_first = 1;
 

--- a/minisatip.c
+++ b/minisatip.c
@@ -73,6 +73,7 @@ static const struct option long_options[] =
 	{ "jess", required_argument, NULL, 'j' },
 	{ "diseqc", required_argument, NULL, 'd' },
 	{ "diseqc-timing", required_argument, NULL, 'q' },
+	{ "diseqc-multi", required_argument, NULL, '0' },
 	{ "nopm", required_argument, NULL, 'Z' },
 #ifndef DISABLE_DVBAPI
 	{ "dvbapi", required_argument, NULL, 'o' },
@@ -149,6 +150,7 @@ static const struct option long_options[] =
 #define AXE_SKIP_PKT 'M'
 #define AXE_POWER 'W'
 #define ABSOLUTE_SRC 'A'
+#define DISEQC_MULTI '0'
 
 char *built_info[] =
 {
@@ -235,7 +237,7 @@ void usage()
 #ifdef AXE
 		"[-7 M1:S1[,M2:S2]] [-M mpegts_packets] [-A SRC1:INP1:DISEQC1[,SRC2:INP2:DISEQC2]]\n\n"
 #endif
-		"\t[-x http_port] [-X xml_path] [-y rtsp_port] \n\n\
+		"\t[-x http_port] [-X xml_path] [-y rtsp_port]\n\n\
 Help\n\
 -------\n\
 \n\
@@ -261,6 +263,10 @@ Help\n\
 \n\
 * -q --diseqc-timing ADAPTER1:BEFORE_CMD1-AFTER_CMD1-AFTER_REPEATED_CMD1-AFTER_SWITCH1-AFTER_BURST1-AFTER_TONE1[,...]\n\
 \t* All timing values are in ms, default adapter values are: 15-54-15-15-15-0\n\
+	- note: * as adapter means apply to all adapters\n\
+\n\
+* -0 --diseqc-multi ADAPTER1:DISEQC_POSITION[,...]\n\
+\t* Send diseqc to selected position before other position is set.\n\
 	- note: * as adapter means apply to all adapters\n\
 \n\
 * -D --device-id DVC_ID: specify the device id (in case there are multiple SAT>IP servers in the network)\n \
@@ -464,6 +470,7 @@ void set_options(int argc, char *argv[])
 	opts.diseqc_after_burst = 15;
 	opts.diseqc_after_tone = 0;
 	opts.diseqc_committed_no = 1;
+	opts.diseqc_multi = -1;
 	opts.nopm = 0;
 	opts.lnb_low = (9750*1000UL);
 	opts.lnb_high = (10600*1000UL);
@@ -491,7 +498,7 @@ void set_options(int argc, char *argv[])
 	memset(opts.playlist, 0, sizeof(opts.playlist));
 
 	while ((opt = getopt_long(argc, argv,
-																											"flr:a:td:w:p:s:n:hB:b:H:m:p:e:x:u:j:o:gy:i:q:D:VR:S:TX:Y:OL:EP:Z:"AXE_OPTS,
+																											"flr:a:td:w:p:s:n:hB:b:H:m:p:e:x:u:j:o:gy:i:q:D:VR:S:TX:Y:OL:EP:Z:0:"AXE_OPTS,
 																											long_options, NULL)) != -1)
 	{
 		//              printf("options %d %c %s\n",opt,opt,optarg);
@@ -648,6 +655,12 @@ void set_options(int argc, char *argv[])
 		case DISEQC_TIMING_OPT:
 		{
 			set_diseqc_timing(optarg);
+			break;
+		}
+
+		case DISEQC_MULTI:
+		{
+			set_diseqc_multi(optarg);
 			break;
 		}
 

--- a/minisatip.h
+++ b/minisatip.h
@@ -77,6 +77,7 @@ struct struct_opts
 	int diseqc_after_switch;
 	int diseqc_after_burst;
 	int diseqc_after_tone;
+	int diseqc_multi;
 	int lnb_low, lnb_high, lnb_switch, lnb_circular;
 	int nopm;
 	int max_pids;


### PR DESCRIPTION
@catalinii : I'm not sure, if you like to merge this one. But it helped on one equipment and it's straight (debugged remotely).

This is really a workaround. I've seen a diseqc hardware which is
not able to switch properly to another input unless the position 0
is activated before any other input.

