### PR TITLE
axe: axe is __sh__ platform but it can do 32 pids

### DIFF
--- a/minisatip.c
+++ b/minisatip.c
@@ -471,7 +471,9 @@ void set_options(int argc, char *argv[])
 	opts.lnb_switch = (11700*1000UL);
 	opts.max_sbuf = 100;
 	opts.max_pids = 0;
-#if defined(__sh__)
+#if defined(AXE)
+	opts.max_pids = 32;
+#elif defined(__sh__)
 	opts.max_pids = 20;
 #endif
 


### PR DESCRIPTION
Uff. It took me 2 hours to find where's the issue (weird no PID data bugs).. Perhaps it should be more visible that this limit is applied. It may really depend on hardware. It should be configurable in my opinion.