### PR TITLE
adapter: handle ad->active_pids correctly, fixes VDR issue

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -878,7 +878,7 @@ int update_pids(int aid)
 			if (dp)
 				dump_pids(aid);
 			dp = 0;
-			if (ad->pids[i].fd <= 0)
+			if (ad->pids[i].fd <= 0) {
 				if ((ad->pids[i].fd = ad->set_pid(ad, ad->pids[i].pid)) < 0)
 				{
 
@@ -888,6 +888,8 @@ int update_pids(int aid)
 					LOG0("Maximum pid filter reached, lowering the value to %d", opts.max_pids);
 					break;
 				}
+				ad->active_pids++;
+			}
 			ad->pids[i].flags = 1;
 			if (ad->pids[i].pid == 0)
 				ad->pat_processed = 0;
@@ -895,7 +897,6 @@ int update_pids(int aid)
 			ad->pids[i].cc = 255;
 			ad->pids[i].cc_err = 0;
 			ad->pids[i].dec_err = 0;
-			ad->active_pids++;
 		}
 	if (ad->commit)
 		ad->commit(ad);


### PR DESCRIPTION
There's a race for the decrementing ad->active_pids. I saw a problem when TEARDOWN / PLAY operations were processed too quickly (VDR) and mark_pid_add() code changed flags from 3 (delete) to 2 (add) for the changed pid. In this case, the update_pids() incremented ad->active_pids again, which is wrong, because it must be tied to the hw config (ad->set_pid call). This change fixes that.