### PR TITLE
Fix split() callers, add ARRAY_SIZE() macro

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -550,7 +550,7 @@ int getAdaptersCount()
 		memset(&fe_map, -1, sizeof(fe_map));
 
 		k = 0;
-		for (i = 0; i < sizeof(order); i++)
+		for (i = 0; i < ARRAY_SIZE(order); i++)
 		{
 			int sys = order[i];
 			for (j = 0; j < ifes[sys]; j++)
@@ -676,7 +676,7 @@ int get_free_adapter(transponder *tp)
 
 	adapter *ad = a[0];
 
-	if ((fe > 0) && (fe <= sizeof(fe_map)) && (fe_map[fe - 1] >= 0))
+	if ((fe > 0) && (fe <= ARRAY_SIZE(fe_map)) && (fe_map[fe - 1] >= 0))
 	{
 		fe = fe_map[fe - 1];
 		ad = a[fe];
@@ -1066,7 +1066,7 @@ void mark_pids_deleted(int aid, int sid, char *pids) //pids==NULL -> delete all 
 		pids ? pids : "NULL");
 	if (pids)
 	{
-		la = split(arg, pids, MAX_PIDS, ',');
+		la = split(arg, pids, ARRAY_SIZE(arg), ',');
 		for (i = 0; i < la; i++)
 		{
 			pid = map_int(arg[i], NULL);
@@ -1146,7 +1146,7 @@ int mark_pids_add(int sid, int aid, char *pids)
 	LOG("adding pids to adapter %d, sid %d, pids=%s", aid, sid,
 		pids ? pids : "NULL");
 
-	la = split(arg, pids, MAX_PIDS, ',');
+	la = split(arg, pids, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		pid = map_intd(arg[i], NULL, -1);
@@ -1242,7 +1242,7 @@ int set_adapter_parameters(int aid, int sid, transponder *tp)
 	{
 		char *arg[64];
 		int i, la;
-		la = split(arg, ad->tp.x_pmt, 64, ',');
+		la = split(arg, ad->tp.x_pmt, ARRAY_SIZE(arg), ',');
 		for (i = 0; i < la; i++)
 		{
 			int pmt = map_int(arg[i], NULL);
@@ -1436,12 +1436,12 @@ void set_disable(int i, int v)
 void enable_adapters(char *o)
 {
 	int i, la, st, end, j;
-	char buf[100], *arg[20], *sep;
+	char buf[1000], *arg[40], *sep;
 	for (i = 0; i < MAX_ADAPTERS; i++)
 		set_disable(i, 1);
 	SAFE_STRCPY(buf, o);
 
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		sep = strchr(arg[i], '-');
@@ -1463,10 +1463,10 @@ void enable_adapters(char *o)
 void set_unicable_adapters(char *o, int type)
 {
 	int i, la, a_id, slot, freq, pin, o13v;
-	char buf[100], *arg[20], *sep1, *sep2, *sep3;
+	char buf[1000], *arg[40], *sep1, *sep2, *sep3;
 	adapter *ad;
 	SAFE_STRCPY(buf, o);
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		a_id = map_intd(arg[i], NULL, -1);
@@ -1504,10 +1504,10 @@ void set_unicable_adapters(char *o, int type)
 void set_diseqc_adapters(char *o)
 {
 	int i, la, a_id, fast, committed_no, uncommitted_no;
-	char buf[100], *arg[20], *sep1, *sep2;
+	char buf[1000], *arg[40], *sep1, *sep2;
 	adapter *ad;
 	SAFE_STRCPY(buf, o);
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		if (arg[i] && arg[i][0] == '*')
@@ -1567,10 +1567,10 @@ void set_diseqc_adapters(char *o)
 void set_diseqc_multi(char *o)
 {
 	int i, la, a_id, position;
-	char buf[100], *arg[20], *sep1;
+	char buf[1000], *arg[40], *sep1;
 	adapter *ad;
 	SAFE_STRCPY(buf, o);
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		if (arg[i] && arg[i][0] == '*')
@@ -1619,10 +1619,10 @@ void set_diseqc_multi(char *o)
 void set_lnb_adapters(char *o)
 {
 	int i, la, a_id, lnb_low, lnb_high, lnb_switch;
-	char buf[100], *arg[20], *sep1, *sep2, *sep3;
+	char buf[1000], *arg[40], *sep1, *sep2, *sep3;
 	adapter *ad;
 	SAFE_STRCPY(buf, o);
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		if (arg[i] && arg[i][0] == '*')
@@ -1692,11 +1692,11 @@ void set_diseqc_timing(char *o)
 	int i, la, a_id;
 	int before_cmd, after_cmd, after_repeated_cmd;
 	int after_switch, after_burst, after_tone;
-	char buf[2000], *arg[20];
+	char buf[2000], *arg[40];
 	char *sep1, *sep2, *sep3, *sep4, *sep5, *sep6;
 	adapter *ad;
 	SAFE_STRCPY(buf, o);
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		if (arg[i] && arg[i][0] == '*')
@@ -1773,10 +1773,10 @@ void set_diseqc_timing(char *o)
 void set_slave_adapters(char *o)
 {
 	int i, j, la, a_id, a_id2, master = 0;
-	char buf[100], *arg[20], *sep, *sep2;
+	char buf[1000], *arg[40], *sep, *sep2;
 	adapter *ad;
 	SAFE_STRCPY(buf, o);
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		a_id = map_intd(arg[i], NULL, -1);
@@ -1826,13 +1826,13 @@ void set_timeout_adapters(char *o)
 {
 	int i, j, la, a_id, a_id2;
 	int timeout = opts.adapter_timeout / 1000;
-	char buf[100], *arg[20], *sep;
+	char buf[1000], *arg[40], *sep;
 	adapter *ad;
 	SAFE_STRCPY(buf, o);
 	sep = strchr(buf, ':');
 	if (sep)
 		timeout = map_intd(sep + 1, NULL, timeout);
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	if (arg[0] && (arg[0][0] == '*'))
 	{
 		opts.adapter_timeout = timeout * 1000;
@@ -1876,10 +1876,10 @@ extern char *fe_delsys[];
 void set_adapters_delsys(char *o)
 {
 	int i, la, a_id, ds;
-	char buf[100], *arg[20], *sep;
+	char buf[1000], *arg[40], *sep;
 	adapter *ad;
 	SAFE_STRCPY(buf, o);
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		a_id = map_intd(arg[i], NULL, -1);
@@ -1916,10 +1916,10 @@ void set_adapters_delsys(char *o)
 void set_adapter_dmxsource(char *o)
 {
 	int i, j, la, st, end, fd;
-	char buf[100], *arg[20], *sep, *seps;
+	char buf[1000], *arg[40], *sep, *seps;
 	adapter *ad;
 	SAFE_STRCPY(buf, o);
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		sep = strchr(arg[i], '-');
@@ -1956,10 +1956,10 @@ void set_signal_multiplier(char *o)
 {
 	int i, la, a_id;
 	float strength_multiplier, snr_multiplier;
-	char buf[100], *arg[20], *sep1, *sep2;
+	char buf[1000], *arg[40], *sep1, *sep2;
 	adapter *ad;
 	SAFE_STRCPY(buf, o);
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		if (arg[i] && arg[i][0] == '*')

--- a/src/axe.c
+++ b/src/axe.c
@@ -829,11 +829,11 @@ void free_axe_input(adapter *ad)
 void set_link_adapters(char *o)
 {
 	int i, la, a_id, b_id;
-	char buf[100], *arg[20], *sep1;
+	char buf[1000], *arg[40], *sep1;
 
 	strncpy(buf, o, sizeof(buf) - 1);
 	buf[sizeof(buf) - 1] = '\0';
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		a_id = map_intd(arg[i], NULL, -1);
@@ -857,11 +857,11 @@ void set_link_adapters(char *o)
 void set_absolute_src(char *o)
 {
 	int i, la, src, inp, pos;
-	char buf[100], *arg[20], *inps, *poss;
+	char buf[1000], *arg[40], *inps, *poss;
 
 	strncpy(buf, o, sizeof(buf) - 1);
 	buf[sizeof(buf) - 1] = '\0';
-	la = split(arg, buf, sizeof(arg), ',');
+	la = split(arg, buf, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		inps = strchr(arg[i], ':');

--- a/src/dvb.c
+++ b/src/dvb.c
@@ -192,7 +192,7 @@ int detect_dvb_parameters(char *s, transponder *tp)
 		init_dvb_parameters(tp);
 
 	LOG("detect_dvb_parameters (S)-> %s", s);
-	la = split(arg, s, 20, '&');
+	la = split(arg, s, ARRAY_SIZE(arg), '&');
 
 	for (i = 0; i < la; i++)
 	{

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -614,7 +614,7 @@ void set_options(int argc, char *argv[])
 			int i;
 			memset(buf, 0, sizeof(buf));
 			strncpy(buf, optarg, sizeof(buf) - 1);
-			int la = split(arg, buf, 50, ',');
+			int la = split(arg, buf, ARRAY_SIZE(arg), ',');
 			for (i = 0; i < la; i++)
 			{
 				int level = map_intd(arg[i], loglevels, -1);
@@ -1046,7 +1046,7 @@ int read_rtsp(sockets *s)
 		return 0;
 	}
 
-	la = split(arg, (char *)s->buf, 50, ' ');
+	la = split(arg, (char *)s->buf, ARRAY_SIZE(arg), ' ');
 	cseq = 0;
 	if (la < 2)
 		LOG_AND_RETURN(0,
@@ -1311,7 +1311,7 @@ int read_http(sockets *s)
 	LOG("read HTTP from %d sid: %d: ", s->sock, s->sid);
 	LOGM("%s", s->buf);
 
-	split(arg, (char *)s->buf, 50, ' ');
+	split(arg, (char *)s->buf, ARRAY_SIZE(arg), ' ');
 	//      LOG("args: %s -> %s -> %s",arg[0],arg[1],arg[2]);
 	if (strncmp(arg[0], "GET", 3) && strncmp(arg[0], "POST", 4) && !is_head)
 		REPLY_AND_RETURN(503);

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -176,7 +176,7 @@ int satipc_reply(sockets *s)
 		sip->option_no_option = 1;
 	}
 
-	la = split(arg, (char *)s->buf, 100, ' ');
+	la = split(arg, (char *)s->buf, ARRAY_SIZE(arg), ' ');
 	rc = map_int(arg[1], NULL);
 
 	if (sip->option_no_session && sip->last_cmd == RTSP_OPTIONS && !sess && sip->session[0])
@@ -1288,7 +1288,7 @@ void find_satip_adapter(adapter **a)
 		return;
 	char satip_servers[strlen(opts.satip_servers) + 10];
 	strcpy(satip_servers, opts.satip_servers);
-	la = split(arg, satip_servers, 50, ',');
+	la = split(arg, satip_servers, ARRAY_SIZE(arg), ',');
 
 	for (i = 0; i < la; i++)
 	{
@@ -1420,7 +1420,7 @@ void satip_getxml_data(char *data, int len, void *opaque, Shttp_client *h)
 		eos = strchr(sep, '<');
 		if (eos)
 			*eos = 0;
-		la = split(arg, sep, MAX_DVBAPI_SYSTEMS, ',');
+		la = split(arg, sep, ARRAY_SIZE(arg), ',');
 		for (i = 0; i < la; i++)
 		{
 			int ds = map_intd(arg[i], satip_delsys, -1);
@@ -1474,7 +1474,7 @@ int satip_getxml(void *x)
 	memset(satip_xml, 0, sizeof(satip_xml));
 	memset(sxd, 0, sizeof(sxd));
 	strncpy(satip_xml, opts.satip_xml, sizeof(satip_xml) - 1);
-	la = split(arg, satip_xml, MAX_SATIP_XML, ',');
+	la = split(arg, satip_xml, ARRAY_SIZE(arg), ',');
 	for (i = 0; i < la; i++)
 	{
 		SAFE_STRCPY(sxd[i].url, arg[i]);

--- a/src/stream.c
+++ b/src/stream.c
@@ -422,7 +422,7 @@ int decode_transport(sockets *s, char *arg, char *default_rtp, int start_rtp)
 			return 0;
 		}
 
-		l = split(arg2, arg, 10, ';');
+		l = split(arg2, arg, ARRAY_SIZE(arg2), ';');
 	}
 	//      LOG("arg2 %s %s %s",arg2[0],arg2[1],arg2[2]);
 	memset(&p, 0, sizeof(p));

--- a/src/utils.h
+++ b/src/utils.h
@@ -263,6 +263,8 @@ static inline int get_index_hash(void *p, int max, int struct_size, uint32_t key
 
 typedef ssize_t (*mywritev)(int fd, const struct iovec *io, int len);
 
+#define ARRAY_SIZE(a) (sizeof(a)/sizeof(a[0]))
+
 #ifdef TESTING
 
 #define writev(a, b, c) _writev(a, b, c)


### PR DESCRIPTION
The sizeof() is not same as array size and it cannot be applied
for arrays which items are not byte types. Define standard
ARRAY_SIZE() macro and fix all split() callers.
