### PR TITLE
Signal code improvements

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -1156,7 +1156,7 @@ int mark_pids_add(int sid, int aid, char *pids)
 	for (i = 0; i < la; i++)
 	{
 		pid = map_intd(arg[i], NULL, -1);
-		if (pid == -1)
+		if (pid < 0 || pid > 8192)
 			continue;
 		if (mark_pid_add(sid, aid, pid) < 0)
 			return -1;

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -2074,7 +2074,7 @@ int signal_thread(sockets *s)
 		status = ad->status;
 		if (ad->status_cnt++ <= 0) // make sure the kernel has updated the status
 			continue;
-		if (opts.no_threads && status >= 0)
+		if (opts.no_threads && !ad->fast_status && status >= 0)
 			continue;
 		ts = getTick();
 		ad->get_signal(ad);

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -951,6 +951,8 @@ int tune(int aid, int sid)
 		ad->status = -1;
 		ad->status_cnt = 0;
 		ad->wait_new_stream = 1;
+		ad->strength = 0;
+		ad->snr = 0;
 		flush_data = 1;
 		ad->is_t2mi = 0;
 		if (ad->restart_when_tune)
@@ -1320,16 +1322,20 @@ describe_adapter(int sid, int aid, char *dad, int ld)
 
 	if (use_ad)
 	{
-		strength = ad->strength;
-		snr = ad->snr;
-		if (snr > 15)
-			snr = snr >> 4;
-		status = (ad->status & FE_HAS_LOCK) > 0;
+		if (ad->status < 0) {
+			status = strength = snr = 0;
+		} else {
+			strength = ad->strength;
+			snr = ad->snr;
+			if (snr > 15)
+				snr = snr >> 4;
+			status = (ad->status & FE_HAS_LOCK) > 0;
 
-		if (strength > 255 || strength < 0)
-			strength = 1;
-		if (snr > 15 || snr < 0)
-			snr = 1;
+			if (strength > 255 || strength < 0)
+				strength = 1;
+			if (snr > 15 || snr < 0)
+				snr = 1;
+		}
 	}
 	if (t->sys == 0)
 		len = snprintf(dad, ld, "ver=1.0;src=1;tuner=%d,0,0,0,0,,,,,,,;pids=",
@@ -2057,24 +2063,28 @@ int delsys_match(adapter *ad, int del_sys)
 
 int signal_thread(sockets *s)
 {
-	int i;
+	int i, status;
 	int64_t ts, ctime;
 	adapter *ad;
-	for (i = 0; i < MAX_ADAPTERS; i++)
-		if ((ad = get_adapter_nw(i)) && ad->get_signal && (ad->fe > 0) && ad->tp.freq && (ad->status_cnt++ > 0) // make sure the kernel has updated the status
-			&& (!opts.no_threads || (ad->status < 0)))
-
-		{
-			int status = ad->status;
-			ts = getTick();
-			ad->get_signal(ad);
-			ctime = getTick();
-			if (status == -1 || (opts.log & DEFAULT_LOG))
-				LOG(
-					"get_signal%s took %jd ms for adapter %d handle %d (status: %d, ber: %d, strength:%d, snr: %d, force scan %d)",
-					(ad->new_gs == 1) ? "_new" : "", ctime - ts, ad->id, ad->fe,
-					ad->status, ad->ber, ad->strength, ad->snr, opts.force_scan);
-		}
+	for (i = 0; i < MAX_ADAPTERS; i++) {
+		if ((ad = get_adapter_nw(i)) == NULL || ad->get_signal == NULL)
+			continue;
+		if (ad->fe <= 0 || ad->tp.freq <= 0)
+			continue;
+		status = ad->status;
+		if (ad->status_cnt++ <= 0) // make sure the kernel has updated the status
+			continue;
+		if (opts.no_threads && status >= 0)
+			continue;
+		ts = getTick();
+		ad->get_signal(ad);
+		ctime = getTick();
+		if (status < 0 || (opts.log & DEFAULT_LOG))
+			LOG(
+				"get_signal%s took %jd ms for adapter %d handle %d (status: %d, ber: %d, strength:%d, snr: %d, force scan %d)",
+				(ad->new_gs == 1) ? "_new" : "", ctime - ts, ad->id, ad->fe,
+				ad->status, ad->ber, ad->strength, ad->snr, opts.force_scan);
+	}
 	return 0;
 }
 

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -58,7 +58,7 @@ typedef struct struct_adapter
 	int64_t rtime;
 	int64_t last_sort;
 	int new_gs;
-	int status, status_cnt;
+	int status, status_cnt, fast_status;
 	int dmx_source;
 	int master_source;
 	int is_fbc;

--- a/src/axe.c
+++ b/src/axe.c
@@ -185,7 +185,7 @@ static void axe_pls_isi(adapter *ad, transponder *tp)
 	static int isi[4] = { -2, -2, -2, -2 };
 	static int pls_code[4] = { -2, -2, -2, -2 };
 	int v;
-	LOGM("axe: isi %d pls %d mode %d\n", tp->plp_isi, tp->pls_code, tp->pls_mode);
+	LOGM("axe: isi %d pls %d mode %d", tp->plp_isi, tp->pls_code, tp->pls_mode);
 	if (tp->plp_isi != isi[ad->pa]) {
 		v = tp->plp_isi < 0 ? -1 : (tp->plp_isi & 0xff);
 		axe_stv0900_i2c_4("mis", ad->pa, v);

--- a/src/axe.c
+++ b/src/axe.c
@@ -883,6 +883,7 @@ void find_axe_adapter(adapter **a)
 				ad->get_signal = (Device_signal)axe_get_signal;
 				ad->wakeup = (Device_wakeup)axe_wakeup;
 				ad->type = ADAPTER_DVB;
+				ad->fast_status = 1;
 				close(fd);
 				na++;
 				a_count = na; // update adapter counter

--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -897,9 +897,10 @@ void *select_and_execute(void *arg)
 			sockets *ss;
 			lt = c_time;
 			i = -1;
-			while (++i < max_sock)
-				if ((ss = get_sockets(i)) && (ss->tid == tid) &&
-					(((ss->timeout_ms > 0) && (lt - ss->rtime > ss->timeout_ms) && (ss->spos == ss->wpos)) || (ss->force_close)))
+			while (++i < max_sock) {
+				if ((ss = get_sockets(i)) == NULL || (ss->tid != tid))
+					continue;
+				if (((ss->timeout_ms > 0) && (lt - ss->rtime > ss->timeout_ms) && (ss->spos == ss->wpos)) || (ss->force_close))
 				{
 					if (ss->timeout && !ss->force_close)
 					{
@@ -915,6 +916,7 @@ void *select_and_execute(void *arg)
 					else
 						sockets_del(i);
 				}
+			}
 		}
 	}
 


### PR DESCRIPTION
The signal/snr is reset to prevent to use old values after tuning. Also, improve the signal_thread() function and add fast_status for the axe hardware. The new code was tested on the axe hardware.