### PR TITLE
Enable DVB-S2 Multistream support for devices running DVBAPI 5.10 or less

### DIFF
--- a/src/dvb.c
+++ b/src/dvb.c
@@ -863,7 +863,12 @@ int dvb_tune(int aid, transponder *tp)
 		ADD_PROP(DTV_ROLLOFF, tp->ro)
 #if DVBAPIVERSION >= 0x0502
 		if (tp->plp_isi >= 0)
+#if DVBAPIVERSION >= 0x050b /* 5.11 */
 			ADD_PROP(DTV_STREAM_ID, tp->plp_isi)
+#else
+			//In DVBAPI < 5.11 DTV_STREAM_ID takes also the PLS Code and Mode
+			ADD_PROP(DTV_STREAM_ID, tp->plp_isi | (tp->pls_code << 8) | (tp->pls_mode << 26))
+#endif
 #endif
 #if DVBAPIVERSION >= 0x050b /* 5.11 */
 		ADD_PROP(DTV_SCRAMBLING_SEQUENCE_INDEX, pls_scrambling_index(tp))


### PR DESCRIPTION
Implemented DVB-S2 Multistream support similar to how its in enigma2, setting the PLS Code and PLS Mode with the DTV_STREAM_ID property

For reference
https://github.com/OpenPLi/enigma2/blob/ef5dccdf3b6c28b6b07c393f743a4a7a0990cfeb/lib/dvb/frontend.cpp#L2066

Tested on 5W channels