### PR TITLE
fix proto style

### DIFF
--- a/src/dvbapi.h
+++ b/src/dvbapi.h
@@ -71,7 +71,7 @@ int dvbapi_enabled();
 int send_ecm(int filter_id, unsigned char *b, int len, void *opaque);
 int batch_size();
 int decrypt_stream(adapter *ad, void *arg);
-int keys_add(int i, int adapter, int pmt);
+int keys_add(int i, int adapter, int pmt_id);
 int keys_del(int i);
 int dvbapi_process_pmt(unsigned char *b, adapter *ad);
 void dvbapi_pid_add(adapter *a, int pid, SPid *cp, int existing);


### PR DESCRIPTION
var names not equal