### PR TITLE
fix rtcp Acknowledging stream

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -503,8 +503,6 @@ int decode_transport(sockets *s, char *arg, char *default_rtp, int start_rtp)
 						   "decode_transport failed: UDP connection on rtcp port to %s:%d failed",
 						   p.dest, p.port + 1);
 
-		set_linux_socket_timeout(sid->rtcp);
-
 		if ((sid->rtcp_sock = sockets_add(sid->rtcp, NULL, sid->sid, TYPE_RTCP,
 										  (socket_action)rtcp_confirm, NULL, NULL)) < 0) // read rtcp
 			LOG_AND_RETURN(-1, "RTCP socket_add failed");


### PR DESCRIPTION
removing  set_linux_socket_timeout brings back Acknowledging rtcp
```
[14/12 12:39:55.027 main]: Acknowledging stream 0 via rtcp packet
[14/12 12:39:55.053 main]: Acknowledging stream 1 via rtcp packet
```
this is long standing bug since 9 Nov 2015 early 0.5
