### PR TITLE
fix ddci detect

### DIFF
--- a/src/ddci.c
+++ b/src/ddci.c
@@ -856,7 +856,7 @@ int ddci_open_device(adapter *ad)
 	write_fd = open(buf, O_WRONLY);
 	if (write_fd < 0)
 	{
-		sprintf(buf, "/dev/dvb/adapter%d/sec%d", ad->pa, ad->fn);
+		sprintf(buf, "/dev/dvb/adapter%d/ci%d", ad->pa, ad->fn);
 		write_fd = open(buf, O_WRONLY)
 		if (write_fd < 0)
 		{

--- a/src/ddci.c
+++ b/src/ddci.c
@@ -1011,6 +1011,10 @@ void find_ddci_adapter(adapter **a)
 			sprintf(buf, "/dev/dvb/adapter%d/sec%d", i, j);
 			if (!access(buf, R_OK))
 				cnt++;
+			else
+			sprintf(buf, "/dev/dvb/adapter%d/ci%d", i, j);
+			if (!access(buf, R_OK))
+				cnt++;
 #ifdef DDCI_TEST
 			cnt = 2;
 #endif

--- a/src/ddci.c
+++ b/src/ddci.c
@@ -856,8 +856,13 @@ int ddci_open_device(adapter *ad)
 	write_fd = open(buf, O_WRONLY);
 	if (write_fd < 0)
 	{
-		LOG("%s: could not open %s in WRONLY mode error %d: %s", __FUNCTION__, buf, errno, strerror(errno));
-		return 1;
+		sprintf(buf, "/dev/dvb/adapter%d/sec%d", ad->pa, ad->fn);
+		write_fd = open(buf, O_WRONLY)
+		if (write_fd < 0)
+		{
+			LOG("%s: could not open %s in WRONLY mode error %d: %s", __FUNCTION__, buf, errno, strerror(errno));
+			return 1;
+		}
 	}
 
 	read_fd = open(buf, O_RDONLY);


### PR DESCRIPTION
if the vendor driver for DDD devices is installed then we need to check for /dev/dvb/adapter0/ci0 the kernel drivers use sec0