### PR TITLE
Encapsulate HTTP responses when using persistent requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,23 @@
-dist: xenial
+dist: bionic
 language: c
-install: apt-get install libdvbcsa-dev dvb-apps
-
+before_install:
+- sudo apt-get -qqy update && sudo apt-get install libdvbcsa-dev dvb-apps libssl-dev
+  -qqy
+- echo -n | openssl s_client -connect https://scan.coverity.com:443 | sed -ne '/-BEGIN
+  CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+script:
+- "./configure"
+- make -j 4
+- make test
+env:
+  global:
+          secure: "13s/vbrHJAkRCQAxScLJ+atOQTXCHNfjV40FXlNWSReTSSJPhebw4tMSRdqp7YPnydMiXitQbO1C3mjJ4U6KJz3e9PpvvaZaY1CGGccp0+iRApVoL1+KTg8KQg7c6ubWk/Nyx4l2eA1Dmie6gZdD1F1juCH0UjHbJRAoq8WIgZvy1aiwXaAbh4XkZlZ1t/k8IHRWbyxaxRIazlwYRFjHoFCAHyxkUOSQJj5j1dBNAgNweEDZ0rVKLnx1VRa0u0y+p17PivP+b9hcSLX1JcjTO/yZzfTRVSjRQQzCoeJ8DErZoHUr9eF8P210TVUYU9nE3my7Vr1WserNq14GYlNXlWkofntaql56Ru1+b835WtrvxRQKtkFgX0w2+9unrwYbhTpPMdJjGMZjkkepkW5kUoIo/NP1ZTJSgd7BPOuSXqJBZVSgJXK5eoTTn1xLUiqGyQLLBj4/nvajUu0oq/uFuk2wMbDtrHSSvU0jxJmYxL+2X8GxU2PuEP+LvaoXgFJxqpJSDWuuUBYu1B24vq3OqWtB8FqUYQXJsj1lk//klKmVnr/R6yyUylo8rC4VnwfNcR98rccg2O6E1RnqzVVcAwUi+7TU1UGdn3F43RmxJaqPRp0/BnKSDGQU1+ygaFN3INpQQ8ZLRfxEa8Tjyng08SZMzpvARVdndGlN4zKRFAo="
+addons:
+  coverity_scan:
+    project:
+      name: catalinii/minisatip
+      description: minisatip
+    notification_email: t_cata_2000@yahoo.com
+    build_command_prepend: "./configure"
+    build_command: make
+    branch_pattern: master

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<a href="https://scan.coverity.com/projects/catalinii-minisatip">
+  <img alt="Coverity Scan Build Status"
+       src="https://scan.coverity.com/projects/18049/badge.svg"/>
+</a>
+<img alt="Build Status" src="https://travis-ci.org/catalinii/minisatip.svg?branch=master" />
+
 # Welcome to Minisatip
 
 Minisatip is a multi-threaded satip server version 1.2 that runs under Linux and it was tested with DVB-S, DVB-S2, DVB-T, DVB-T2, DVB-C, DVB-C2, ATSC and ISDB-T cards.
@@ -25,20 +31,10 @@ https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=7UWQ7FXSABUH8&item
 Usage:
 -------
 
-minisatip version 0.7.15, compiled with s2api version: 050A
-[07/01 06:55:48.445 main]: Built with dvbcsa
-[07/01 06:55:48.445 main]: Built with CI
-[07/01 06:55:48.445 main]: Built with dvbapi
-[07/01 06:55:48.445 main]: Built with AES (OpenSSL)
-[07/01 06:55:48.445 main]: Built with tables processing
-[07/01 06:55:48.445 main]: Built with pmt processing
-[07/01 06:55:48.445 main]: Built with satip client
-[07/01 06:55:48.445 main]: Built with linux dvb client
-[07/01 06:55:48.445 main]: Built with backtrace
-[07/01 06:55:48.445 main]: Built with netceiver
+minisatip version 0.7.16, compiled with s2api version: 050B
 
 	./minisatip [-[fgtzE]] [-a x:y:z] [-b X:Y] [-B X] [-H X:Y] [-d A:C-U ] [-D device_id] [-e X-Y,Z] [-i prio] 
-		[-[uj] A1:S1-F1[-PIN]] [-m mac] [-P port] [-l module1[,module2]] [-v module1[,module2]][-o oscam_host:dvbapi_port] [-p public_host] [-r remote_rtp_host] [-R document_root] [-s [DELSYS:]host[:port] [-u A1:S1-F1[-PIN]] [-L A1:low-high-switch] [-w http_server[:port]] 
+		[-[uj] A1:S1-F1[-PIN]] [-m mac] [-P port] [-l module1[,module2]] [-v module1[,module2]][-o oscam_host:dvbapi_port] [-p public_host] [-r remote_rtp_host] [-R document_root] [-s [*][DELSYS:][FE_ID@][source_ip/]host[:port] [-u A1:S1-F1[-PIN]] [-L A1:low-high-switch] [-w http_server[:port]] 
  	[-x http_port] [-X xml_path] [-y rtsp_port]
 
 Help
@@ -54,12 +50,16 @@ Help
 * -B X : set the app socket write buffer to X KB. 
 	* eg: -B 10000 - to set the socket buffer to 10MB
 
+* -2 --tcp-max-pack X : set the TCP data chunk size in MPEG-TS packets (188 bytes), default value is 42
+
 * -d --diseqc ADAPTER1:COMMITTED1-UNCOMMITTED1[,ADAPTER2:COMMITTED2-UNCOMMITTED2[,...]
 	* The first argument is the adapter number, second is the number of committed packets to send to a Diseqc 1.0 switch, third the number of uncommitted commands to sent to a Diseqc 1.1 switch
 	The higher number between the committed and uncommitted will be sent first.
 	* eg: -d 0:1-0  (which is the default for each adapter).
 	- note: * as adapter means apply to all adapters
 	- note: * before committed number enables fast-switch (only voltage/tone)
+	- note: @ before committed number sets 'Any Device' diseqc address (0x00)
+	- note: . before committed number sets 'LNB' diseqc address (0x11)
 
 * -q --diseqc-timing ADAPTER1:BEFORE_CMD1-AFTER_CMD1-AFTER_REPEATED_CMD1-AFTER_SWITCH1-AFTER_BURST1-AFTER_TONE1[,...]
 	* All timing values are in ms, default adapter values are: 15-54-15-15-15-0
@@ -103,7 +103,7 @@ Help
 	* eg: -l http,pmt
 
 * -v specifies the modules comma separated that will have increased debug level (more verbose than -l), 
-	* eg: -d http,pmt
+	* eg: -v http,pmt
 
 * -L --lnb specifies the adapter and LNB parameters (low, high and switch frequency)
 	* eg: -L *:9750-10600-11700 - sets all the adapters to use Universal LNB parameters (default)
@@ -127,9 +127,6 @@ Help
 	- turns off power management for all adapters (recommended instead of --adapter-timeout 0-32:0) 
 	- required for some Unicable LNBs 
 
-* -n --netceiver if:count: use network interface <if> (default vlan4) and look for <count> netceivers
-	* eg: -n vlan4:2 
-
 * -o --dvbapi host:port - specify the hostname and port for the dvbapi server (oscam). Port 9000 is set by default (if not specified) 
 	* eg: -o 192.168.9.9:9000 
 	192.168.9.9 is the host where oscam is running and 9000 is the port configured in dvbapi section in oscam.conf.
@@ -149,9 +146,10 @@ Help
  
 * -R --document-root directory: document root for the minisatip web page and images
 
-* -s --satip-servers [~][DELSYS:][FE_ID@][source_ip/]host[:port] - specify the remote satip host and port with delivery system DELSYS, it is possible to use multiple -s 
-	* ~ When using this symbol at start the "pids=all" call is replaced with "pids=0-20"
-	* DELSYS - can be one of: dvbs, dvbs2, dvbt, dvbt2, dvbc, dvbc2, isdbt, atsc, dvbcb ( - DVBC_ANNEX_B ) [default: dvbs2]
+* -s --satip-servers [~][*][DELSYS:][FE_ID@][source_ip/]host[:port] - specify the remote satip host and port with delivery system DELSYS, it is possible to use multiple -s 
+	* ~ When using this symbol at start the `pids=all` call is replaced with `pids=0-20`
+	* - Use TCP if -O is not specified and UDP if -O is specified
+	DELSYS - can be one of: dvbs, dvbs2, dvbt, dvbt2, dvbc, dvbc2, isdbt, atsc, dvbcb ( - DVBC_ANNEX_B ) [default: dvbs2]
 	host - the server of the satip server
 	port - rtsp port for the satip server [default: 554]
 	FE_ID - will be determined automatically
@@ -183,7 +181,7 @@ Help
 
 * -t --cleanpsi clean the PSI from all CA information, the client will see the channel as clear if decrypted successfully
 
-* -T --threads: enables/disable multiple threads (reduces memory consumptions) (default: ENABLED)
+* -T --threads: enables/disable multiple threads (reduces memory consumption) (default: ENABLED)
 
 * -u --unicable unicable_string: defines the unicable adapters (A) and their slot (S), frequency (F) and optionally the PIN for the switch:
 	* The format is: A1:S1-F1[-PIN][,A2:S2-F2[-PIN][,...]]
@@ -209,8 +207,10 @@ Help
 	* 0 - use dvrX device 
 	* 1 - use demuxX device 
 	* 2 - use dvrX device and additionally capture PSI data from demuxX device 
+	* 3 - use demuxX device and additionally capture PSI data from demuxX device 
 
- How to compile:
+ 
+How to compile:
 ------
 
 - ./configure
@@ -231,7 +231,7 @@ make EXTRA_CFLAGS=....
 
 Examples:
 -------
-- In order to listen to a radio after minisatip is started open the following URL in your favourite media player:
+- In order to listen to a radio after minisatip is started open the following URL in your favorite media player:
 	- on Hotbird 13E: "http://MINISATIP_HOST:8080/?msys=dvbs&freq=11623&pol=v&sr=27500&pids=0,10750,254"
 	- Astra 19.2E: "http://MINISATIP_HOST:8080/?msys=dvbs&freq=12266&pol=h&sr=27500&pids=0,851"	
 

--- a/readme_header
+++ b/readme_header
@@ -1,3 +1,9 @@
+<a href="https://scan.coverity.com/projects/catalinii-minisatip">
+  <img alt="Coverity Scan Build Status"
+       src="https://scan.coverity.com/projects/18049/badge.svg"/>
+</a>
+<img alt="Build Status" src="https://travis-ci.org/catalinii/minisatip.svg?branch=master" />
+
 # Welcome to Minisatip
 
 Minisatip is a multi-threaded satip server version 1.2 that runs under Linux and it was tested with DVB-S, DVB-S2, DVB-T, DVB-T2, DVB-C, DVB-C2, ATSC and ISDB-T cards.

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -645,7 +645,7 @@ int compare_slave_parameters(adapter *ad, transponder *tp)
 	{
 		int i;
 		for (i = 0; i < MAX_ADAPTERS; i++)
-			if (ad->used & (1 << i))
+			if (ad->used & (1L << i))
 			{
 				adapter *ad2 = get_adapter(i);
 				if (!ad2)

--- a/src/ca.c
+++ b/src/ca.c
@@ -554,7 +554,7 @@ static int ca_ca_info_callback(void *arg, uint8_t slot_id,
 	ca_device_t *d = arg;
 	LOG("%02x:%s", slot_id, __func__);
 	uint32_t i;
-	for (i = 0; i < ca_id_count; i++)
+	for (i = 0; i < 1 /*ca_id_count*/; i++)
 	{
 		LOG("  Supported CA ID: %04x for CA %d", ca_ids[i], d->id);
 		add_caid_mask(dvbca_id, d->id, ca_ids[i], 0xFFFF);

--- a/src/dvbapi.c
+++ b/src/dvbapi.c
@@ -220,6 +220,7 @@ int dvbapi_reply(sockets *s)
 						k->filter_id[fpos] = -1;
 						k->pid[fpos] = -1;
 					}
+					break;
 				}
 			}
 			if (i >= 0 && fid >= 0 && k)

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -500,6 +500,12 @@ void update_cw(SPMT *pmt)
 	}
 	if (!pmt->invalidated && !master->invalidated)
 	{
+		LOGM("PMT %d or pmt %d invalidated", pmt->id, pmt->master_pmt);
+		return;
+	}
+	if (pmt->cw)
+	{
+		LOGM("Valid CW for PMT %d", pmt->master_pmt);
 		return;
 	}
 	LOGM("%s: pmt %d, parity %d, CW %d", __FUNCTION__, pmt->id, pmt->parity, pmt->cw ? pmt->cw->id : -1);

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -1001,8 +1001,8 @@ void satipc_commit(adapter *ad)
 
 	url[0] = 0;
 	LOG(
-		"satipc: commit for adapter %d pids to add %d, pids to delete %d, expect_reply %d, force_commit %d want_tune %d do_tune %d, force_pids %d",
-		ad->id, sip->lap, sip->ldp, sip->expect_reply, sip->force_commit, sip->want_tune, ad->do_tune, sip->force_pids);
+		"satipc: commit for adapter %d pids to add %d, pids to delete %d, expect_reply %d, force_commit %d want_tune %d do_tune %d, force_pids %d, sent_transport %d",
+		ad->id, sip->lap, sip->ldp, sip->expect_reply, sip->force_commit, sip->want_tune, ad->do_tune, sip->force_pids, sip->sent_transport);
 
 	if (ad->do_tune && !sip->want_tune)
 	{
@@ -1096,7 +1096,7 @@ void satipc_commit(adapter *ad)
 		sip->ignore_packets = 1; // ignore all the packets until we get 200 from the server
 		sip->want_tune = 0;
 		sip->err = 0;
-		if (!sip->setup_pids)
+		if (!sip->setup_pids && !sip->sent_transport)
 		{
 			strcatf(url, len, "&pids=none");
 			http_request(ad, url, NULL);

--- a/src/stream.c
+++ b/src/stream.c
@@ -312,7 +312,6 @@ int start_play(streams *sid, sockets *s)
 	if (!sid->tp.apids && sid->tp.pids && (!sid->tp.pids[0] || !strcmp(sid->tp.pids, "0")))
 		s->flush_enqued_data = 1;
 	sid->do_play = 1;
-	sid->start_streaming = 0;
 	if (s->type != TYPE_HTTP)
 		sid->start_streaming = 0;
 	sid->tp.apids = sid->tp.dpids = sid->tp.pids = sid->tp.x_pmt = NULL;

--- a/src/stream.c
+++ b/src/stream.c
@@ -313,6 +313,8 @@ int start_play(streams *sid, sockets *s)
 		s->flush_enqued_data = 1;
 	sid->do_play = 1;
 	sid->start_streaming = 0;
+	if (s->type != TYPE_HTTP)
+		sid->start_streaming = 0;
 	sid->tp.apids = sid->tp.dpids = sid->tp.pids = sid->tp.x_pmt = NULL;
 
 	ad = get_adapter(sid->adapter);
@@ -349,6 +351,7 @@ int close_stream(int i)
 	}
 	mutex_lock(&st_mutex);
 	sid->enabled = 0;
+	sid->start_streaming = 0;
 	sid->timeout = 0;
 	ad = sid->adapter;
 	sid->adapter = -1;
@@ -741,7 +744,14 @@ void flush_streamb(streams *sid, unsigned char *buf, int rlen, int64_t ctime)
 	int i, rv = 0, blen, len;
 
 	if (sid->type == STREAM_HTTP)
+	{
 		rv = sockets_write(sid->rsock_id, buf, rlen);
+		if (sid->start_streaming == 0)
+		{
+			sid->start_streaming = 1;
+			LOG("Start HTTP streaming of stream %d to handle %d", sid->sid, sid->rsock);
+		}
+	}
 	else
 	{
 		int max_pack = sid->type == STREAM_RTSP_TCP ? sid->max_iov : UDP_MAX_PACK;
@@ -769,7 +779,14 @@ int flush_streami(streams *sid, int64_t ctime)
 	int rv;
 
 	if (sid->type == STREAM_HTTP)
+	{
 		rv = sockets_writev(sid->rsock_id, sid->iov, sid->iiov);
+		if (sid->start_streaming == 0)
+		{
+			sid->start_streaming = 1;
+			LOG("Start HTTP streaming of stream %d to handle %d", sid->sid, sid->rsock);
+		}
+	}
 	else
 		rv = send_rtp(sid, sid->iov, sid->iiov);
 

--- a/tests/test_ddci.c
+++ b/tests/test_ddci.c
@@ -102,7 +102,7 @@ int test_copy_ts_from_ddci()
 	__attribute__((unused)) int ad_pos = 0;
 	buf[0] = buf2[0] = 0x47;
 	d.pid_mapping[1000] = 22; // forcing mapping to a different pid
-	int new_pid = add_pid_mapping_table(1, 1000, 0, 0);
+	int new_pid = add_pid_mapping_table(1, 1000, 0, 0, 0);
 	ad.rlen = 188;
 	set_pid_ts(buf, new_pid);
 	set_pid_ts(buf2, 0x1FFF);
@@ -185,8 +185,8 @@ int test_ddci_process_ts()
 	buf[0] = 0x47;
 	d.pid_mapping[1000] = 22; // forcing mapping to a different pid
 	d.pid_mapping[2000] = 22; // forcing mapping to a different pid
-	int new_pid = add_pid_mapping_table(1, 1000, 0, 0);
-	int new_pid2 = add_pid_mapping_table(1, 2000, 0, 0);
+	int new_pid = add_pid_mapping_table(1, 1000, 0, 0, 0);
+	int new_pid2 = add_pid_mapping_table(1, 2000, 0, 0, 0);
 	ad.rlen = ad.lbuf - 188; // allow just 1 packet + 1 cleared that it will be written to the socket
 	set_pid_ts(ad.buf + 188, 1000);
 
@@ -234,7 +234,7 @@ int test_create_pat()
 	ddci_devices[0] = &d;
 	int pid = 4096;
 	d.pid_mapping[pid] = 22; // forcing mapping to a different pid
-	int dpid = add_pid_mapping_table(0, pid, 0, 0);
+	int dpid = add_pid_mapping_table(0, pid, 0, 0, 0);
 	f.flags = FILTER_CRC;
 	f.id = 0;
 	f.adapter = 0;
@@ -289,8 +289,8 @@ int test_create_pmt()
 	int capid = 7068;
 	//	d.pid_mapping[pid] = 22; // forcing mapping to a different pid
 	//	d.pid_mapping[capid] = 23; // forcing mapping to a different pid
-	int dpid = add_pid_mapping_table(0, pid, 0, 0);
-	int dcapid = add_pid_mapping_table(0, capid, 0, 0);
+	int dpid = add_pid_mapping_table(0, pid, 0, 0, 0);
+	int dcapid = add_pid_mapping_table(0, capid, 0, 0, 0);
 	f.flags = FILTER_CRC;
 	f.id = 0;
 	f.adapter = 0;
@@ -302,14 +302,18 @@ int test_create_pmt()
 	pmt.pid = pid;
 	strcpy(pmt.name, "TEST CHANNEL HD");
 	memcpy(pmt.pmt, pmt_sample, sizeof(pmt_sample));
-	pmt.pmt_len = sizeof(pmt_sample);
+	pmt.pmt_len = sizeof(pmt_sample) - 1;
 	psi_len = ddci_create_pmt(&d, &pmt, psi, 0);
 	cc = 1;
-	hexdump("PACK ", psi, psi_len);
+	_hexdump("PACK: ", psi, psi_len);
 	buffer_to_ts(packet, 188, psi, psi_len, &cc, 0x63);
+	_hexdump("TS: ", packet, 188);
 	int len = assemble_packet(&f, packet);
 	if (!len)
+	{
+		LOG("Assemble packet failed");
 		return 1;
+	}
 	int new_pid = packet[42] * 256 + packet[43];
 	int new_capid = packet[21] * 256 + packet[22];
 	new_pid &= 0x1FFF;
@@ -324,14 +328,14 @@ int test_create_pmt()
 int main()
 {
 	opts.log = 1;
-	strcpy(thread_name, "test");;
-	//	opts.log = LOG_DVBCA + 1;
+	opts.debug = 0;
+	strcpy(thread_name, "test");
 	find_ddci_adapter(a);
 	TEST_FUNC(test_push_ts_to_ddci(), "testing test_push_ts_to_ddci");
 	TEST_FUNC(test_copy_ts_from_ddci(), "testing test_copy_ts_from_ddci");
 	TEST_FUNC(test_ddci_process_ts(), "testing ddci_process_ts");
 	TEST_FUNC(test_create_pat(), "testing create_pat");
-	TEST_FUNC(test_create_pmt(), "testing create_pat");
+	TEST_FUNC(test_create_pmt(), "testing create_pmt");
 	fflush(stdout);
 	return 0;
 }

--- a/tests/test_pmt.c
+++ b/tests/test_pmt.c
@@ -140,16 +140,18 @@ int test_clean_psi_buffer()
 
 	if (process_pmt(0, f.data, len, &pmt))
 		LOG_AND_RETURN(1, "process_pmt failed");
+#if defined(__x86_64__) || defined(__i386__)
 	if (!createCAPMT(pmt.pmt, pmt.pmt_len, 1, clean, sizeof(clean)))
 		LOG_AND_RETURN(1, "createCAPMT failed");
+#endif
 	return 0;
 }
 
 int main()
 {
-	opts.log = -1;
-	opts.debug = -1;
-	strcpy(thread_name, "test");;
+	opts.log = 1;
+	opts.debug = 0;
+	strcpy(thread_name, "test");
 	TEST_FUNC(test_clean_psi_buffer_only(), "testing test_clean_psi_buffer_only");
 	TEST_FUNC(test_clean_psi_buffer(), "testing test_clean_psi_buffer");
 	fflush(stdout);

--- a/tools/gen_readme
+++ b/tools/gen_readme
@@ -3,5 +3,5 @@ rm src/minisatip.o
 gcc -c src/minisatip.c -o src/minisatip.o
 make 
 cat readme_header > README.md
-./minisatip -h  >> README.md
+./minisatip -h | grep -v 'Built with' >> README.md
 cat readme_footer >> README.md


### PR DESCRIPTION
When using the HTTP protocol for streaming, it's possible to process multiple requests (aka Persistent Mode). And this is great! However, when doing the streaming the HTTP response is sended in between of the TS packets. Then it's possible to "encapsulate" the response inside a NULL TS packet.

This patch implements this and allows the client to change pids or request new streams without interrupting the streaming.
