### PR TITLE
Fix NetCeiver build when CFLAGS in environment, Fix tests

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2,23 +2,21 @@
 AUTOMAKE_OPTIONS = foreign
 TARGET=minisatip
 
-$(TARGET): FORCE
-	$(MAKE) -C src
-
-clean: FORCE
-	$(MAKE) -C src $@
-	$(MAKE) -C tests $@
-
-test: FORCE
-	$(MAKE) -C src clean
-	$(MAKE) -C tests $@
-
-debug: FORCE
-	$(MAKE) -C src DEBUG=1
-	
-FORCE:
-
 # pull in dependency info for *existing* .o files
 ifneq "$(MAKECMDGOALS)" "clean"
 -include $(DEPS)
 endif
+
+$(TARGET):
+	$(MAKE) -C src
+
+clean:
+	$(MAKE) -C src $@
+	$(MAKE) -C tests $@
+
+test:
+	$(MAKE) -C src
+	$(MAKE) -C tests $@
+
+debug:
+	$(MAKE) -C src DEBUG=1

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -18,9 +18,10 @@ ENIGMA=@ENIGMA@
 DDCI=0
 T2MI=0
 
-CFLAGS?=-Wall -Wno-switch -ggdb -fPIC $(EXTRA_CFLAGS) @CFLAGS@
-LDFLAGS?=@LDFLAGS@
-LDFLAGS += -lpthread
+CFLAGS?=-Wall -Wno-switch -ggdb -fPIC
+CFLAGS += $(EXTRA_CFLAGS) @CFLAGS@
+LDFLAGS += @LDFLAGS@ -lpthread
+CPPFLAGS += @CPPFLAGS@
 
 OS := $(shell $(CC) -v 2>&1 | grep Target | sed 's/Target: //' | cut -d- -f 2)
 ARCH := $(shell $(CC) -v 2>&1 | grep Target | sed 's/Target: //' | cut -d- -f 1)

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -2,7 +2,7 @@
 AUTOMAKE_OPTIONS = foreign
 BUILDDIR := ../build
 
-CFLAGS?=-Wall -Wno-switch -ggdb -fPIC $(EXTRA_CFLAGS) -I../src
+CFLAGS?=-Wall -Wno-switch -ggdb -fPIC $(EXTRA_CFLAGS)
 LDFLAGS?=-lpthread 
 
 OS := $(shell $(CC) -v 2>&1 | grep Target | sed 's/Target: //' | cut -d- -f 2)
@@ -24,6 +24,7 @@ LIBS+=dvbcsa
 LIBS+=dvben50221 dvbapi ucsi
 CFLAGS += -DAXE
 #CFLAGS += -fsanitize=address -fno-omit-frame-pointer -fsanitize=leak -fsanitize=null
+CFLAGS += -I../src
 
 CFLAGS += -DENIGMA
 CFLAGS += -DTESTING


### PR DESCRIPTION
In most distribution package build systems, a "CFLAGS" and "CPPFLAGS" environment variable is provided by the build helper which has the distribution default compiler settings.

If this is the case, then NetCeiver build fails as the NetCeiver includes and library flags are overwritten by the fact that the environment variable is there.

This patch fixes this problem and also fixes building tests. If "clean" is run before building tests, then the tests fail.

Original discussion: https://www.vdr-portal.de/forum/index.php?thread/131575-yavdr-ansible/&postID=1317572#post1317572