### PR TITLE
[pmt,web-gui] fix channel name not being displayed in the web-gui

### DIFF
--- a/src/pmt.c
+++ b/src/pmt.c
@@ -1703,6 +1703,7 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque)
 		if ((cp = find_pid(ad->id, spid))) // the pid is already requested by the client
 		{
 			enabled_channels++;
+			pmt->running = 1;
 			cp->pmt = pmt->master_pmt;
 		}
 	}


### PR DESCRIPTION
Partial revert of commit b354345. Keep pmt running so that channel name gets retrieved for adapter.  
Resolves issue #600  