### PR TITLE
netceiver: Enable "API socket" needed for netcvdiag and netcvupdate

### DIFF
--- a/src/netceiver.c
+++ b/src/netceiver.c
@@ -409,6 +409,10 @@ void find_netcv_adapter(adapter **a)
 	if (recv_init(opts.netcv_if, 23000))
 		LOG("Netceiver init failed");
 
+	/* Call api_sock_init to initialize the socket needed for netceiver tools */
+	if (api_sock_init(API_SOCK_NAMESPACE))
+		LOG("Netceiver API socket init failed");
+
 	sprintf(dbuf, "REEL: Search for %d Netceiver%s on %s... ",
 			opts.netcv_count, opts.netcv_count == 1 ? "" : "s", opts.netcv_if);
 	n = 0;

--- a/src/netceiver.h
+++ b/src/netceiver.h
@@ -3,6 +3,7 @@
 
 #include "adapter.h"
 
+#define API_SOCK
 #ifndef DISABLE_LINUXDVB
 #undef AOT_CA_PMT
 #include "headers.h"

--- a/src/netceiver_mcli_defs.h
+++ b/src/netceiver_mcli_defs.h
@@ -197,6 +197,7 @@ typedef struct recv_festatus
 #include "mcast.h"
 #include "recv_ccpp.h"
 #include "recv_tv.h"
+#include "api_server.h"
 #include "tca_handler.h"
 
 #endif


### PR DESCRIPTION
The sources, libmcli is created from, also contain some useful tools that can be used to maintain and debug the NetCeiver unit.

netcvdiag: Diagnosis tool to query NetCeiver status
netcvupdate: Update and config tool to change NetCeiver firmware and settings
netcvlogview: Live log viewer

Most of the tools require an unix socket to communicate with the NetCeiver platform.

A very small change makes it possible that minisatip creates this socket, so a running minisatip can act as the required "bridge" for the NetCeiver tools.

I've tried this change with minisatip connected to an NetCeiver equipped with 3 DVB-S2 dual tuners. No issues at all. It really helps with setting up if the maintenance tools are working.