### PR TITLE
Fix letter collision disable-SSDP

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -69,7 +69,7 @@ int rtsp, http, si, si1, ssdp1;
 
 #define RRTP_OPT 'r'
 #define DISABLEDVB_OPT 'N'
-#define DISABLESSDP_OPT 'A'
+#define DISABLESSDP_OPT 'G'
 #define HTTPSERVER_OPT 'w'
 #define HTTPPORT_OPT 'x'
 #define LOG_OPT 'l'
@@ -603,7 +603,7 @@ void set_options(int argc, char *argv[])
 
 #endif
 
-	while ((opt = getopt_long(argc, argv, "fl:v:r:a:td:w:p:s:n:hB:b:H:m:p:e:x:u:j:o:gy:i:q:D:NAVR:S:TX:Y:OL:EP:Z:0:F:M:1:2:3:C:" AXE_OPTS, long_options, NULL)) != -1)
+	while ((opt = getopt_long(argc, argv, "fl:v:r:a:td:w:p:s:n:hB:b:H:m:p:e:x:u:j:o:gy:i:q:D:NGVR:S:TX:Y:OL:EP:Z:0:F:M:1:2:3:C:" AXE_OPTS, long_options, NULL)) != -1)
 	{
 		//              printf("options %d %c %s\n",opt,opt,optarg);
 		switch (opt)


### PR DESCRIPTION
Instead of the letter 'A' already used, we change to `-G` or `--disable-ssdp`.