### PR TITLE
Disable insane log

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1165,7 +1165,7 @@ void process_file(void *sock, char *s, int len, char *ctype)
 		strcpy(outp + io, "\r\n\r\n");
 		rv = sockets_write(so->id, outp, io + 4);
 		outp[io] = 0;
-		LOG("%s", outp);
+		//LOG("%s", outp);
 	}
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -1165,7 +1165,7 @@ void process_file(void *sock, char *s, int len, char *ctype)
 		strcpy(outp + io, "\r\n\r\n");
 		rv = sockets_write(so->id, outp, io + 4);
 		outp[io] = 0;
-		//LOG("%s", outp);
+		DEBUGM("%s", outp);
 	}
 }
 


### PR DESCRIPTION
This log line prints partial content of an entire file. The log is then unreadable. It's preferable to disable this line (only enbale it for deep debug).