### PR TITLE
aes: Don't initialize under OpenSSL 1.1 and above

### DIFF
--- a/src/aes.c
+++ b/src/aes.c
@@ -164,9 +164,9 @@ SCW_op aes_cbc_op =
 
 void init_algo_aes()
 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	ERR_load_crypto_strings();
 	OpenSSL_add_all_algorithms();
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	OPENSSL_config(NULL);
 #endif
 


### PR DESCRIPTION
Initialization is deprecated and does not compile without deprecated APIs.