### PR TITLE
Change minimum limit of the app adapter buffer

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -722,8 +722,8 @@ void set_options(int argc, char *argv[])
 		{
 			sscanf(optarg, "%d:%d", &opts.adapter_buffer, &opts.dvr_buffer);
 			opts.adapter_buffer = (opts.adapter_buffer / 188) * 188;
-			if (opts.adapter_buffer < ADAPTER_BUFFER)
-				opts.adapter_buffer = ADAPTER_BUFFER;
+			if (opts.adapter_buffer < 1316)
+				opts.adapter_buffer = 1316;  // 188 * 7 = 1316
 #ifdef AXE
 			opts.dvr_buffer += 7 * 188 - 1;
 			opts.dvr_buffer -= opts.dvr_buffer % (7 * 188);


### PR DESCRIPTION
The default value for the app adapter buffer (72192 == ADAPTER_BUFFER) is currently the lower limit.
This limit has been changed (up to 1316 bytes, which is one RTP packet) so the user can use smaller values.