### PR TITLE
Fix incorrect handle of SAT>IP client close

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -437,13 +437,13 @@ int close_adapter(int na)
 	}
 
 	LOG("closing adapter %d  -> fe:%d dvr:%d, sock:%d, fe_sock:%d", na, ad->fe, ad->dvr, ad->sock, ad->fe_sock);
-	ad->enabled = 0;
-	if (ad->close)
-		ad->close(ad);
 	//close all streams attached to this adapter
 	//	close_streams_for_adapter (na, -1);
 	mark_pids_deleted(na, -1, NULL);
-	update_pids(na);
+	// update_pids(na); // No update pids as the adapter is closing!
+	ad->enabled = 0;
+	if (ad->close)
+		ad->close(ad);
 	//      if(ad->dmx>0)close(ad->dmx);
 	if (ad->fe > 0)
 		close(ad->fe);

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -1040,6 +1040,8 @@ void satipc_commit(adapter *ad)
 	if (sip->lap + sip->ldp == 0)
 		if (!sip->force_commit || !ad->tp.freq)
 			return;
+	if (sip->ldp > 0 && sip->last_connect == 0 && !sip->want_tune)
+		return;
 
 	if (sip->expect_reply)
 	{

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -1040,8 +1040,11 @@ void satipc_commit(adapter *ad)
 	if (sip->lap + sip->ldp == 0)
 		if (!sip->force_commit || !ad->tp.freq)
 			return;
-	if (sip->ldp > 0 && sip->last_connect == 0 && !sip->want_tune)
-		return;
+	if (sip->ldp > 0 && (sip->last_cmd == RTSP_TEARDOWN || sip->last_setup < 0))
+	{
+		LOG("satipc: spurious pids to remove, clearing the dpid list");
+		sip->ldp = 0;
+	}
 
 	if (sip->expect_reply)
 	{


### PR DESCRIPTION
It resolves two problems:

1. Free the adapter pid list when closing the adapter.
2. Don't send incorrect SETUP command when committing DELETE pids before the first connection of the SAT>IP client mode.