### PR TITLE
Optimize reading of NULL packets

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -860,6 +860,8 @@ int check_cc(adapter *ad)
 			continue;
 
 		pid = PID_FROM_TS(b);
+		if (pid == 8191)
+			continue;
 		p = find_pid(ad->id, pid);
 
 		if ((!p))
@@ -871,9 +873,6 @@ int check_cc(adapter *ad)
 		}
 
 		p->packets++;
-
-		if (pid == 8191)
-			continue;
 
 		if (b[3] & 0x10)
 		{


### PR DESCRIPTION
Directly check for pid 8191 and discard the packet with this pid. So, don't waste time searching for it in the adapter list.