### PR TITLE
try fix Panasonic streamID equals stream=

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -1223,13 +1223,13 @@ int read_rtsp(sockets *s)
 							 //							opts.start_rtp, opts.start_rtp + 1,
 							 get_sock_sport(sid->rsock),
 							 get_sock_sport(sid->rtcp), get_session_id(s->sid),
-							 s_timeout, sid->sid + 1);
+							 s_timeout, sid->sid == 0 ? sid->sid + 1 : sid->sid);
 				else
 					snprintf(buf, sizeof(buf),
 							 "Transport: RTP/AVP;multicast;destination=%s;port=%d-%d\r\nSession: %010d;timeout=%d\r\ncom.ses.streamID: %d",
 							 ra, get_stream_rport(sid->sid),
 							 ntohs(sid->sa.sin_port) + 1,
-							 get_session_id(s->sid), s_timeout, sid->sid + 1);
+							 get_session_id(s->sid), s_timeout, sid->sid == 0 ? sid->sid + 1 : sid->sid);
 				break;
 			case STREAM_RTSP_TCP:
 				snprintf(buf, sizeof(buf),

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -1223,18 +1223,18 @@ int read_rtsp(sockets *s)
 							 //							opts.start_rtp, opts.start_rtp + 1,
 							 get_sock_sport(sid->rsock),
 							 get_sock_sport(sid->rtcp), get_session_id(s->sid),
-							 s_timeout, sid->sid == 0 ? sid->sid + 1 : sid->sid);
+							 s_timeout, sid->sid == 0 ? 1 : sid->sid);
 				else
 					snprintf(buf, sizeof(buf),
 							 "Transport: RTP/AVP;multicast;destination=%s;port=%d-%d\r\nSession: %010d;timeout=%d\r\ncom.ses.streamID: %d",
 							 ra, get_stream_rport(sid->sid),
 							 ntohs(sid->sa.sin_port) + 1,
-							 get_session_id(s->sid), s_timeout, sid->sid == 0 ? sid->sid + 1 : sid->sid);
+							 get_session_id(s->sid), s_timeout, sid->sid == 0 ? 1 : sid->sid);
 				break;
 			case STREAM_RTSP_TCP:
 				snprintf(buf, sizeof(buf),
 						 "Transport: RTP/AVP/TCP;interleaved=0-1\r\nSession: %010d;timeout=%d\r\ncom.ses.streamID: %d",
-						 get_session_id(s->sid), s_timeout, sid->sid + 1);
+						 get_session_id(s->sid), s_timeout, sid->sid == 0 ? 1 : sid->sid);
 				break;
 			}
 		}


### PR DESCRIPTION
part of fix Panasonic scan 
from spec
The client should use the streamID in order to refer to a stream which has been previously setup.