### PR TITLE
use SO_REUSEPORT if available

### DIFF
--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -147,6 +147,15 @@ int udp_bind(char *addr, int port)
 		close(sock);
 		return -1;
 	}
+#ifdef SO_REUSEPORT
+	if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) < 0)
+	{
+		LOG("udp_bind failed: setsockopt(SO_REUSEPORT): %s",
+			strerror(errno));
+		close(sock);
+		return -1;
+	}
+#endif
 
 	if (bind(sock, (struct sockaddr *)&serv, sizeof(serv)) < 0)
 	{


### PR DESCRIPTION
REUSEPORT will work on linux starting with 3.9 kernel version(which was released back in 2013)
https://stackoverflow.com/questions/14388706/how-do-so-reuseaddr-and-so-reuseport-differ/14388707#14388707