### PR TITLE
Revert "use SO_REUSEPORT if available"

### DIFF
--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -176,15 +176,6 @@ int udp_bind(char *addr, int port, int ipv4_only)
 		close(sock);
 		return -1;
 	}
-#ifdef SO_REUSEPORT
-	if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) < 0)
-	{
-		LOG("udp_bind failed: setsockopt(SO_REUSEPORT): %s",
-			strerror(errno));
-		close(sock);
-		return -1;
-	}
-#endif
 
 	if (bind(sock, &serv.sa, sizeof(serv)) < 0)
 	{


### PR DESCRIPTION
Reverts catalinii/minisatip#656
unfortunately there are systems out where it is defined but not working
and it is not covered by POSIX, so I believe it's better to revert the commit
https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html#tag_15_10_16
