### PR TITLE
SO_REUSEPORT tryfix

### DIFF
--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -178,10 +178,7 @@ int udp_bind(char *addr, int port, int ipv4_only)
 	}
 #ifdef SO_REUSEPORT
 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) < 0)
-	{
-		LOG("udp_bind failed: setsockopt(SO_REUSEPORT): ignored %s",
-			strerror(errno));
-	}
+		LOG("setsockopt failed to set SO_REUSEPORT %s", strerror(errno));
 #endif
 
 	if (bind(sock, &serv.sa, sizeof(serv)) < 0)

--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -177,9 +177,9 @@ int udp_bind(char *addr, int port, int ipv4_only)
 		return -1;
 	}
 #ifdef SO_REUSEPORT
-	if ((setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) < 0) && (errno != ENOPROTOOPT))
+	if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) < 0)
 	{
-		LOG("Can't set setsockopt(SO_REUSEPORT): %s",
+		LOG("udp_bind failed: setsockopt(SO_REUSEPORT): ignored %s",
 			strerror(errno));
 	}
 #endif

--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -177,12 +177,10 @@ int udp_bind(char *addr, int port, int ipv4_only)
 		return -1;
 	}
 #ifdef SO_REUSEPORT
-	if (setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) < 0)
+	if ((setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof(optval)) < 0) && (errno != ENOPROTOOPT))
 	{
-		LOG("udp_bind failed: setsockopt(SO_REUSEPORT): %s",
+		LOG("Can't set setsockopt(SO_REUSEPORT): %s",
 			strerror(errno));
-		close(sock);
-		return -1;
 	}
 #endif
 


### PR DESCRIPTION
RedHat defines SO_REUSEPORT with a kernel which does not support
it and returns ENOPROTOOPT so in this case ignore the error.