### PR TITLE
Improve messages about unkown pids

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -603,7 +603,7 @@ void dump_pids(int aid)
 		if (p->pids[i].flags > 0)
 		{
 			if (dp)
-				LOG("Dumping pids table for adapter %d, pid errors %d", aid, p->pid_err);
+				LOG("Dumping pids table for adapter %d, pid unknown %d", aid, p->pid_err);
 			dp = 0;
 			LOG("pid %d, fd %d, packets %d, d/c errs %d/%d, flags %d, pmt %d, filter %d, sock %d, sids: %d %d %d %d %d %d %d %d",
 				p->pids[i].pid, p->pids[i].fd,

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -352,7 +352,7 @@ int satipc_rtcp_reply(sockets *s)
 
 		if (!sip->init_use_tcp && ((++sip->repno % 100) == 0)) //every 20s
 			LOG(
-				"satipc: rtp report, adapter %d: rtcp missing packets %d, rtp missing %d, rtp ooo %d, pid err %d",
+				"satipc: rtp report, adapter %d: rtcp missing packets %d, rtp missing %d, rtp ooo %d, pid unknown %d",
 				ad->id, rp - sip->rcvp, sip->rtp_miss, sip->rtp_ooo,
 				ad->pid_err);
 	}


### PR DESCRIPTION
The current LOG messages about pids errors are confusing. The code computes the number of _unkown _ packets with a pid number not requested. And this isn't a real error. For example, when a pid is removed from the active pid list, for a short time several packets of this pid can be entered in the incoming buffer. So when processing such packets the counter is raised. And this is normal.

Therefore, the patch changes the name in the log for better understanding.
