### PR TITLE
WIP: fix for CC-errors in dvbapi

### DIFF
--- a/src/dvbapi.c
+++ b/src/dvbapi.c
@@ -267,9 +267,13 @@ int dvbapi_reply(sockets *s)
 				k_id, i, a_id, demux, filter, _pid, _pid);
 			if (i < MAX_KEY_FILTERS && i >= 0)
 			{
+				// Workaround to fix CC-erros with some sources
+				/*
 				del_filter(k->filter_id[i]);
 				k->filter_id[i] = -1;
 				k->pid[i] = -1;
+				*/
+				LOG("dvbapi: request to delete filter, but NOT deleting the filter!");
 			}
 
 			if (k)


### PR DESCRIPTION
Some DVR sources (SAT>IP servers) generate CC-errors when the pid list is updated. This patch fixes it.