### PR TITLE
Improve unconditional logs

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -258,7 +258,7 @@ void print_version(int use_log)
 	if (!use_log)
 		puts(buf);
 	else
-		LOG(buf);
+		LOG0(buf);
 	for (i = 0; built_info[i]; i++)
 		LOG("%s", built_info[i]);
 }
@@ -1816,7 +1816,9 @@ int main(int argc, char *argv[])
 #ifndef DISABLE_PMT
 	pmt_destroy();
 #endif
+	LOG0("Closing...");
 	free_all();
+	LOG0("Exit OK.");
 	if (opts.slog)
 		closelog();
 	return 0;

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -1731,7 +1731,7 @@ int main(int argc, char *argv[])
 	set_options(argc, argv);
 	if ((rv = init_utils(argv[0])))
 	{
-		LOG("init_utils failed with %d", rv);
+		LOG0("init_utils failed with %d", rv);
 		return rv;
 	}
 	if (opts.daemon)

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -134,8 +134,8 @@ int satipc_reply(sockets *s)
 	__attribute__((unused)) int rv;
 	get_ad_and_sipr(s->sid, 1);
 	s->rlen = 0;
-	LOG("satipc_reply (sock %d) handle %d, adapter %d:\n%s", s->id, s->sock,
-		s->sid, s->buf);
+	LOG("satipc_reply (sock %d) handle %d, adapter %d :", s->id, s->sock, s->sid);
+	LOGM("%s", s->buf);
 
 	if ((timeout = strstr((char *)s->buf, "timeout=")))
 	{
@@ -1006,8 +1006,9 @@ int http_request(adapter *ad, char *url, char *method)
 	lb = snprintf(buf, sizeof(buf), format, method, sip->sip, sip->sport, sid,
 				  qm, url, sip->cseq++, session);
 
-	LOG("satipc_http_request (ad %d): %s to sock %d: \n%s", ad->id,
-		sip->expect_reply ? "queueing" : "sending", remote_socket, buf);
+	LOG("satipc_http_request (ad %d): %s to sock %d :", ad->id,
+		sip->expect_reply ? "queueing" : "sending", remote_socket);
+	LOGM("%s", buf);
 	if (sip->expect_reply)
 	{
 		setItem(MAKE_ITEM(ad->id, sip->qp++), (unsigned char *)buf, lb + 1, 0);

--- a/src/utils.h
+++ b/src/utils.h
@@ -205,7 +205,10 @@ static inline int get_index_hash(void *p, int max, int struct_size, uint32_t key
 
 #define FAIL(a, ...)               \
 	{                              \
-		LOGL(0, a, ##__VA_ARGS__); \
+		if (opts.log) {            \
+			LOGL(0, a, ##__VA_ARGS__); \
+		} else                     \
+			LOG0(a, ##__VA_ARGS__);    \
 		unlink(pid_file);          \
 		exit(1);                   \
 	}


### PR DESCRIPTION
When running without logs we need to know when the process is started, and when is closed.
Futhermore, a message regading the closing procedure it's added to detect some kill errors.