### PR TITLE
RTP-Info fix Range white space

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -1258,7 +1258,7 @@ int read_rtsp(sockets *s)
 				strcat(buf, "\r\n");
 
 			snprintf(buf + strlen(buf), sizeof(buf) - strlen(buf) - 1,
-					 "RTP-Info: url=%s;seq=%d;rtptime=%jd\r\nRange: npt=0.000-",
+					 "RTP-Info: url=%s;seq=%d;rtptime=%jd\r\nRange: npt = 0.000-",
 					 arg[1], sid->seq, (getTickUs() / 1000000));
 		}
 		if (buf[0] == 0 && sid->type == STREAM_HTTP)


### PR DESCRIPTION
After checking the with ffplay -v trace and Live555 code it seems that's unable to parse correctly the PLAY request header
'Range: npt=0.000-'
because it expects white spaces like this
'Range: npt = 0.000 -'
This then causes "start", "end" and "duration" to be 0 so can explain why it stops after sending one frame of video...