### PR TITLE
Fix for rtsp issue

### DIFF
--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -860,7 +860,7 @@ void *select_and_execute(void *arg)
 						read_ok ? "OK" : "NOK", rlen, master->rlen, master->lbuf,
 						ss->sock, ss->id, master->id, pos, master->buf, ss->iteration, master->action);
 
-					if (((master->rlen > 0) || err == EWOULDBLOCK) && master->action && (master->type != TYPE_SERVER) && rlen != 0)
+					if (((master->rlen > 0) || err == EWOULDBLOCK) && master->action && (master->type != TYPE_SERVER) && rlen > 0)
 						master->action(master);
 
 					sockets_unlock(ss);

--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -860,7 +860,7 @@ void *select_and_execute(void *arg)
 						read_ok ? "OK" : "NOK", rlen, master->rlen, master->lbuf,
 						ss->sock, ss->id, master->id, pos, master->buf, ss->iteration, master->action);
 
-					if (((master->rlen > 0) || err == EWOULDBLOCK) && master->action && (master->type != TYPE_SERVER))
+					if (((master->rlen > 0) || err == EWOULDBLOCK) && master->action && (master->type != TYPE_SERVER) && rlen != 0)
 						master->action(master);
 
 					sockets_unlock(ss);


### PR DESCRIPTION
fix for "Most likely not an RTSP packet sock_id: 16 sid: 0 rlen: 0, dropping ...."
there are unwanted buffer length 0 given to the action if the client did close the socket normal and read gives back rv 0 and no errno
