### PR TITLE
Implementing the socket priority

### DIFF
--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -1638,12 +1638,15 @@ void set_sockets_sid(int id, int sid)
 		LOGM("sid for socket id %d could not be set", id);
 }
 
-void set_socket_dscp(int id, int dscp)
+void set_socket_dscp(int id, int dscp, int prio)
 {
 	int d;
 
 	d = dscp & IPTOS_DSCP_MASK_VALUE;
 	setsockopt(id, IPPROTO_IP, IP_TOS, &d, sizeof(d));
+
+	d = prio;
+	setsockopt(id, SOL_SOCKET, SO_PRIORITY, &d, sizeof(d));
 }
 
 void sockets_set_opaque(int id, void *opaque, void *opaque2, void *opaque3)

--- a/src/socketworks.h
+++ b/src/socketworks.h
@@ -119,7 +119,7 @@ int sockets_write(int sock_id, void *buf, int len);
 int flush_socket(sockets *s);
 void get_socket_iteration(int s_id, int it);
 void set_sockets_sid(int id, int sid);
-void set_socket_dscp(int id, int dscp);
+void set_socket_dscp(int id, int dscp, int prio);
 void sockets_set_opaque(int id, void *opaque, void *opaque2, void *opaque3);
 void sockets_force_close(int id);
 void sockets_set_master(int slave, int master);

--- a/src/stream.c
+++ b/src/stream.c
@@ -499,7 +499,7 @@ int decode_transport(sockets *s, char *arg, char *default_rtp, int start_rtp)
 			LOG_AND_RETURN(-1, "RTP sockets_add failed");
 
 		set_socket_send_buffer(sid->rsock, opts.output_buffer);
-		set_socket_dscp(sid->rsock, IPTOS_DSCP_EF);
+		set_socket_dscp(sid->rsock, IPTOS_DSCP_EF, 7);
 
 		if ((sid->rtcp = udp_bind_connect(NULL,
 										  opts.start_rtp + (sid->sid * 2) + 1, p.dest, p.port + 1, &sa)) < 1)
@@ -508,7 +508,7 @@ int decode_transport(sockets *s, char *arg, char *default_rtp, int start_rtp)
 						   p.dest, p.port + 1);
 
 		set_linux_socket_timeout(sid->rtcp);
-		set_socket_dscp(sid->rtcp, IPTOS_DSCP_EF);
+		set_socket_dscp(sid->rtcp, IPTOS_DSCP_EF, 6);
 
 		if ((sid->rtcp_sock = sockets_add(sid->rtcp, &sa, sid->sid, TYPE_RTCP,
 										  (socket_action)rtcp_confirm, NULL, NULL)) < 0) // read rtcp


### PR DESCRIPTION
For UDP (RTP & RTCP) sockets, it implements the socket priority capability. This will improve the jitter performance of output streams in servers with low resources and high cpu use.