### PR TITLE
Improve message description

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -603,7 +603,7 @@ void dump_pids(int aid)
 		if (p->pids[i].flags > 0)
 		{
 			if (dp)
-				LOG("Dumping pids table for adapter %d, pid unknown %d", aid, p->pid_err);
+				LOG("Dumping pids table for adapter %d, number of unknown pids: %d", aid, p->pid_err);
 			dp = 0;
 			LOG("pid %d, fd %d, packets %d, d/c errs %d/%d, flags %d, pmt %d, filter %d, sock %d, sids: %d %d %d %d %d %d %d %d",
 				p->pids[i].pid, p->pids[i].fd,


### PR DESCRIPTION
The member "adapter->pid_err" declared in adapter.h: https://github.com/catalinii/minisatip/blob/6add3c0c8db79dc535126f4414fe9c2a74bdcf9d/src/adapter.h#L70
corresponds to a counter of unkown pids. The value is updated here: https://github.com/catalinii/minisatip/blob/49290afdaf48e39766e04ed459f1594bfa47d425/src/stream.c#L811
so the LOG message used without this patch is incorrect.