### PR TITLE
Fix no TEARDOWN with satipc module 

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -837,7 +837,7 @@ void close_adapter_for_stream(int sid, int aid, int force)
 	mutex_unlock(&ad->mutex);
 	if (((ad->restart_needed == 1) || force) && !is_slave)
 	{
-		LOG("restarting adapter %d as needed", ad->id);
+		LOG("%s adapter %d as needed", force ? "closing" : "restarting", ad->id);
 		//		request_adapter_close (ad);
 		close_adapter(ad->id);
 	}

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -789,7 +789,7 @@ int set_adapter_for_stream(int sid, int aid)
 	return 0;
 }
 
-void close_adapter_for_stream(int sid, int aid)
+void close_adapter_for_stream(int sid, int aid, int force)
 {
 	adapter *ad;
 	streams *s = get_sid(sid);
@@ -811,8 +811,8 @@ void close_adapter_for_stream(int sid, int aid)
 	}
 	if (ad->sid_cnt > 0)
 		ad->sid_cnt--;
-	LOG("closed adapter %d for stream %d m:%d sid_cnt:%d, restart_needed %d", aid, sid, ad->master_sid,
-		ad->sid_cnt, ad->restart_needed);
+	LOG("closed adapter %d for stream %d m:%d sid_cnt:%d, restart_needed %d, force_close %d", aid, sid, ad->master_sid,
+		ad->sid_cnt, ad->restart_needed, force);
 	// delete the attached PIDs as well
 	if (ad->sid_cnt == 0)
 	{
@@ -835,7 +835,7 @@ void close_adapter_for_stream(int sid, int aid)
 	update_pids(aid);
 	adapter_update_threshold(ad);
 	mutex_unlock(&ad->mutex);
-	if ((ad->restart_needed == 1) && !is_slave)
+	if (((ad->restart_needed == 1) || force) && !is_slave)
 	{
 		LOG("restarting adapter %d as needed", ad->id);
 		//		request_adapter_close (ad);

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -835,14 +835,14 @@ void close_adapter_for_stream(int sid, int aid, int stby)
 		mark_pids_deleted(aid, sid, NULL);
 	update_pids(aid);
 	adapter_update_threshold(ad);
-	mutex_unlock(&ad->mutex);
-	if (stby && !is_slave && ad->type == ADAPTER_SATIP)
+	if (stby && !is_slave && ad->type == ADAPTER_SATIP && ad->sid_cnt == 0)
 	{
 		LOG("adapter %d closing for standby", ad->id);
 		ad->is_standby = 1;
 		close_adapter(ad->id);
 		ad->is_standby = 0;
 	}
+	mutex_unlock(&ad->mutex);
 	if ((ad->restart_needed == 1) && !is_slave)
 	{
 		LOG("restarting adapter %d as needed", ad->id);

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -843,9 +843,9 @@ void close_adapter_for_stream(int sid, int aid, int stby)
 		close_adapter(ad->id);
 		ad->is_standby = 0;
 	}
-	if (((ad->restart_needed == 1) || force) && !is_slave)
+	if ((ad->restart_needed == 1) && !is_slave)
 	{
-		LOG("%s adapter %d as needed", force ? "closing" : "restarting", ad->id);
+		LOG("restarting adapter %d as needed", ad->id);
 		//		request_adapter_close (ad);
 		close_adapter(ad->id);
 	}

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -52,6 +52,7 @@ typedef struct struct_adapter
 	int master_sid; // first SID, the one that controls the tuning
 	int sid_cnt;	//number of streams
 	int sock, fe_sock;
+	int is_standby;
 	int do_tune;
 	int force_close;
 	unsigned char *buf; // 7 rtp packets = MAX_PACK, 7 frames / packet
@@ -119,7 +120,7 @@ adapter *adapter_alloc();
 int close_adapter(int na);
 int get_free_adapter(transponder *tp);
 int set_adapter_for_stream(int sid, int aid);
-void close_adapter_for_stream(int sid, int aid, int force);
+void close_adapter_for_stream(int sid, int aid, int stby);
 int set_adapter_parameters(int aid, int sid, transponder *tp);
 void mark_pids_deleted(int aid, int sid, char *pids);
 int mark_pids_add(int sid, int aid, char *pids);

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -119,7 +119,7 @@ adapter *adapter_alloc();
 int close_adapter(int na);
 int get_free_adapter(transponder *tp);
 int set_adapter_for_stream(int sid, int aid);
-void close_adapter_for_stream(int sid, int aid);
+void close_adapter_for_stream(int sid, int aid, int force);
 int set_adapter_parameters(int aid, int sid, transponder *tp);
 void mark_pids_deleted(int aid, int sid, char *pids);
 int mark_pids_add(int sid, int aid, char *pids);

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -496,6 +496,12 @@ void satip_close_device(adapter *ad)
 	satipc *sip = get_satip(ad->id);
 	if (!sip)
 		return;
+	if (ad->is_standby)
+	{
+		LOG("satip device %s:%d going to standby", sip->sip, sip->sport);
+		http_request(ad, NULL, "TEARDOWN");
+		return;
+	}
 	LOG("satip device %s:%d is closing", sip->sip, sip->sport);
 	http_request(ad, NULL, "TEARDOWN");
 	sip->session[0] = 0;

--- a/src/stream.c
+++ b/src/stream.c
@@ -272,10 +272,10 @@ int start_play(streams *sid, sockets *s)
 
 	if (compare_tunning_parameters(sid->adapter, &sid->tp)) // close the adapter that is required to be closed
 	{
-		restart_needed_adapters(sid->adapter, sid->sid, 0);
+		restart_needed_adapters(sid->adapter, sid->sid);
 		if (ad && !compare_slave_parameters(ad, &sid->tp))
 		{
-			close_adapter_for_stream(sid->sid, ad->id);
+			close_adapter_for_stream(sid->sid, ad->id, 0);
 		}
 		ad = get_adapter(sid->adapter);
 	}

--- a/src/stream.c
+++ b/src/stream.c
@@ -236,7 +236,7 @@ setup_stream(char *str, sockets *s)
 		int ad = sid->adapter;
 		if (!strstr(tmp_str, "addpids") && !strstr(tmp_str, "delpids"))
 		{
-			close_adapter_for_stream(sid->sid, ad);
+			close_adapter_for_stream(sid->sid, ad, 0);
 		}
 	}
 
@@ -272,7 +272,7 @@ int start_play(streams *sid, sockets *s)
 
 	if (compare_tunning_parameters(sid->adapter, &sid->tp)) // close the adapter that is required to be closed
 	{
-		restart_needed_adapters(sid->adapter, sid->sid);
+		restart_needed_adapters(sid->adapter, sid->sid, 0);
 		if (ad && !compare_slave_parameters(ad, &sid->tp))
 		{
 			close_adapter_for_stream(sid->sid, ad->id);
@@ -293,7 +293,7 @@ int start_play(streams *sid, sockets *s)
 		if (ad)
 		{
 			LOG("slave stream tuning to a new frequency, finding a new adapter");
-			close_adapter_for_stream(sid->sid, ad->id);
+			close_adapter_for_stream(sid->sid, ad->id, 0);
 		}
 		a_id = get_free_adapter(&sid->tp);
 		LOG("Got adapter %d on stream %d socket %d", a_id, sid->sid, s->id);
@@ -383,7 +383,7 @@ int close_stream(int i)
 	}
 
 	if (ad >= 0)
-		close_adapter_for_stream(i, ad);
+		close_adapter_for_stream(i, ad, 1);
 
 	sockets_del_for_sid(i);
 


### PR DESCRIPTION
This fixes the problem when a TEARDOWN is received from the SAT>IP client, and the tuner is a SAT>IP server. With this patch the SAT>IP server receives a TEARDOWN command when the tuner is released. Fixes the issue #655 .
 