### PR TITLE
WIP: SATIPC Fix delpids when closing

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -261,6 +261,7 @@ int init_hw(int i)
 	ad->fe_sock = -1;
 	ad->sock = -1;
 	ad->force_close = 0;
+	ad->is_closing = 0;
 	ad->restart_needed = 0;
 
 	if (opts.max_pids)
@@ -443,6 +444,7 @@ int close_adapter(int na)
 	//close all streams attached to this adapter
 	//	close_streams_for_adapter (na, -1);
 	mark_pids_deleted(na, -1, NULL);
+	ad->is_closing = 1;
 	update_pids(na);
 	//      if(ad->dmx>0)close(ad->dmx);
 	if (ad->fe > 0)

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -443,8 +443,8 @@ int close_adapter(int na)
 		ad->close(ad);
 	//close all streams attached to this adapter
 	//	close_streams_for_adapter (na, -1);
-	mark_pids_deleted(na, -1, NULL);
 	ad->is_closing = 1;
+	mark_pids_deleted(na, -1, NULL);
 	update_pids(na);
 	//      if(ad->dmx>0)close(ad->dmx);
 	if (ad->fe > 0)

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -54,6 +54,7 @@ typedef struct struct_adapter
 	int sock, fe_sock;
 	int do_tune;
 	int force_close;
+	int is_closing;
 	unsigned char *buf; // 7 rtp packets = MAX_PACK, 7 frames / packet
 	int64_t rtime;
 	int64_t last_sort;

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -828,7 +828,7 @@ int satipc_del_filters(adapter *ad, int fd, int pid)
 	int i;
 	satipc *sip = get_satip(ad->id);
 	fd -= 100;
-	if (ad->is_closing) // Before a TEARDOWN command is redundant to send a "delpids" !
+	if (ad && ad->is_closing) // Before a TEARDOWN command is redundant to send a "delpids" !
 	{
 		LOGM("satipc: del_pid for pid %d not commited before a TEARDOWN", pid);
 		return 0;


### PR DESCRIPTION
It resolves two problems:

1. Don't send irrelevant "delpids" when closing the adapter.
2. Don't send incorrect SETUP command when committing DELETE pids before the first connection of the SAT>IP client mode.

Supersedes PR #638 .