### PR TITLE
SATIPC/GENERAL: New sleep tuner mode (aka "Fix no TEARDOWN with satipc module v2")

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -821,6 +821,8 @@ void close_adapter_for_stream(int sid, int aid)
 		ad->master_sid = -1;
 		mark_pids_deleted(aid, -1, NULL);
 		init_dvb_parameters(&ad->tp);
+		if (ad->standby)
+			ad->standby(ad);
 #ifdef AXE
 		free_axe_input(ad);
 #endif

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -21,6 +21,7 @@ typedef int (*Adapter_commit)(void *ad);
 typedef int (*Open_device)(void *ad);
 typedef int (*Device_signal)(void *ad);
 typedef int (*Device_wakeup)(void *ad, int fd, int voltage);
+typedef int (*Device_standby)(void *ad);
 typedef int (*Tune)(int aid, transponder *tp);
 typedef uint8_t (*Dvb_delsys)(int aid, int fd,
 							  uint8_t *sys);
@@ -106,6 +107,7 @@ typedef struct struct_adapter
 	Dvb_delsys delsys;
 	Device_signal get_signal;
 	Device_wakeup wakeup;
+	Device_standby standby;
 	Adapter_commit post_init, close;
 } adapter;
 

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -499,7 +499,9 @@ void satip_close_device(adapter *ad)
 
 	LOG("satip device %s:%d is closing", sip->sip, sip->sport);
 	if (sip->sleep)
+	{
 		LOGM("satip device %s:%d sleeping, so not sending the TEARDOWN message", sip->sip, sip->sport);
+	}
 	else
 		http_request(ad, NULL, "TEARDOWN");
 	sip->sleep = 0;
@@ -526,7 +528,9 @@ void satip_standby_device(adapter *ad)
 
 	LOG("satip device %s:%d going to standby sleep", sip->sip, sip->sport);
 	if (sip->sleep)
+	{
 		LOGM("satip device %s:%d already sleeping in standby", sip->sip, sip->sport);
+	}
 	else
 		http_request(ad, NULL, "TEARDOWN");
 	sip->sleep = 1;


### PR DESCRIPTION
This patch implements a new optional adapter callback function named standby(). This function is called when the adapter doesn't have any stream clients running. This function is previous to the close() adapter. The expected behaviour is to put the tuner in a standby sleep for a fast restart in the future.

This new functionality is used in the satipc module. With the new functionality when the last client sends a TEARDOWN command, the module sends a TEARDOWN to the remote SAT>IP server, but it doesn't close the connection. Then any new tuning command from a SAT>IP client can be served instantly. In any case, when the timeout of the adapter is reached, then the adapter is closed definitively.

This PR supersedes #728.