### PR TITLE
ADAPTER: Limit adapters to specific sources (aka "Assign adapters to specific sources v3")

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ Help
 
 * -j --jess jess_string - same format as -u 
 
+* -U --sources sources_for_adapters: limit the adapters to specific sources/positions
+	* eg: -U 0-2:*:3:2,6,8 (no spaces between parameters)
+	- In this example: for SRC=1 only 0,1,2; for SRC=2 all; for SRC=3 only 3; and for SRC=4 the 2,6,8 adapters are used.
+	- For each position (separated by : ) you need to declare all the adapters that use this position with no exception.
+	- The special char * indicates all adapters for this position.
+	- The number of sources range from 1 to 64; but the list can include less than 64 (in this case all are enabled for undefined sources). 
+	- By default or in case of errors all adapters have enabled all positions.
+
 * -w --http-host http_server[:port]: specify the host and the port (if not 80) where the xml file can be downloaded from [default: default_local_ip_address:8080] 
 	* eg: -w 192.168.1.1:8080 
 

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -96,6 +96,15 @@ adapter *adapter_alloc()
 	ad->master_source = -1;
 	ad->diseqc_multi = opts.diseqc_multi;
 
+	/* enable all sources */
+	ad->debug_pos[0]='\0';
+	ad->debug_src = 0;
+	int i;
+	for (i = 0; i <= MAX_SOURCES; i++)
+	{
+		ad->sources_pos[i] = 1;
+	}
+
 	/* LOF setup */
 	ad->diseqc_param.lnb_low = opts.lnb_low;
 	ad->diseqc_param.lnb_high = opts.lnb_high;
@@ -502,6 +511,12 @@ int getAdaptersCount()
 	for (i = 0; i < MAX_ADAPTERS; i++)
 		if ((ad = a[i]))
 		{
+			// Note: Adapter 0 uses map bit 0, and source_map uses ranges from 0..SRC-1 (SRC=0 can't be configured)
+			for (j = 0; j < MAX_SOURCES; j++)
+			{
+				ad->sources_pos[j] = (source_map[j-1] >> i) & 1;
+			}
+
 			if (!opts.force_sadapter && (delsys_match(ad, SYS_DVBS) || delsys_match(ad, SYS_DVBS2)))
 			{
 				ts2++;
@@ -569,6 +584,34 @@ int getAdaptersCount()
 			}
 		}
 	}
+	char lsrc[256];
+	for (i = 0; i < MAX_ADAPTERS; i++)
+		if ((ad = a[i]))
+		{
+			ad->debug_pos[0]='\0';
+			ad->debug_src = 0;
+			lsrc[0] = '\0';
+			for (j = 1; j <= MAX_SOURCES; j++)
+			{
+				if (ad->sources_pos[j])
+				{
+					char usrc[8];
+					sprintf(usrc, ",%d", j);
+					strcat(lsrc, usrc);
+
+					strcat(ad->debug_pos, "X");
+					ad->debug_src += (unsigned long)1 << (j - 1);
+				}
+				else
+				{
+					strcat(ad->debug_pos, ".");
+				}
+			}
+			if (strlen(lsrc) > 0)
+				lsrc[0]=' ';
+			DEBUGM("Adpater %d enabled sources:%s", i, lsrc);
+			DEBUGM("Adpater %d debug sources: %s (%lu)", i, ad->debug_pos, ad->debug_src);
+		}
 	return tuner_s2 + tuner_c2 + tuner_t2 + tuner_c + tuner_t;
 }
 
@@ -581,10 +624,10 @@ void dump_adapters()
 	LOG("Dumping adapters:");
 	for (i = 0; i < MAX_ADAPTERS; i++)
 		if ((ad = get_adapter_nw(i)))
-			LOG("%d|f: %d sid_cnt:%d master_sid:%d master_source:%d del_sys: %s %s %s", i,
+			LOG("%d|f: %d sid_cnt:%d master_sid:%d master_source:%d del_sys: %s,%s,%s src_map: %s (%lu)", i,
 				ad->tp.freq, ad->sid_cnt, ad->master_sid, ad->master_source,
 				get_delsys(ad->sys[0]), get_delsys(ad->sys[1]),
-				get_delsys(ad->sys[2]));
+				get_delsys(ad->sys[2]), ad->debug_pos, ad->debug_src);
 	dump_streams();
 }
 
@@ -694,9 +737,9 @@ int get_free_adapter(transponder *tp)
 
 	if (ad)
 		LOG(
-			"get free adapter %d - a[%d] => e:%d m:%d sid_cnt:%d f:%d pol=%d sys: %s %s",
+			"get free adapter %d - a[%d] => e:%d m:%d sid_cnt:%d src:%d f:%d pol=%d sys: %s %s",
 			tp->fe, ad->id, ad->enabled, ad->master_sid, ad->sid_cnt,
-			ad->tp.freq, ad->tp.pol, get_delsys(ad->sys[0]),
+			ad->tp.diseqc, ad->tp.freq, ad->tp.pol, get_delsys(ad->sys[0]),
 			get_delsys(ad->sys[1]))
 	else
 		LOG("get free adapter %d msys %s requested %s", fe, get_delsys(fe),
@@ -711,31 +754,32 @@ int get_free_adapter(transponder *tp)
 				match = 1;
 			if (!ad->enabled || !compare_tunning_parameters(ad->id, tp))
 				match = 1;
-			if (match && !init_hw(fe))
+			if (match && ad->sources_pos[tp->diseqc] && !init_hw(fe))
 				return fe;
 		}
 		goto noadapter;
 	}
 	// provide an already existing adapter
 	for (i = 0; i < MAX_ADAPTERS; i++)
-		if ((ad = get_adapter_nw(i)) && delsys_match(ad, msys))
+		if ((ad = get_adapter_nw(i)) && delsys_match(ad, msys) && ad->sources_pos[tp->diseqc])
 			if (!compare_tunning_parameters(ad->id, tp))
 				return i;
 
 	for (i = 0; i < MAX_ADAPTERS; i++)
 	{
 		//first free adapter that has the same msys
-		if ((ad = get_adapter_nw(i)) && ad->sid_cnt == 0 && delsys_match(ad, msys) && !compare_slave_parameters(ad, tp))
+		if ((ad = get_adapter_nw(i)) && ad->sid_cnt == 0 && delsys_match(ad, msys) && !compare_slave_parameters(ad, tp) && ad->sources_pos[tp->diseqc])
 			return i;
 		if (!ad && delsys_match(a[i], msys) && !compare_slave_parameters(a[i], tp)) // device is not initialized
 		{
-			if (!init_hw(i))
+			ad = a[i];
+			if (ad->sources_pos[tp->diseqc] && !init_hw(i))
 				return i;
 		}
 	}
 
 noadapter:
-	LOG("no adapter found for f:%d pol:%d msys:%d", tp->freq, tp->pol, tp->sys);
+	LOG("no adapter found for src:%d f:%d pol:%d msys:%d", tp->diseqc, tp->freq, tp->pol, tp->sys);
 	dump_adapters();
 	return -1;
 }
@@ -1619,6 +1663,83 @@ void set_diseqc_adapters(char *o)
 			a_id, fast, addr, committed_no, uncommitted_no);
 	}
 }
+
+void set_sources_adapters(char *o)
+{
+	int i, la, lb, st, end, j, k, adap;
+	uint64_t all = 0xFFFFFFFFFFFFFFFF;
+	char buf[1024], *arg[128], *sep;
+	SAFE_STRCPY(buf, o);
+	la = split(arg, buf, ARRAY_SIZE(arg), ':');
+	if ((la == 1 && strlen(arg[0]) == 0) || la < 1 || la > MAX_SOURCES)
+		goto ERR;
+
+	LOG("Calculating adapter sources: [%s] ", o);
+	for (i = 0; i < MAX_SOURCES; i++)
+	{
+		if (i >= la)
+		{
+			LOGM(" src=%d undefined, using all", i + 1);
+			source_map[i] = all;
+			continue;
+		}
+
+		source_map[i] = 0;
+		if (arg[i] && arg[i][0] == '*')
+		{
+			if (strlen(arg[i]) != 1)
+				goto ERR;
+			source_map[i] = all;
+			char buf2[128];
+			buf2[0]='\0';
+			for (j = 0; j < MAX_ADAPTERS; j++)
+				strcat(buf2, "X");
+			LOGM(" src=%d using adapters %s (%lu)", i + 1, buf2, (unsigned long)source_map[i]);
+			continue;
+		}
+		char buf2[128], *arg2[128];
+		SAFE_STRCPY(buf2, arg[i]);
+		lb = split(arg2, buf2, ARRAY_SIZE(arg2), ',');
+		for (j = 0; j < lb; j++)
+		{
+			sep = strchr(arg2[j], '-');
+			if (sep == NULL)
+			{
+				adap = map_int(arg2[j], NULL);
+				if (adap < 0 || adap >= MAX_ADAPTERS)
+					goto ERR;
+				source_map[i] |= (unsigned long)1 << adap;
+			}
+			else
+			{
+				st = map_int(arg2[j], NULL);
+				end = map_int(sep + 1, NULL);
+				if (st < 0 || end < 0 || st >= MAX_ADAPTERS || end >= MAX_ADAPTERS || end < st)
+					goto ERR;
+				for (k = st; k <= end; k++)
+				{
+					adap = k;
+					source_map[i] |= (unsigned long)1 << adap;
+				}
+			}
+		}
+		buf2[0]='\0';
+		for (j = 0; j < MAX_ADAPTERS; j++)
+			if (source_map[i] & ((unsigned long)1 << j))
+				strcat(buf2, "X");
+			else
+				strcat(buf2, ".");
+		LOGM(" src=%d using adapters %s (%lu)", i + 1, buf2, (unsigned long)source_map[i]);
+	}
+	LOG("Adapter correct sources format parameter");
+	return;
+
+ERR:
+	for (i = 0; i < MAX_SOURCES; i++)
+		source_map[i] = all;
+	LOG("Adapter sources format parameter %s, using defaults for all adapters!", strlen(arg[0]) > 0 ? "incorrect" : "missing");
+}
+
 
 void set_diseqc_multi(char *o)
 {

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -6,6 +6,7 @@
 typedef struct ca_device ca_device_t;
 
 #define MAX_ADAPTERS 32
+#define MAX_SOURCES 64
 #define DVR_BUFFER 30 * 1024 * 188
 
 #define ADAPTER_BUFFER 384 * DVB_FRAME // 128 * 3 > 65535
@@ -71,6 +72,9 @@ typedef struct struct_adapter
 	uint32_t pid_err, dec_err;				   // detect pids received but not part of any stream, decrypt errors
 	diseqc diseqc_param;
 	int diseqc_multi;
+	int sources_pos[MAX_SOURCES + 1]; // includes SRC=0 used internally only
+	char debug_pos[MAX_SOURCES + 1];
+	uint64_t debug_src;
 	int old_diseqc;
 	int old_hiband;
 	int old_pol;
@@ -110,6 +114,7 @@ typedef struct struct_adapter
 } adapter;
 
 extern adapter *a[MAX_ADAPTERS];
+uint64_t source_map[MAX_SOURCES];
 extern int a_count;
 extern char do_dump_pids;
 
@@ -137,6 +142,7 @@ void dump_pids(int aid);
 void sort_pids(int aid);
 void enable_adapters(char *o);
 void set_unicable_adapters(char *o, int type);
+void set_sources_adapters(char *o);
 void set_diseqc_adapters(char *o);
 void set_diseqc_timing(char *o);
 void set_diseqc_multi(char *o);

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -536,7 +536,7 @@ void set_options(int argc, char *argv[])
 {
 	int opt;
 	int is_log = 0;
-    int adapter_sources = 0;
+	int adapter_sources = 0;
 	char *lip;
 	memset(&opts, 0, sizeof(opts));
 	opts.log = 1;

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -87,6 +87,7 @@ int rtsp, http, si, si1, ssdp1;
 #define ENABLE_ADAPTERS_OPT 'e'
 #define UNICABLE_OPT 'u'
 #define JESS_OPT 'j'
+#define SOURCES_OPT 'U'
 #define DISEQC_OPT 'd'
 #define DISEQC_TIMING_OPT 'q'
 #define SLAVE_OPT 'S'
@@ -136,6 +137,7 @@ static const struct option long_options[] =
 		{"enable-adapters", required_argument, NULL, 'e'},
 		{"unicable", required_argument, NULL, 'u'},
 		{"jess", required_argument, NULL, 'j'},
+		{"sources", required_argument, NULL, 'U'},
 		{"diseqc", required_argument, NULL, 'd'},
 		{"diseqc-timing", required_argument, NULL, 'q'},
 		{"diseqc-multi", required_argument, NULL, DISEQC_MULTI},
@@ -460,6 +462,14 @@ Help\n\
 \n\
 * -j --jess jess_string - same format as -u \n\
 \n\
+* -U --sources sources_for_adapters: limit the adapters to specific sources/positions\n\
+	* eg: -U 0-2:*:3:2,6,8 (no spaces between parameters)\n\
+	- In this example: for SRC=1 only 0,1,2; for SRC=2 all: for SRC=3 only 3; and for SRC=4 the 2,6,8 adapters are used.\n\
+	- For each position (separated by : ) you need to declare all the adapters that use this position with no exception.\n\
+	- The special char * indicates all adapters for this position.\n\
+	- The number of sources range from 1 to 64; but the list can include less than 64 (in this case all are enabled for undefined sources).\n\
+	- By default or in case of errors all adapters have enabled all positions.\n\
+\n\
 * -w --http-host http_server[:port]: specify the host and the port (if not 80) where the xml file can be downloaded from [default: default_local_ip_address:8080] \n\
 	* eg: -w 192.168.1.1:8080 \n\
 \n\
@@ -526,6 +536,7 @@ void set_options(int argc, char *argv[])
 {
 	int opt;
 	int is_log = 0;
+    int adapter_sources = 0;
 	char *lip;
 	memset(&opts, 0, sizeof(opts));
 	opts.log = 1;
@@ -599,7 +610,7 @@ void set_options(int argc, char *argv[])
 
 #endif
 
-	while ((opt = getopt_long(argc, argv, "fl:v:r:a:td:w:p:s:n:hB:b:H:m:p:e:x:u:j:o:gy:i:q:D:NGVR:S:TX:Y:OL:EP:Z:0:F:M:1:2:3:C:4" AXE_OPTS, long_options, NULL)) != -1)
+	while ((opt = getopt_long(argc, argv, "fl:v:r:a:td:w:p:s:n:hB:b:H:m:p:e:x:u:j:U:o:gy:i:q:D:NGVR:S:TX:Y:OL:EP:Z:0:F:M:1:2:3:C:4" AXE_OPTS, long_options, NULL)) != -1)
 	{
 		//              printf("options %d %c %s\n",opt,opt,optarg);
 		switch (opt)
@@ -810,6 +821,13 @@ void set_options(int argc, char *argv[])
 		case DISEQC_OPT:
 		{
 			set_diseqc_adapters(optarg);
+			break;
+		}
+
+		case SOURCES_OPT:
+		{
+			adapter_sources = 1;
+			set_sources_adapters(optarg);
 			break;
 		}
 
@@ -1031,6 +1049,8 @@ void set_options(int argc, char *argv[])
 	}
 	if (!is_log)
 		opts.log = 0;
+	if (!adapter_sources)
+		set_sources_adapters("");
 
 	// FBC setup
 	if (!access("/proc/stb/frontend/0/fbc_connect", W_OK))


### PR DESCRIPTION
This patch adds a new parameter (-U) to limit specific sources to some adapters.

It supersedes previous catalinii#623 with these changes:

- More robust functionality.
- Increased total number of sources to 64.
- The list of the sources parameter can be less than the MAX_SOURCES.
- Improved debug to identify troubles.