### PR TITLE
SATIPC: Check to don't send a TEARDOWN without stream parameter

### DIFF
--- a/src/satipc.c
+++ b/src/satipc.c
@@ -1040,6 +1040,11 @@ int http_request(adapter *ad, char *url, char *method)
 
 	if (sip->stream_id != -1)
 		sprintf(sid, "stream=%d", sip->stream_id);
+	else if (!strcmp(method, "TEARDOWN"))
+	{
+		LOG("satipc_http_request (adapter %d): impossible to send TEARDOWN without specific stream!", ad->id);
+		return 0;
+	}
 
 	lb = snprintf(buf, sizeof(buf), format, method, sip->sip, sip->sport, sid,
 				  qm, url, sip->cseq++, session);


### PR DESCRIPTION
In some very specific cases, for example when the SAT>IP server doesn't send any RTP data, the device can be closed without a valid stream id. In this case, it's not required to send the TEARDOWN message. Futhermore, some SAT>IP servers have toubles when receiving a TEARDOWN message without the stream parameter, what actually is a break of the specifications (the TEARDOWN command **requires** the "/stream=" part in the URI).

This patch fixes this problem.