### PR TITLE
WEBIF: Provide VLC stream URL as LINK

### DIFF
--- a/html/status.html
+++ b/html/status.html
@@ -276,9 +276,11 @@
 						// Create VLC stream URL
 						// Example: rtsp://@satip/?src=1&freq=12382&pol=H&msys=DVBS2&sr=27500&pids=0,5375,5378,116,5375,32
 						var hostArray = window.location.host.split(':');
-						myTable += "<small>rtsp://@" + hostArray[0]  + "/?src=" + state['ad_pos'][i] + "&freq=" + state['ad_freq'][i] 
-+ "&pol=" + pol[state['ad_pol'][i]].replace('(', '').replace(')', '') + "&msys=" + sys[state['ad_sys'][i]].toUpperCase() + "&sr=" + state['ad_sr'][i] + "&pids="  + st_p + "</small><br />";
-						
+						myTable += "<small><a href=" + '"' + "rtsp://@" + state['rtsp_host'] + "/?src=" + state['ad_pos'][i] + "&freq=" + state['ad_freq'][i]
++ "&pol=" + pol[state['ad_pol'][i]].replace('(', '').replace(')', '') + "&msys=" + sys[state['ad_sys'][i]].toUpperCase() + "&sr=" + state['ad_sr'][i] + "&pids="  + st_p + '"' + ">RTSP Link</a></small><br />";
+						myTable += "<small><a href=" + '"' + "http://" + hostArray[0] + ":" + hostArray[1] + "/?src=" + state['ad_pos'][i] + "&freq=" + state['ad_freq'][i]
++ "&pol=" + pol[state['ad_pol'][i]].replace('(', '').replace(')', '') + "&msys=" + sys[state['ad_sys'][i]].toUpperCase() + "&sr=" + state['ad_sr'][i] + "&pids="  + st_p + '"' + ">HTTP Link</a></small><br />";
+
 						if (state['st_overflow'][j] > 0)
 							myTable += "<small>Dropped: " + (state['st_overflow'][j]/1048576.0).toFixed(2) + " MB</small><br />";
 						if (state['st_buffered'][j] > 0)


### PR DESCRIPTION
With this patch you can copy&paste the URL links directly to VLC or any other tool that can handle the MPEG2-TS streaming.