### PR TITLE
LOG improvement v3 (aka "Improve logs of the HTTP module v3")

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -221,7 +221,7 @@ int close_adapter_for_socket(sockets *s)
 {
 	int aid = s->sid;
 	adapter *ad = get_adapter(aid);
-	LOG("closing DVR socket %d pos %d aid %d", s->sock, s->id, aid);
+	LOG("closing DVR socket sock %d (handle %d) adapter %d", s->sock, s->id, aid);
 	if (ad && (s->sid == ad->sock))
 	{
 		ad->sock = -1;

--- a/src/csa.c
+++ b/src/csa.c
@@ -47,6 +47,8 @@
 #include "pmt.h"
 #include <dvbcsa/dvbcsa.h>
 
+#define DEFAULT_LOG LOG_DVBCA
+
 void dvbcsa_create_key(SCW *cw)
 {
 	cw->key = dvbcsa_bs_key_alloc();

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -401,13 +401,14 @@ int satipc_open_device(adapter *ad)
 	if ((sip->last_connect > 0) && (ctime - sip->last_connect < 5000))
 		return 3;
 
+	USockAddr sv;
 	sip->last_connect = ctime;
-	ad->fe = tcp_connect_src(sip->sip, sip->sport, NULL, 1, sip->source_ip[0] ? sip->source_ip : NULL); // blocking socket
+	ad->fe = tcp_connect_src(sip->sip, sip->sport, &sv, 1, sip->source_ip[0] ? sip->source_ip : NULL); // blocking socket
 	if (ad->fe < 0)
 		LOG_AND_RETURN(2, "could not connect to %s:%d", sip->sip, sip->sport);
 
-	LOG("satipc: connected to SAT>IP server %s port %d %s handle %d %s %s", sip->sip,
-		sip->sport, sip->use_tcp ? "[RTSP OVER TCP]" : "", ad->fe, sip->source_ip[0] ? "from source" : "", sip->source_ip[0] ? sip->source_ip : "");
+	LOG("satipc: connected to SAT>IP server %s port %d%s (socket handle %d) %s %s", sip->sip,
+		sip->sport, sip->use_tcp ? " [RTSP OVER TCP]" : "", ad->fe, sip->source_ip[0] ? "from source" : "", sip->source_ip[0] ? sip->source_ip : "");
 
 	sip->init_use_tcp = sip->use_tcp;
 	if (!sip->init_use_tcp)
@@ -421,12 +422,12 @@ int satipc_open_device(adapter *ad)
 		if (sip->rtcp < 0)
 			LOG("Could not listen on port %d: err %d: %s", sip->listen_rtp + 1, errno, strerror(errno));
 
-		ad->fe_sock = sockets_add(ad->fe, NULL, ad->id, TYPE_TCP,
+		ad->fe_sock = sockets_add(ad->fe, &sv, ad->id, TYPE_TCP,
 								  (socket_action)satipc_reply, (socket_action)satipc_close,
 								  (socket_action)satipc_timeout);
 		sip->rtcp_sock = -1;
 		if (sip->rtcp >= 0)
-			sip->rtcp_sock = sockets_add(sip->rtcp, NULL, ad->id, TYPE_TCP,
+			sip->rtcp_sock = sockets_add(sip->rtcp, &sv, ad->id, TYPE_TCP,
 										 (socket_action)satipc_rtcp_reply, (socket_action)satipc_close,
 										 NULL);
 		sockets_timeout(ad->fe_sock, 25000); // 25s
@@ -451,7 +452,7 @@ int satipc_open_device(adapter *ad)
 	{
 		ad->dvr = ad->fe;
 		ad->fe = -1;
-		ad->fe_sock = sockets_add(SOCK_TIMEOUT, NULL, ad->id, TYPE_UDP,
+		ad->fe_sock = sockets_add(SOCK_TIMEOUT, &sv, ad->id, TYPE_UDP,
 								  NULL, NULL, (socket_action)satipc_timeout);
 		sockets_timeout(ad->fe_sock, 25000); // 25s
 	}

--- a/src/utils.h
+++ b/src/utils.h
@@ -112,7 +112,7 @@ void myfree(void *x, char *f, int l);
 char *header_parameter(char **arg, int i);
 char *get_current_timestamp();
 char *get_current_timestamp_log();
-void _log(char *file, int line, char *fmt, ...);
+void _log(char *file, int line, unsigned long level, char *fmt, ...);
 char *strip(char *s);
 int split(char **rv, char *s, int lrv, char sep);
 void set_signal_handler(char *argv0);
@@ -177,17 +177,22 @@ static inline int get_index_hash(void *p, int max, int struct_size, uint32_t key
 #define LOGL(level, a, ...)                             \
 	{                                                   \
 		if ((level)&opts.log)                           \
-			_log(__FILE__, __LINE__, a, ##__VA_ARGS__); \
+			_log(__FILE__, __LINE__, level, a, ##__VA_ARGS__); \
 	}
-
+#define LOG(a, ...)                                     \
+	{                                                   \
+			_log(__FILE__, __LINE__, DEFAULT_LOG, a, ##__VA_ARGS__); \
+	}
+#define LOGG(level, a, ...)                                     \
+	{                                                   \
+			_log(__FILE__, __LINE__, level, a, ##__VA_ARGS__); \
+	}
 #define LOGM(a, ...) LOGL(DEFAULT_LOG, a, ##__VA_ARGS__)
-
-#define LOG(a, ...) LOGL(1, a, ##__VA_ARGS__)
 
 #define DEBUGL(level, a, ...)                           \
 	{                                                   \
 		if ((level)&opts.debug)                         \
-			_log(__FILE__, __LINE__, a, ##__VA_ARGS__); \
+			_log(__FILE__, __LINE__, level, a, ##__VA_ARGS__); \
 	}
 #define DEBUGM(a, ...) DEBUGL(DEFAULT_LOG, a, ##__VA_ARGS__)
 
@@ -200,7 +205,7 @@ static inline int get_index_hash(void *p, int max, int struct_size, uint32_t key
 
 #define LOG0(a, ...)                                \
 	{                                               \
-		_log(__FILE__, __LINE__, a, ##__VA_ARGS__); \
+		_log(__FILE__, __LINE__, 0, a, ##__VA_ARGS__); \
 	}
 
 #define FAIL(a, ...)               \
@@ -251,24 +256,25 @@ static inline int get_index_hash(void *p, int max, int struct_size, uint32_t key
 			LOG("%-40s OK", #a);                                 \
 	}
 
-#define LOG_GENERAL 1
-#define LOG_HTTP (1 << 1)
-#define LOG_SOCKETWORKS (1 << 2)
-#define LOG_STREAM (1 << 3)
-#define LOG_ADAPTER (1 << 4)
-#define LOG_SATIPC (1 << 5)
-#define LOG_PMT (1 << 6)
-#define LOG_TABLES (1 << 7)
-#define LOG_DVBAPI (1 << 8)
-#define LOG_LOCK (1 << 9)
-#define LOG_NETCEIVER (1 << 10)
-#define LOG_DVBCA (1 << 11)
-#define LOG_AXE (1 << 12)
-#define LOG_SOCKET (1 << 13)
-#define LOG_UTILS (1 << 14)
-#define LOG_DMX (1 << 15)
-#define LOG_SSDP (1 << 16)
-#define LOG_DVB (1 << 17)
+#define LOG_GENERAL 1UL
+#define LOG_HTTP (1UL << 1)
+#define LOG_SOCKETWORKS (1UL << 2)
+#define LOG_STREAM (1UL << 3)
+#define LOG_ADAPTER (1UL << 4)
+#define LOG_SATIPC (1UL << 5)
+#define LOG_PMT (1UL << 6)
+#define LOG_TABLES (1UL << 7)
+#define LOG_DVBAPI (1UL << 8)
+#define LOG_LOCK (1UL << 9)
+#define LOG_NETCEIVER (1UL << 10)
+#define LOG_DVBCA (1UL << 11)
+#define LOG_AXE (1UL << 12)
+#define LOG_SOCKET (1UL << 13)
+#define LOG_UTILS (1UL << 14)
+#define LOG_DMX (1UL << 15)
+#define LOG_SSDP (1UL << 16)
+#define LOG_DVB (1UL << 17)
+#define LOG_RTSP (1UL << 18)
 
 typedef ssize_t (*mywritev)(int fd, const struct iovec *io, int len);
 
@@ -283,7 +289,7 @@ typedef ssize_t (*mywritev)(int fd, const struct iovec *io, int len);
 
 #ifdef UTILS_C
 char *loglevels[] =
-	{"general", "http", "socketworks", "stream", "adapter", "satipc", "pmt", "tables", "dvbapi", "lock", "netceiver", "ca", "axe", "socket", "utils", "dmx", "ssdp", "dvb", NULL};
+	{"general", "http", "socketworks", "stream", "adapter", "satipc", "pmt", "tables", "dvbapi", "lock", "netceiver", "ca", "axe", "socket", "utils", "dmx", "ssdp", "dvb", "rtsp", NULL};
 mywritev _writev = writev;
 #else
 extern char *loglevels[];


### PR DESCRIPTION
This patch improves the LOG part in some areas:

- Fixes a bug with some module names ("socketworks" can't be selected because is a substring of "socket").
- Fixes the unkown IP of the SAT>IP servers.
- Prints the name the of the module in each debug line.
- Prints the enabled module debug level of selected modules.
- Disambiguation of HTTP/RTSP protocols.
- Enhacement of some socket messages with incorrect values.
- Other minor changes.