### PR TITLE
Support for reporting the closing of the socket

### DIFF
--- a/src/socketworks.h
+++ b/src/socketworks.h
@@ -106,6 +106,7 @@ void free_pack(SNPacket *p);
 void sockets_setread(int i, void *r);
 void set_socket_send_buffer(int sock, int len);
 void set_socket_receive_buffer(int sock, int len);
+void set_socket_disconnect_flag(int sock);
 void set_socket_pos(int sock, int pos);
 void set_sock_lock(int i, SMutex *m);
 void set_socket_thread(int s_id, pthread_t tid);


### PR DESCRIPTION
In the loop of sockets activity a new check is added for reporting to the adapter that the socket is closed.

This new functionality is based on this:
- The report is done calling to the function `action()` with a negative `rlen` size.
- This call is only done if the adapter understand this new semantic.
- To enable this new semantic for a socket it's required to use the new function `set_socket_disconnect_flag()`.
- When reporting the close when returning from `action()` the return value indicates: >=0 --> OK; <0 --> ERROR.
- When responding with error, the general behaviour is executed. When responding with ok, the loop continues.

The new behavioiur can be used to trigger some action in the adapter when this case is detected. In general, if the adapter catch this action, then the adapter will not be closed when the sockets is closed.