### PR TITLE
Fix declaration and definition of global variables

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -62,6 +62,7 @@ int a_count;
 char disabled[MAX_ADAPTERS]; // disabled adapters
 int sock_signal;
 char do_dump_pids = 1;
+uint64_t source_map[MAX_SOURCES];
 
 SMutex a_mutex;
 

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -116,7 +116,7 @@ typedef struct struct_adapter
 } adapter;
 
 extern adapter *a[MAX_ADAPTERS];
-uint64_t source_map[MAX_SOURCES];
+extern uint64_t source_map[MAX_SOURCES];
 extern int a_count;
 extern char do_dump_pids;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -63,6 +63,8 @@
 int MAX_SINFO;
 char pn[256];
 
+Shttp_client *httpc[MAX_HTTPC];
+
 typedef struct tmpinfo
 {
 	unsigned char enabled;

--- a/src/utils.h
+++ b/src/utils.h
@@ -88,7 +88,8 @@ typedef struct struct_http_client
 
 #define get_httpc(i) ((i >= 0 && i < MAX_HTTPC && httpc[i] && httpc[i]->enabled) ? httpc[i] : NULL)
 
-Shttp_client *httpc[MAX_HTTPC];
+extern Shttp_client *httpc[MAX_HTTPC];
+
 int http_client(char *url, char *request, void *callback, void *opaque);
 
 unsigned char *getItem(uint32_t key);


### PR DESCRIPTION
Definition of global variable httpc now in utils.c with declaration in utils.h.
Definition of global variable source_map now in adapter.c with declaration in adapter.h.
This fixes multiple defined symbol linking errors in Fedora 32 with gcc version 10.1.1 20200507 (Red Hat 10.1.1-1) (GCC)