### PR TITLE
Disable continuity counter checks when AXE is defined

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -995,6 +995,9 @@ int process_dmx(sockets *s)
 #endif
 
 	rlen = ad->rlen;
+#ifndef AXE
+	check_cc(ad);
+#endif
 
 	for (i = 0; i < MAX_STREAMS; i++)
 		if (st[i] && st[i]->enabled && st[i]->adapter == ad->id)

--- a/src/stream.c
+++ b/src/stream.c
@@ -995,7 +995,6 @@ int process_dmx(sockets *s)
 #endif
 
 	rlen = ad->rlen;
-	check_cc(ad);
 
 	for (i = 0; i < MAX_STREAMS; i++)
 		if (st[i] && st[i]->enabled && st[i]->adapter == ad->id)


### PR DESCRIPTION
@perexg has forever carried a patch that removes this call to `check_cc` (see https://github.com/perexg/minisatip/commit/26343094ef3907b131bd9b71361a290939ad5f45). That particular patch is the last one that hasn't already been merged upstream.

AFAICT axe has it's own way to check for continuity counter errors (https://github.com/catalinii/minisatip/blob/master/src/axe.c#L1047), so skipping this call when AXE is defined should have no real side effects for anyone.

This came up in https://github.com/perexg/satip-axe/issues/167