### PR TITLE
Emulated pids all: Include a fixed pid list

### DIFF
--- a/src/minisatip.h
+++ b/src/minisatip.h
@@ -11,6 +11,8 @@
 #define VERSION "1.0-unknown"
 #endif
 
+#define EMU_PIDS_ALL_ENFORCED_PIDS_LIST 1,16,17,18,20,21
+
 void set_options(int argc, char *argv[]);
 
 extern char pid_file[];

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -1904,6 +1904,17 @@ void emulate_add_all_pids(adapter *ad)
 							pids[pmts[j]->stream_pid[k].pid] = 1;
 							updated = 1;
 						}
+
+			int forced_pids[] = {EMU_PIDS_ALL_ENFORCED_PIDS_LIST};
+			int i_forced = sizeof(forced_pids);
+			for (j = 0; j < i_forced; j++)
+			{
+				int fpid = forced_pids[j];
+				LOG("%s: adding (enforced) pid %d to emulate all pids", __FUNCTION__, fpid);
+				mark_pid_add(p_all->sid[i], ad->id, fpid);
+				updated = 1;
+			}
+
 		}
 	if (updated)
 		update_pids(ad->id);


### PR DESCRIPTION
When using the emulated-pids-all mode, include a list of fixed missing pids related to standard DVB tables. Without these pids the output is not DVB conformant and some pids aren't included in the output stream. The list doesn't include the NULL pid (8191).