### PR TITLE
Enhanced drop of non-decrypted packets

### DIFF
--- a/src/pmt.c
+++ b/src/pmt.c
@@ -104,7 +104,10 @@ static inline void mark_pid_null(uint8_t *b) {
 
 static inline void mark_pcr_only(uint8_t *b) { // Generate a clean packet with only the Adaptation field header and no payload
     if ((b[3] & 0x10) == 0) // No payload
-        return; 
+    {
+       mark_pid_null(b); 
+       return; 
+    }
 
     // Convert the Payload Data in Adaptation Stuffing
     int i;

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -950,7 +950,7 @@ void mark_pids_null(adapter *ad) {
     for (i = 0; i < ad->rlen; i += DVB_FRAME) {
         uint8_t *b = ad->buf + i;
         int pid = PID_FROM_TS(b);
-        if (pid == 0x1FFF && ad->drop_encrypted) // When no drop encrypted content pass NULLs too!
+        if (pid == 0x1FFF)
             continue;
         if ((b[3] & 0x80) == 0x80) {
             if (opts.debug & (DEFAULT_LOG | LOG_DMX))

--- a/src/stream.c
+++ b/src/stream.c
@@ -1040,7 +1040,8 @@ int read_dmx(sockets *s) {
     if (rtime - ad->rtime > threshold)
         send = 1;
 
-    if (rtime - ad->rtime > 4 * threshold)
+    // No wait more than the PCR interval (around 40ms for DVB)
+    if ((rtime - ad->rtime > 40) || (rtime - ad->rtime > 4 * threshold))
         force_send = 1;
 
     if (s->lbuf - s->rlen <= 7 * DVB_FRAME)


### PR DESCRIPTION
When a packet can't be decrypted (and the drop encrypted packets is enabled) instead of filter out all encrypted packets do a more smart strategy. The implemented strategy consists of passing only packets with PCR time stamps. The passed PCR packets will don't have any payload data, so only the TS header is preserved. This will be more friendly for decoders that require the PCR marks. Futhermore the client will continue receiving packets, and then the stream can be considered active. Without this patch when a decoding disruption is a bit long several clients will close the session if it is not repaired in a short time.

In addition a second fix limits the wait time in the output buffer to resolve troubles when packets with PCR timestamps are not sended. This is necessary to flush the PCR packets when a temporary interruption of decoding happens.