### PR TITLE
Fix pids=all filtering encypted packets

### DIFF
--- a/src/pmt.c
+++ b/src/pmt.c
@@ -914,10 +914,17 @@ int pmt_decrypt_stream(adapter *ad) {
 
 void mark_pids_null(adapter *ad) {
     int i;
+    int pids_all = 0;
+
+    if (ad->drop_encrypted) { // Check (one time) if pids=all is activated
+        SPid *p = find_pid(ad->id, 8192);
+        if (p)
+            pids_all = 1;
+    }
     for (i = 0; i < ad->rlen; i += DVB_FRAME) {
         uint8_t *b = ad->buf + i;
         int pid = PID_FROM_TS(b);
-        if (pid == 0x1FFF)
+        if (pid == 0x1FFF || pids_all) // When pids=all don't drop encrypted packets
             continue;
         if ((b[3] & 0x80) == 0x80) {
             if (opts.debug & (DEFAULT_LOG | LOG_DMX))


### PR DESCRIPTION
When "pids=all" is running, then instead of filter out ALL encrypted packets you need to pass them. Without this patch, when not using the `-E` parameter (disabled by default) you receive all encrypted packets converted to NULL stuff. This modification solves this problem, and when you request the full transport stream (pids=all) then encrypted packets will pass untouched.