### PR TITLE
Fix typo in usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Help
 
 * -A --disable-ssdp disable SSDP announcement
  
-* -b --buffers X:Y : set the app adapter buffer to X Bytes (default: 376000) and set the kernel DVB buffer to Y Bytes (default: 5775360) - both multiple of 188
+* -b --buffer X:Y : set the app adapter buffer to X Bytes (default: 376000) and set the kernel DVB buffer to Y Bytes (default: 5775360) - both multiple of 188
 	* eg: -b 18800:18988
 
 * -B X : set the app socket write buffer to X KB. 

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -303,7 +303,7 @@ Help\n\
 \n\
 * -G --disable-ssdp disable SSDP announcement\n \
 \n\
-* -b --buffers X:Y : set the app adapter buffer to X Bytes (default: %d) and set the kernel DVB buffer to Y Bytes (default: %d) - both multiple of 188\n\
+* -b --buffer X:Y : set the app adapter buffer to X Bytes (default: %d) and set the kernel DVB buffer to Y Bytes (default: %d) - both multiple of 188\n\
 	* eg: -b 18800:18988\n\
 \n\
 * -B X : set the app socket write buffer to X KB. \n\


### PR DESCRIPTION
The long option is called `--buffer` and not `--buffers`. See https://github.com/catalinii/minisatip/blob/ab5a33539581b9c8972c81f700525e053be3c16d/src/minisatip.c#L128