### PR TITLE
New PIDS_ALL emulation with NULLs

### DIFF
--- a/src/minisatip.h
+++ b/src/minisatip.h
@@ -12,7 +12,6 @@
 #endif
 
 #define EMU_PIDS_ALL_ENFORCED_PIDS_LIST 1, 16, 17, 18, 20, 21
-#define EMU_PIDS_ALL_ENFORCED_WITH_NULL 1, 16, 17, 18, 20, 21, 8191
 
 void set_options(int argc, char *argv[]);
 

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -1952,16 +1952,18 @@ void emulate_add_all_pids(adapter *ad) {
                         }
 
             int *forced_pids;
-            int list_plain[]     = {EMU_PIDS_ALL_ENFORCED_PIDS_LIST};
-            int list_with_null[] = {EMU_PIDS_ALL_ENFORCED_WITH_NULL};
-            forced_pids = (ad->drop_encrypted) ? list_plain : list_with_null;
-            int i_forced = sizeof(forced_pids) / sizeof(int);
+            int forced_pids[] = {EMU_PIDS_ALL_ENFORCED_PIDS_LIST};
             for (j = 0; j < i_forced; j++) {
                 int fpid = forced_pids[j];
                 LOG("%s: adding (enforced) pid %d to emulate all pids",
                     __FUNCTION__, fpid);
                 mark_pid_add(p_all->sid[i], ad->id, fpid);
                 updated = 1;
+            }
+            if (!ad->drop_encrypted) {
+                LOG("%s: adding (enforced) pid 8191 (NULL) too",
+                    __FUNCTION__);
+                mark_pid_add(p_all->sid[i], ad->id, 8191);
             }
         }
     if (updated)


### PR DESCRIPTION
Instead of using two list, this code now adds the NULL (8191) pid when it's necessary.

This partially rollbacks the PR #820. The problem is created with some compilers that doesn't calculate the sizeof of the pointer when assigned an array. This new implementation is more simple.
