### PR TITLE
Flush output in some necessary cases

### DIFF
--- a/src/pmt.c
+++ b/src/pmt.c
@@ -967,7 +967,7 @@ void mark_pids_null(adapter *ad) {
                 if (get_has_pcr(b)) // It has PCR
                 {
                     mark_pcr_only(b);
-                    ad->flush = 1;
+                    // ad->flush = 1; // Not necessary as process_packets_for_stream() flush all packets.
                 }
                 else
                     mark_pid_null(b);

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -965,7 +965,10 @@ void mark_pids_null(adapter *ad) {
             {
                 // Instead of remove ALL packets, when the packet has a PCR remove all payload and pass it
                 if (get_has_pcr(b)) // It has PCR
+                {
                     mark_pcr_only(b);
+                    ad->flush = 1;
+                }
                 else
                     mark_pid_null(b);
             }

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -684,6 +684,14 @@ int satipc_read(int socket, void *buf, int len, sockets *ss, int *rb) {
 
     size_msg -= (num_msg - rr) * 1316;  // update the theoretical total size of the read buffer
 
+    // It checks if the read is full, because in that case there is a high
+    // probability that there are still pending packets in the buffer, so then
+    // the output buffer will be flushed to avoid waiting at the next read.
+    if (num_msg > 1 && rr == num_msg) {
+        DEBUGM("satipc_read: read full, so flushing output");
+        ad->flush = 1;
+    }
+
     // Loop over all datagrams received
     ad = get_adapter(ss->sid);
     uint8_t *bf1 = buf1;


### PR DESCRIPTION
This patch incorporates these to enhancements:

- SATIPC: When the reading of the incoming RTP packets is full, then it will be a high probability that there are still pending packets in the buffer. To improve the efficiency, flush the output buffer. This increases the performance. So not needed an aggressive `-H 1:1` command line option.
- PMT: When converting undecrypted packets to PCR only packets, it's mandatory to flush the output to send the corresponding TS packet with the PCR mark at time, without waiting to pack them with next packets. Without this, the player can receive inconsistent PCR timestamps joined.
