### PR TITLE
add support for binding to an address and/or an interface

### DIFF
--- a/src/minisatip.h
+++ b/src/minisatip.h
@@ -56,6 +56,8 @@ struct struct_opts {
     char *name_app;
     char *http_host; // http-server host
     char *rtsp_host; // rtsp-server host
+    char *bind; // bind address
+    char *bind_dev; // bind device
     char *datetime_compile;
     time_t start_time;
     char *datetime_start;


### PR DESCRIPTION
-V --bind address: address for listening (all services)
-J --bind-dev device: device name for binding (all services)
 beware that only works with 1 device. loopback may not work!

Please notice that binding the interface is especially useful in multihomed setups.