### PR TITLE
Added delay for starting service

### DIFF
--- a/tools/autostart.readme
+++ b/tools/autostart.readme
@@ -36,6 +36,7 @@ After=network-online.target
 #Group=minisatip
 WorkingDirectory=/var/lib/minisatip
 Type=simple
+ExecStartPre=/usr/bin/sleep 30
 EnvironmentFile=-/etc/minisatip.conf
 ExecStart=/usr/bin/minisatip -f $SERVER_ARGS
 


### PR DESCRIPTION
I needed this delay for the new Sundtek SkyTV Dual 2x (DVB-S/S2/S2X) tuner. It seems that the drivers starts pretty late.