### PR TITLE
remove dead code

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -224,7 +224,7 @@ streams *setup_stream(char *str, sockets *s) {
 
     if (sid->adapter >= 0 &&
         !strncasecmp((const char *)s->buf, "SETUP", 5)) // SETUP after PLAY
-    {Variable 'num_enabled_pids' is modified but its new value is never used.
+    {
         int ad = sid->adapter;
         if (!strstr(tmp_str, "addpids") && !strstr(tmp_str, "delpids")) {
             close_adapter_for_stream(sid->sid, ad, 0);
@@ -862,7 +862,7 @@ int check_cc(adapter *ad) {
     return packet_no_sid;
 }
 
-int process_packets_for_stream(streams *sid, adapter *ad) {Variable 'num_enabled_pids' is modified but its new value is never used.
+int process_packets_for_stream(streams *sid, adapter *ad) {
     int i, j, st_id = sid->sid;
     SPid *p;
     uint8_t *b;

--- a/src/stream.c
+++ b/src/stream.c
@@ -872,7 +872,6 @@ int process_packets_for_stream(streams *sid, adapter *ad) {
     char rtp_buf[16 * (max_iov + 1)];
     int rtp_pos = 0;
     int iiov = 1;
-    int num_enabled_pids = 0;
     int last_rtp_header = 0;
     int64_t rtime = ad->rtime;
     int total_len = 0;
@@ -888,7 +887,6 @@ int process_packets_for_stream(streams *sid, adapter *ad) {
             for (j = 0; j < MAX_STREAMS_PER_PID && p->sid[j] > -1; j++)
                 if (p->sid[j] == st_id) {
                     pids[p->pid] = 1;
-                    num_enabled_pids++;
                 }
         }
 

--- a/src/stream.c
+++ b/src/stream.c
@@ -224,7 +224,7 @@ streams *setup_stream(char *str, sockets *s) {
 
     if (sid->adapter >= 0 &&
         !strncasecmp((const char *)s->buf, "SETUP", 5)) // SETUP after PLAY
-    {
+    {Variable 'num_enabled_pids' is modified but its new value is never used.
         int ad = sid->adapter;
         if (!strstr(tmp_str, "addpids") && !strstr(tmp_str, "delpids")) {
             close_adapter_for_stream(sid->sid, ad, 0);
@@ -862,7 +862,7 @@ int check_cc(adapter *ad) {
     return packet_no_sid;
 }
 
-int process_packets_for_stream(streams *sid, adapter *ad) {
+int process_packets_for_stream(streams *sid, adapter *ad) {Variable 'num_enabled_pids' is modified but its new value is never used.
     int i, j, st_id = sid->sid;
     SPid *p;
     uint8_t *b;
@@ -989,8 +989,6 @@ int process_dmx(sockets *s) {
 #ifndef DISABLE_TABLES
     pmt_process_stream(ad);
 #endif
-
-    rlen = ad->rlen;
 
     for (i = 0; i < MAX_STREAMS; i++)
         if (st[i] && st[i]->enabled && st[i]->adapter == ad->id)


### PR DESCRIPTION
Variable 'num_enabled_pids' is modified but its new value is never used.