### PR TITLE
Coverity fix in ca.c

### DIFF
--- a/src/ca.c
+++ b/src/ca.c
@@ -1032,7 +1032,7 @@ int dvbca_process_pmt(adapter *ad, SPMT *spmt) {
 
     LOG("PMT CA %d pmt %d pid %u (%s) ver %u sid %u (%d), "
         "enabled_pmts %d, "
-        "%s, PMTS to be send %d %d, pos %d",
+        "%s, PMTS to be send %d %d, pos %l",
         spmt->adapter, spmt->id, pid, spmt->name, ver, sid, capmt->sid,
         get_enabled_pmts_for_ca(d), listmgmt_str[listmgmt], capmt->pmt_id,
         capmt->other_id, capmt - d->capmt);


### PR DESCRIPTION
CID 314144 (#1 of 1): Invalid type in argument to printf format specifier (PRINTF_ARGS)invalid_type: Argument capmt - d->capmt to format specifier %d was expected to have type int but has type long.