### PR TITLE
satipc quirk for Gainatech EyeTV Netstream 4C

### DIFF
--- a/src/satipc.c
+++ b/src/satipc.c
@@ -204,7 +204,7 @@ int satipc_reply(sockets *s) {
     if (rc == 404)
         sip->restart_needed = 1;
 
-//quirk for Gainatech Netstream 4C when fe=1 is in the URL
+//quirk for Gainatech EyeTV Netstream 4C when fe=1 is in the URL
     if (rc == 503)
         if (ad->sys[0] == SYS_DVBC_ANNEX_A || ad->sys[0] == SYS_DVBC2)
             sip->satip_fe = 0;

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -204,6 +204,11 @@ int satipc_reply(sockets *s) {
     if (rc == 404)
         sip->restart_needed = 1;
 
+//quirk for Gainatech Netstream 4C when fe=1 is in the URL
+    if (rc == 503)
+        if (ad->sys[0] == SYS_DVBC_ANNEX_A || ad->sys[0] == SYS_DVBC2)
+            sip->satip_fe = 0;
+
     if (rc == 454 || rc == 503 || rc == 405) {
         sip->sent_transport = 0;
         sip->want_tune = 1;


### PR DESCRIPTION
Gainatech Netstream 4C did reply  with 503 when fe=1 is in the  request URL
fixes https://github.com/catalinii/minisatip/issues/879