### PR TITLE
fix name_app default for status page

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -640,6 +640,8 @@ void set_options(int argc, char *argv[]) {
     opts.no_threads = 1;
     opts.document_root = "/usr/share/minisatip/html";
 #endif
+
+    opts.name_app = app_name;
     char short_opts[200];
     get_short_opts(short_opts, long_options);
 


### PR DESCRIPTION
if no -I name is given the status page "Service Name" is empty