### PR TITLE
add LATM (AAC)

### DIFF
--- a/src/pmt.c
+++ b/src/pmt.c
@@ -1743,7 +1743,7 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
 
         int is_video =
             (stype == 2) || (stype == 27) || (stype == 36) || (stype == 15);
-        int is_audio = isAC3 || (stype == 3) || (stype == 4);
+        int is_audio = isAC3 || (stype == 3) || (stype == 4) || (stype == 17);
 
         int stream_pid_id = -1;
 


### PR DESCRIPTION
there is a new ARD transponder for radio on 19.2East with LATM/ACC audio 0x11
mpv "http://192.168.178.129:8080/?src=1&freq=11053&pol=h&msys=dvbs2&mtype=8psk&sr=22000&pids=0,16,17,18,601"
 (+) Audio --aid=1 (aac_latm 2ch 48000Hz)
AO: [pulse] 48000Hz stereo 2ch float
A: 00:00:01 / 00:00:14 (11%) Cache: 12s/514KB