### PR TITLE
Add --cache-dir, use it for bootid, ddci.conf, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Help
 * -B X : set the app socket write buffer to X KB. 
 	* eg: -B 10000 - to set the socket buffer to 10MB
 
+* -z --cache-dir dir : set the app cache directory to dir. The directory will be created if it doesn't exist. 
+	* defaults to /var/cache/minisati
+
 * -d --diseqc ADAPTER1:COMMITTED1-UNCOMMITTED1[,ADAPTER2:COMMITTED2-UNCOMMITTED2[,...]
 	* The first argument is the adapter number, second is the number of committed packets to send to a Diseqc 1.0 switch, third the number of uncommitted commands to sent to a Diseqc 1.1 switch
 	The higher number between the committed and uncommitted will be sent first.
@@ -264,4 +267,3 @@ Examples:
 	- Astra 19.2E, Kika HD: "rtsp://MINISATIP_HOST:554/?src=1&freq=11347&pol=v&ro=0.35&msys=dvbs2&mtype=8psk&plts=on&sr=22000&fec=23&pids=0,17,18,6600,6610,6620,6630"
 
 - msys can be one of: dvbs, dvbs2, dvbt, dvbt2, dvbc, dvbc2, atsc, isdbt, dvbcb ( - DVBC_ANNEX_B )
-

--- a/src/ca.c
+++ b/src/ca.c
@@ -1323,9 +1323,9 @@ static void get_authdata_filename(char *dest, size_t len, unsigned int slot,
             cin[i] = 95; /* underscore _ */
         i++;
     };
-    snprintf(source, sizeof(source) - 1, "%s/ci_auth_%d.bin", getenv("HOME"),
+    snprintf(source, sizeof(source) - 1, "%s/ci_auth_%d.bin", opts.cache_dir,
              slot);
-    snprintf(target, sizeof(target) - 1, "%s/ci_auth_%s_%d.bin", getenv("HOME"),
+    snprintf(target, sizeof(target) - 1, "%s/ci_auth_%s_%d.bin", opts.cache_dir,
              cin, slot);
 
     struct stat buf;
@@ -1377,7 +1377,7 @@ static void get_authdata_filename(char *dest, size_t len, unsigned int slot,
         }
         /* else do nothing to prevent stranded symlinks */
     }
-    snprintf(dest, len, "%s/ci_auth_%s_%d.bin", getenv("HOME"), cin, slot);
+    snprintf(dest, len, "%s/ci_auth_%s_%d.bin", opts.cache_dir, cin, slot);
 }
 
 static int get_authdata(uint8_t *host_id, uint8_t *dhsk, uint8_t *akh,
@@ -1837,7 +1837,7 @@ static int check_ci_certificates(struct cc_ctrl_data *cc_data) {
         char ci_cert_file[256];
         memset(ci_cert_file, 0, sizeof(ci_cert_file));
         snprintf(ci_cert_file, sizeof(ci_cert_file) - 1,
-                 "/%s/ci_cert_%s_%d.der", getenv("HOME"), ci_name_underscore,
+                 "%s/ci_cert_%s_%d.der", opts.cache_dir, ci_name_underscore,
                  ci_number);
         LOG("CI%d EXTRACTING %s", ci_number, ci_cert_file);
         int fd =

--- a/src/ca.h
+++ b/src/ca.h
@@ -26,4 +26,6 @@ void set_ca_adapter_force_ci(char *o);
 char *get_ca_pin(int i);
 void set_ca_multiple_pmt(char *o);
 int get_max_pmt_for_ca(int i);
+void get_authdata_filename(char *dest, size_t len, unsigned int slot, 
+                           char *ci_name);
 #endif

--- a/src/ddci.h
+++ b/src/ddci.h
@@ -78,8 +78,8 @@ int ddci_create_pat(ddci_device_t *d, uint8_t *b);
 int ddci_create_pmt(ddci_device_t *d, SPMT *pmt, uint8_t *new_pmt, int pmt_size,
                     int ver, int pcr_pid);
 ddci_mapping_table_t *get_pid_mapping_allddci(int ad, int pid);
-void save_channels(SHashTable *ch, char *file);
-void load_channels(SHashTable *ch, char *file);
+void save_channels(SHashTable *ch);
+void load_channels(SHashTable *ch);
 int ddci_process_pmt(adapter *ad, SPMT *pmt);
 void blacklist_pmt_for_ddci(SPMT *pmt, int ddid);
 int ddci_del_pmt(adapter *ad, SPMT *spmt);

--- a/src/minisatip.h
+++ b/src/minisatip.h
@@ -121,6 +121,7 @@ struct struct_opts {
     char disable_ssdp;
     char pmt_scan;
     char emulate_pids_all;
+    char *cache_dir;
 #ifdef AXE
     int quattro;
     int quattro_hiband;

--- a/src/minisatip.h
+++ b/src/minisatip.h
@@ -121,7 +121,6 @@ struct struct_opts {
     char disable_ssdp;
     char pmt_scan;
     char emulate_pids_all;
-    char ca_quirks;
 #ifdef AXE
     int quattro;
     int quattro_hiband;

--- a/src/utils.c
+++ b/src/utils.c
@@ -30,6 +30,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <math.h>
 #include <net/if.h>
 #include <netdb.h>
@@ -1749,6 +1750,25 @@ int buffer_to_ts(uint8_t *dest, int dstsize, uint8_t *src, int srclen, char *cc,
         len += 188;
     }
     return len;
+}
+
+// http://nion.modprobe.de/blog/archives/357-Recursive-directory-creation.html
+void mkdir_recursive(const char *path) {
+    char tmp[PATH_MAX];
+    char *p = NULL;
+    size_t len;
+
+    snprintf(tmp, sizeof(tmp),"%s",path);
+    len = strlen(tmp);
+    if (tmp[len - 1] == '/')
+        tmp[len - 1] = 0;
+    for (p = tmp + 1; *p; p++)
+        if (*p == '/') {
+            *p = 0;
+            mkdir(tmp, S_IRWXU);
+            *p = '/';
+        }
+    mkdir(tmp, S_IRWXU);
 }
 
 /*

--- a/src/utils.h
+++ b/src/utils.h
@@ -177,6 +177,7 @@ int get_index_hash_search(int start_pos, void *p, int max, int struct_size,
 int buffer_to_ts(uint8_t *dest, int dstsize, uint8_t *src, int srclen, char *cc,
                  int pid);
 void write_buf_to_file(char *file, uint8_t *buf, int len);
+void mkdir_recursive(const char *path);
 
 #define mutex_lock(m) mutex_lock1(__FILE__, __LINE__, m)
 #define mutex_unlock(m) mutex_unlock1(__FILE__, __LINE__, m)

--- a/tests/test_ca.c
+++ b/tests/test_ca.c
@@ -123,9 +123,21 @@ int test_create_capmt() {
     return 0;
 }
 
+int test_get_authdata_filename() {
+    const char *expected_file_name = "/tmp/ci_auth_Conax_CSP_CIPLUS_CAM_4.bin";
+    char actual_filename[FILENAME_MAX];
+    get_authdata_filename(actual_filename, sizeof(actual_filename), 4, "Conax CSP CIPLUS CAM");
+    LOG("Expected file name: %s", expected_file_name)
+    LOG("File name: %s", actual_filename);
+    ASSERT(strcmp(actual_filename, expected_file_name) == 0, "Auth data filename mismatch");
+
+    return 0;
+}
+
 int main() {
     opts.log = 1;
     opts.debug = 255;
+    opts.cache_dir = "/tmp";
 
     strcpy(thread_name, "test");
     memset(&d, 0, sizeof(d));
@@ -137,6 +149,7 @@ int main() {
     TEST_FUNC(test_multiple_pmt(), "testing CA multiple pmt");
     memset(d.capmt, -1, sizeof(d.capmt));
     TEST_FUNC(test_create_capmt(), "testing CA creating multiple pmt");
+    TEST_FUNC(test_get_authdata_filename(), "testing filename helper function");
     fflush(stdout);
     return 0;
 }

--- a/tests/test_ddci.c
+++ b/tests/test_ddci.c
@@ -114,10 +114,10 @@ int test_channels() {
     c.ddci[1].ddci = 1;
     c.ddcis = 1;
     setItem(&h, c.sid, &c, sizeof(c));
-    save_channels(&h, "/tmp/minisatip.channels");
+    save_channels(&h);
     free_hash(&h);
     create_hash_table(&h, 10);
-    load_channels(&h, "/tmp/minisatip.channels");
+    load_channels(&h);
     ASSERT(getItem(&h, 200) != NULL, "Saved SID not found in table");
     int ch = 0;
     FOREACH_ITEM(&h, t) { ch++; }
@@ -561,6 +561,7 @@ int test_create_pmt() {
 int main() {
     opts.log = 65535;
     opts.debug = 0;
+    opts.cache_dir = "/tmp";
     strcpy(thread_name, "test");
     TEST_FUNC(test_channels(), "testing test_channels");
     TEST_FUNC(test_add_del_pmt(), "testing adding and removing pmts");

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -99,9 +99,21 @@ int test_hash_table() {
 
     return 0;
 }
+
+int test_mkdir_recursive() {
+    const char *dir = "/tmp/minisatip/test";
+    mkdir_recursive(dir);
+    
+    struct stat sb;
+    ASSERT(stat(dir, &sb) == 0 && S_ISDIR(sb.st_mode), "stat should report that directory exists");
+
+    return 0;
+}
+
 int main() {
     opts.log = 255;
     strcpy(thread_name, "test");
     TEST_FUNC(test_hash_table(), "testing hash table");
+    TEST_FUNC(test_mkdir_recursive(), "testing directory creation");
     return 0;
 }


### PR DESCRIPTION
Add `--cache-dir`, defaulting to `/var/cache/minisatip`. Use it to store various files, such as:
    - bootid
    - ddci.conf
    - CI+ files
    
When running as a systemd service, the working directory may not be set. Same thing with `HOME`. This ensures the application always has a dedicated place to write files to. It also prevents your home directory from being spammed with files of unknown origin.