### PR TITLE
Fix DDCI platform check

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -28,7 +28,7 @@ ARCH := $(shell $(CC) -v 2>&1 | grep Target | sed 's/Target: //' | cut -d- -f 1)
 MINOR := $(shell git tag --points-at HEAD | cut -d. -f3 | tail -1)
 CFLAGS+=-DMINOR=\"$(MINOR)\"
 
-ifeq ($(OS),x86_64-linux-gnu)
+ifeq ($(OS),linux)
 DDCI=1
 endif
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -28,10 +28,6 @@ ARCH := $(shell $(CC) -v 2>&1 | grep Target | sed 's/Target: //' | cut -d- -f 1)
 MINOR := $(shell git tag --points-at HEAD | cut -d. -f3 | tail -1)
 CFLAGS+=-DMINOR=\"$(MINOR)\"
 
-ifeq ($(OS),linux)
-DDCI=1
-endif
-
 ifneq ($(OS),apple)
         LDFLAGS += -lrt
 else
@@ -75,6 +71,9 @@ LIBS+=dvben50221 dvbapi ucsi
 SOURCES+=ca.c
 TABLES=1
 PMT=1
+ifeq ($(OS),linux)
+DDCI=1
+endif
 else
 CFLAGS+=-DDISABLE_DVBCA
 endif


### PR DESCRIPTION
Not sure why this has gone unfixed until now :shrug: It's cumbersome to always edit the generated `Makefile` afterwards.

Potentially the check should be guarded by `--enable-dvbca` since it's related to that?