### PR TITLE
Optional pids=all filtering encypted packets (v2)

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -409,7 +409,7 @@ Help\n\
 #ifndef DISABLE_DVBAPI
         "\
 * -o --dvbapi [~]host:port,offset - specify the hostname and port for the dvbapi server (oscam). Port 9000 is set by default (if not specified) \n\
-	* [~] When using this symbol at start of a `pids=all` request the filtering out of encrypted packets is disabled (useful when not using -E).\n\
+	* [~] This symbol at the beginning indicates that in all `pids=all` requests the filtering of unencrypted packets must be disabled (useful when not using -E).\n\
 	* eg: -o 192.168.9.9:9000 or -o 192.168.9.9:9999,2  with offset if multiple dvbapi clients use the same server\n\
 	192.168.9.9 is the host where oscam is running and 9000 is the port configured in dvbapi section in oscam.conf.\n\
 	* eg: -o /tmp/camd.socket \n\

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -289,7 +289,7 @@ void usage() {
         "\n\t./%s [-[fgtzE]] [-a x:y:z] [-b X:Y] [-B X] [-H X:Y] [-d A:C-U ] [-D device_id] [-e X-Y,Z] [-i prio] \n\
 	\t[-[uj] A1:S1-F1[-PIN]] [-m mac] [-P port] [-l module1[,module2]] [-v module1[,module2]]"
 #ifndef DISABLE_DVBAPI
-        "[-o oscam_host:dvbapi_port,offset] "
+        "[-o [~]oscam_host:dvbapi_port,offset] "
 #endif
         "[-p public_host] [-r remote_rtp_host] [-R document_root] "
 #ifndef DISABLE_SATIPCLIENT
@@ -408,7 +408,8 @@ Help\n\
 #endif
 #ifndef DISABLE_DVBAPI
         "\
-* -o --dvbapi host:port,offset - specify the hostname and port for the dvbapi server (oscam). Port 9000 is set by default (if not specified) \n\
+* -o --dvbapi [~]host:port,offset - specify the hostname and port for the dvbapi server (oscam). Port 9000 is set by default (if not specified) \n\
+	* [~] When using this symbol at start with a `pids=all` request the decryption is disabled (not decode all services).\n\
 	* eg: -o 192.168.9.9:9000 or -o 192.168.9.9:9999,2  with offset if multiple dvbapi clients use the same server\n\
 	192.168.9.9 is the host where oscam is running and 9000 is the port configured in dvbapi section in oscam.conf.\n\
 	* eg: -o /tmp/camd.socket \n\
@@ -594,6 +595,7 @@ void set_options(int argc, char *argv[]) {
     opts.dvbapi_port = 0;
     memset(opts.dvbapi_host, 0, sizeof(opts.dvbapi_host));
     opts.drop_encrypted = 1;
+    opts.pids_all_no_dec = 0;
     opts.rtsp_port = 554;
     opts.use_ipv4_only = 1;
 #ifndef DISABLE_SATIPCLIENT
@@ -909,6 +911,11 @@ void set_options(int argc, char *argv[]) {
             char buf[100];
             memset(buf, 0, sizeof(buf));
             strncpy(buf, optarg, sizeof(buf) - 1);
+            if (buf[0] == '~')
+            {
+                opts.pids_all_no_dec = 1;
+                memmove(&buf[0], &buf[1], sizeof(buf) - 1);
+            }
             char *sep2 = strchr(buf, ',');
             if (sep2 != NULL) {
                 *sep2 = 0;

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -409,7 +409,7 @@ Help\n\
 #ifndef DISABLE_DVBAPI
         "\
 * -o --dvbapi [~]host:port,offset - specify the hostname and port for the dvbapi server (oscam). Port 9000 is set by default (if not specified) \n\
-	* [~] When using this symbol at start with a `pids=all` request the decryption is disabled (not decode all services).\n\
+	* [~] When using this symbol at start of a `pids=all` request the filtering out of encrypted packets is disabled (useful when not using -E).\n\
 	* eg: -o 192.168.9.9:9000 or -o 192.168.9.9:9999,2  with offset if multiple dvbapi clients use the same server\n\
 	192.168.9.9 is the host where oscam is running and 9000 is the port configured in dvbapi section in oscam.conf.\n\
 	* eg: -o /tmp/camd.socket \n\

--- a/src/minisatip.h
+++ b/src/minisatip.h
@@ -85,6 +85,7 @@ struct struct_opts {
     char dvbapi_host[100];
     int dvbapi_offset;
     int drop_encrypted;
+    int pids_all_no_dec;
     int rtsp_port;
     uint8_t netcv_count;
     char *netcv_if;

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -961,10 +961,17 @@ int pmt_decrypt_stream(adapter *ad) {
 
 void mark_pids_null(adapter *ad) {
     int i;
+    int pids_all = 0;
+
+    if (ad->drop_encrypted && opts.pids_all_no_dec) { // Check (one time) if pids=all is activated
+        SPid *p = find_pid(ad->id, 8192);
+        if (p)
+            pids_all = 1;
+    }
     for (i = 0; i < ad->rlen; i += DVB_FRAME) {
         uint8_t *b = ad->buf + i;
         int pid = PID_FROM_TS(b);
-        if (pid == 0x1FFF)
+        if (pid == 0x1FFF || pids_all) // When pids=all don't drop encrypted packets
             continue;
         if ((b[3] & 0x80) == 0x80) {
             if (opts.debug & (DEFAULT_LOG | LOG_DMX))


### PR DESCRIPTION
This patch incorporates a new parameter in the oscam option to disable the default behaviour of filter out all packets when `pids=all` is requested. With this option on (disabled by default) when `pids=all` is running, then instead of filter out all encrypted packets they are passed. Without this patch, when not using the -E parameter (disabled by default too) you receive all encrypted packets converted to NULL stuff. This new optional parameter solves this problem, and when you request the full transport stream (pids=all) then encrypted packets will pass untouched.