### PR TITLE
Fix CAPMT version and current-next indicator field

### DIFF
--- a/src/ca.c
+++ b/src/ca.c
@@ -898,7 +898,7 @@ int create_capmt(SCAPMT *ca, int listmgmt, uint8_t *capmt, int capmt_len,
     capmt[pos++] = listmgmt;
     copy16(capmt, pos, ca->sid);
     pos += 2;
-    capmt[pos++] = ((version & 0xF) << 1);
+    capmt[pos++] = ((version & 0xF) << 1) | 0x1;
     capmt[pos++] = 0; // PI LEN 2 bytes, set 0
     capmt[pos++] = 0;
 


### PR DESCRIPTION
@Yuri666 suggested this on the forums and it made decryption work for me (without this, the CAM simply wouldn't decrypt anything). I'm not exactly sure what's going on here, but AFAICT the "current/next indicator" bit is set to 1? I might be totally wrong though.