### PR TITLE
Fix potential warning overflow

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -1595,7 +1595,7 @@ int close_http(sockets *s) {
 
 int ssdp_notify(sockets *s, int alive) {
     char buf[500], mac[15] = "00000000000000";
-    char nt[3][50];
+    char nt[3][60];
     int ptr = 0;
     char *op = alive ? "Discovery" : "ByeBye";
 


### PR DESCRIPTION
Eliminates this compiling warning:
```
minisatip.c: In function ‘ssdp_notify’:
minisatip.c:1615:28: warning: ‘%s’ directive writing up to 49 bytes into a region of size 43 [-Wformat-overflow=]
 1615 |     sprintf(nt[1], "::uuid:%s", uuid);
      |                            ^~   ~~~~
minisatip.c:1615:5: note: ‘sprintf’ output between 8 and 57 bytes into a destination of size 50
 1615 |     sprintf(nt[1], "::uuid:%s", uuid);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```