### PR TITLE
Fix calculation of signal values

### DIFF
--- a/src/dvb.c
+++ b/src/dvb.c
@@ -387,6 +387,10 @@ float get_db_snr_map(transponder *tp) {
                 top = DVB_S__QPSK__FEC_7_8;
                 break;
 
+            case FEC_AUTO:
+                top = DVB_S__OTHER;
+                break;
+
             default:
                 top = DVB_S__OTHER;
                 LOG("get_db_snr_map -> DVB-S modulation SNR scale not "
@@ -414,6 +418,9 @@ float get_db_snr_map(transponder *tp) {
             case FEC_3_4:
                 top = DVB_S2_QPSK__FEC_3_4;
                 break;
+            case FEC_4_5:
+                top = DVB_S2_QPSK__FEC_4_5;
+                break;
             case FEC_5_6:
                 top = DVB_S2_QPSK__FEC_5_6;
                 break;
@@ -422,6 +429,10 @@ float get_db_snr_map(transponder *tp) {
                 break;
             case FEC_9_10:
                 top = DVB_S2_QPSK__FEC_9_10;
+                break;
+
+            case FEC_AUTO:
+                top = DVB_S2_OTHER;
                 break;
 
             default:
@@ -434,17 +445,30 @@ float get_db_snr_map(transponder *tp) {
         case PSK_8:
             switch (tp->fec) {
 
+            case FEC_1_2:
+                top = DVB_S2_PSK_8_FEC_1_2;
+                break;
             case FEC_2_3:
                 top = DVB_S2_PSK_8_FEC_2_3;
                 break;
             case FEC_3_4:
                 top = DVB_S2_PSK_8_FEC_3_4;
                 break;
+            case FEC_4_5:
+                top = DVB_S2_PSK_8_FEC_4_5;
+                break;
             case FEC_5_6:
                 top = DVB_S2_PSK_8_FEC_5_6;
                 break;
             case FEC_8_9:
                 top = DVB_S2_PSK_8_FEC_8_9;
+                break;
+            case FEC_9_10:
+                top = DVB_S2_PSK_8_FEC_9_10;
+                break;
+
+            case FEC_AUTO:
+                top = DVB_S2_PSK_8_OTHER;
                 break;
 
             default:

--- a/src/dvb.h
+++ b/src/dvb.h
@@ -170,21 +170,25 @@ typedef enum dvb_snr_table {
     DVB_S__QPSK__FEC_3_4     =  100 ,
     DVB_S__QPSK__FEC_5_6     =  110 ,
     DVB_S__QPSK__FEC_7_8     =  120 ,
-    DVB_S__OTHER             =  150 ,
+    DVB_S__OTHER             =  130 ,  /* Calculated */
 
     DVB_S2_QPSK__FEC_1_2     =   90 ,
     DVB_S2_QPSK__FEC_2_3     =  110 ,
     DVB_S2_QPSK__FEC_3_4     =  120 ,
+    DVB_S2_QPSK__FEC_4_5     =  130 ,  /* Calculated */
     DVB_S2_QPSK__FEC_5_6     =  120 ,
     DVB_S2_QPSK__FEC_8_9     =  130 ,
     DVB_S2_QPSK__FEC_9_10    =  135 ,
-    DVB_S2_OTHER             =  150 ,
+    DVB_S2_OTHER             =  130 ,  /* Calculated */
 
+    DVB_S2_PSK_8_FEC_1_2     =  128 ,  /* Calculated */
     DVB_S2_PSK_8_FEC_2_3     =  145 ,
     DVB_S2_PSK_8_FEC_3_4     =  160 ,
+    DVB_S2_PSK_8_FEC_4_5     =  180 ,  /* Deduced */
     DVB_S2_PSK_8_FEC_5_6     =  175 ,
     DVB_S2_PSK_8_FEC_8_9     =  190 ,
-    DVB_S2_PSK_8_OTHER       =  210 ,
+    DVB_S2_PSK_8_FEC_9_10    =  200 ,  /* Deduced */
+    DVB_S2_PSK_8_OTHER       =  180 ,  /* Deduced */
 
     DVB_T__QPSK__FEC_1_2     =   41 ,
     DVB_T__QPSK__FEC_2_3     =   61 ,


### PR DESCRIPTION
When the DVB adapter reports dB signal, fix the result value (it's less in the order of 100 smaller times).
For Enigma STB devices assume that the driver reports dB allways.