### PR TITLE
Properly handle CAMs that request date time updates in intervals

### DIFF
--- a/src/ca.c
+++ b/src/ca.c
@@ -219,7 +219,6 @@ typedef struct ca_device {
     int uri_mask;
 
     uint16_t ai_session_number;
-    uint16_t mmi_session_number;
 
     struct list_head *txq;
     struct list_head *mmiq;

--- a/src/ca.c
+++ b/src/ca.c
@@ -218,7 +218,7 @@ typedef struct ca_device {
     int ca_session_number;
     int uri_mask;
 
-    uint16_t ai_session_number;
+    int ai_session_number;
 
     struct list_head *txq;
     struct list_head *mmiq;
@@ -3357,6 +3357,9 @@ int ca_init(ca_device_t *d) {
         LOG("failed to create session layer");
         goto fail;
     }
+
+    d->ai_session_number = -1;
+    d->ca_session_number = -1;
 
     // create the sendfuncs
     d->sf.arg = d->sl;

--- a/src/ca.c
+++ b/src/ca.c
@@ -1137,7 +1137,6 @@ int ca_ai_callback(void *arg, uint8_t slot_id, uint16_t session_number,
     LOG("  Manufacturer code: %04x", manufacturer_code);
     LOG("  Menu string: %.*s", menu_string_length, menu_string);
 
-    d->ai_session_number = session_number;
     memcpy(d->ci_name, menu_string, menu_string_length);
     return 0;
 }


### PR DESCRIPTION
Many CAMs request the current date and time once, but some want regular updates sent to it. Things seem to work without this interval support, but it's definitely supposed to be implemented according to the spec.

Been using this "in production" for a few weeks without any issues.

@Yuri666 any comments?