### PR TITLE
Fix update_cw() validated initialization

### DIFF
--- a/src/pmt.c
+++ b/src/pmt.c
@@ -729,7 +729,7 @@ void update_cw(SPMT *pmt) {
     LOGL(old_cw == cw ? DEFAULT_LOG : 1,
          "found CW: %d %s for %s PMT %d, old cw %d, packets %d, parity %d, pid "
          "%d: %s",
-         cw ? cw->id : -1, validated ? "[validated]" : "[pending]", pmt->name, pmt->id,
+         cw ? cw->id : -1, validated ? "[validated]" : "[not validated]", pmt->name, pmt->id,
          old_cw ? old_cw->id : -1, pmt->blen, pmt->parity, pmt->pid,
          cw_to_string(cw, buf));
 

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -659,6 +659,17 @@ int fill_packet_start_indicator(SPMT_batch *all, int max_all, SPMT_batch *start,
     return s;
 }
 
+void dump_cws() {
+    int i;
+    char buf[200];
+    uint64_t ctime = getTick();
+    LOG("List of CWs:");
+    for (i = 0; i < ncws; i++)
+        if (cws[i] && cws[i]->enabled && cws[i]->expiry > ctime) {
+            LOG("* CW %d: %s", cws[i]->id, cw_to_string(cws[i], buf));
+        }
+}
+
 void update_cw(SPMT *pmt) {
     SCW *cw = NULL, *old_cw = pmt->cw;
     char buf[300];
@@ -753,17 +764,6 @@ void update_cw(SPMT *pmt) {
     } else {
         if (opts.debug & LOG_PMT)
             dump_cws();
-}
-
-void dump_cws() {
-    int i;
-    char buf[200];
-    uint64_t ctime = getTick();
-    LOG("List of CWs:");
-    for (i = 0; i < ncws; i++)
-        if (cws[i] && cws[i]->enabled && cws[i]->expiry > ctime) {
-            LOG("* CW %d: %s", cws[i]->id, cw_to_string(cws[i], buf));
-        }
 }
 
 int send_cw(int pmt_id, int algo, int parity, uint8_t *cw, uint8_t *iv,

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -677,10 +677,7 @@ void update_cw(SPMT *pmt) {
     int i = 0;
     SPMT_batch start[10];
     int len = fill_packet_start_indicator(pmt->batch, pmt->blen, start, 9);
-    int validated = 1;
-
-    if (len <= 0)
-        validated = 0;
+    int validated = (len > 0);
 
     // If no CW exists and we can validate the CW, try to find one again
     // Helps for CI+ case

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -666,7 +666,10 @@ void update_cw(SPMT *pmt) {
     int i = 0;
     SPMT_batch start[10];
     int len = fill_packet_start_indicator(pmt->batch, pmt->blen, start, 9);
-    int validated = (len > 1);
+    int validated = 1;
+
+    if (len <= 0)
+        validated = 0;
 
     // If no CW exists and we can validate the CW, try to find one again
     // Helps for CI+ case
@@ -716,9 +719,9 @@ void update_cw(SPMT *pmt) {
         }
 
     LOGL(old_cw == cw ? DEFAULT_LOG : 1,
-         "found CW: %d %sfor %s PMT %d, old cw %d, packets %d, parity %d, pid "
+         "found CW: %d %s for %s PMT %d, old cw %d, packets %d, parity %d, pid "
          "%d: %s",
-         cw ? cw->id : -1, validated ? "[validated] " : "", pmt->name, pmt->id,
+         cw ? cw->id : -1, validated ? "[validated]" : "[pending]", pmt->name, pmt->id,
          old_cw ? old_cw->id : -1, pmt->blen, pmt->parity, pmt->pid,
          cw_to_string(cw, buf));
 
@@ -747,17 +750,19 @@ void update_cw(SPMT *pmt) {
                         cw_to_string(cws[i], buf));
                 }
         }
-    }
+    } else {
+        if (opts.debug & LOG_PMT)
+            dump_cws();
 }
 
 void dump_cws() {
     int i;
     char buf[200];
     uint64_t ctime = getTick();
-    LOG("List of CWs");
+    LOG("List of CWs:");
     for (i = 0; i < ncws; i++)
         if (cws[i] && cws[i]->enabled && cws[i]->expiry > ctime) {
-            LOG("CW %d: %s", cws[i]->id, cw_to_string(cws[i], buf));
+            LOG("* CW %d: %s", cws[i]->id, cw_to_string(cws[i], buf));
         }
 }
 

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -764,6 +764,7 @@ void update_cw(SPMT *pmt) {
     } else {
         if (opts.debug & LOG_PMT)
             dump_cws();
+    }
 }
 
 int send_cw(int pmt_id, int algo, int parity, uint8_t *cw, uint8_t *iv,


### PR DESCRIPTION
The initialization of the "validated" flag is incorrect when only one TS packet with the PUSI mark it's found. With only one positive check it's sufficient to grant that the key is correct. So, the variable requires to be iniatialized to 1 when "len > 0", and not when "len > 1". Futhermore one change in the LOG is included for improved readability.