### PR TITLE
Reset decoding errors when starting to decode

### DIFF
--- a/src/dvb.h
+++ b/src/dvb.h
@@ -355,6 +355,7 @@ typedef struct struct_pid {
                  // tune is called, 3 disable when tune is called
     int packets; // how many packets for this pid arrived, used to sort the pids
     int dec_err; // decrypt errors, continuity counters
+    uint8_t is_decrypted;  // Set when first decrypted
     int16_t pmt, filter;
     char cc, cc1;
     int sock; // sock_id

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -997,6 +997,13 @@ void mark_pids_null(adapter *ad) {
             if (p)
                 p->dec_err++;
         }
+        else if (pid > 0x001F && pid < 0x1FFF && ad->ca_mask) {
+            SPid *p = find_pid(ad->id, pid);
+            if (p && !p->is_decrypted) {
+                p->is_decrypted = 1;
+                p->dec_err = 0; // When starting to decrypt reset the counter of decoding errors
+            }
+        }
     }
 }
 
@@ -1809,6 +1816,7 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
             enabled_channels++;
             pmt->state = PMT_RUNNING;
             cp->pmt = pmt->master_pmt;
+            cp->is_decrypted = 0;
         }
     }
     // Add the PCR pid if it's independent


### PR DESCRIPTION
When a new program is started to decode, at first some packets can't be decoded. This could be annoying when viewing the UI as you can interpret that some decoding errors have appeared. But this is not the case. Futhermore, if after the initial decoding some packets can't be decoded you need to remember the initial count to know the real non-decoded packets.

This patch adds a new behaviour: When first starting to receive a new program, the counter of non-decoded packets will continue to work as now. Therefore, if the program cannot be decoded, the counter can be viewed incrementing. But when the program starts to be decoded, then the counters are reset. So only if new decoding errors appear after the initial decoding you will see this counter in the UI.

This new behaviour is more consistent and user friendly. 