### PR TITLE
Debug dump of CWs if the validation fails

### DIFF
--- a/src/pmt.c
+++ b/src/pmt.c
@@ -757,6 +757,9 @@ void update_cw(SPMT *pmt) {
                     LOG("Expiring CW %d for pmt %d: %s", cws[i]->id, pmt->id,
                         cw_to_string(cws[i], buf));
                 }
+        } else {
+            if (opts.debug & LOG_PMT)
+                dump_cws();
         }
     } else {
         if (opts.debug & LOG_PMT)


### PR DESCRIPTION
Print debug data of all CWs not only when the no CW is found, but also when not validated.