### PR TITLE
Add FreeBSD support

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -1851,6 +1851,7 @@ int main(int argc, char *argv[]) {
         if ((ssdp1 = udp_bind(opts.disc_host, 1900, 1)) < 1)
             FAIL("SSDP: Could not bind on %s udp port 1900", opts.disc_host);
         if (opts.bind_dev) {
+#if defined(SO_BINDTODEVICE)
             struct ifreq ifr;
             memset(&ifr, 0, sizeof(ifr));
             snprintf(ifr.ifr_name, sizeof(ifr.ifr_name), "%s", opts.bind_dev);
@@ -1861,6 +1862,9 @@ int main(int argc, char *argv[]) {
                            sizeof(ifr)) < 0)
                 LOG("SSDP: Failed to set SO_BINDTODEVICE to %s", opts.bind_dev);
             LOG("SSDP: Bound to device %s", opts.bind_dev);
+#else
+            LOG("SSDP: Binding to device with SO_BINDTODEVICE not supported!");
+#endif
         }
 
         si = sockets_add(ssdp, NULL, -1, TYPE_UDP, (socket_action)ssdp_reply,

--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -1563,9 +1563,13 @@ void set_socket_dscp(int id, int dscp, int prio) {
     if (setsockopt(id, IPPROTO_IP, IP_TOS, &d, sizeof(d)))
         LOG("%s: setsockopt IP_TOS failed", __FUNCTION__);
 
+#if defined(SO_PRIORITY)
     d = prio;
     if (setsockopt(id, SOL_SOCKET, SO_PRIORITY, &d, sizeof(d)))
         LOG("%s: setsockopt SO_PRIORITY failed", __FUNCTION__);
+#else
+    LOG("%s: setsockopt SO_PRIORITY not implemented", __FUNCTION__);
+#endif
 }
 
 void sockets_set_opaque(int id, void *opaque, void *opaque2, void *opaque3) {

--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -970,7 +970,7 @@ void set_sockets_rtime(int i, int r) {
     if (ss)
         ss->rtime = r;
 }
-#ifndef __APPLE__
+#ifdef __linux__
 
 int get_mac_address(char *mac) {
     struct ifreq ifr;

--- a/src/socketworks.h
+++ b/src/socketworks.h
@@ -3,6 +3,7 @@
 #define MAX_SOCKS 300
 #include "utils.h"
 #include <netinet/in.h>
+#include <sys/socket.h>
 
 typedef int (*socket_action)(void *s);
 typedef int (*read_action)(int, void *, size_t, void *, int *);


### PR DESCRIPTION
Thanks a lot for that really nice project! During one of the lockdowns in 2020 I played around with minisatip on FreeBSD and created a few patches to get it compile properly. The submitted patches are from that time but it took me quite long to finally upstream them because minisatip compiles, starts fine, detects an adapter and the webui works but I cannot seem to get a stream. I still need to figure out why and fix it.

Compiling on FreeBSD works like this:

```
./configure
gmake EXTRA_CFLAGS=-I/usr/local/include EXTRA_LDFLAGS=-L/usr/local/lib
```

I also created a FreeBSD port for minisatip so users might prefer to do:

`pkg add minisatip`

Port: https://cgit.freebsd.org/ports/tree/multimedia/minisatip