### PR TITLE
Fix incorrect index in keys_del()

### DIFF
--- a/src/dvbapi.c
+++ b/src/dvbapi.c
@@ -752,7 +752,7 @@ int keys_del(int i) {
     for (j = 0; j < MAX_KEYS; j++)
         if (i != j && keys[j] && keys[j]->enabled) {
             ek++;
-            if (k->demux_index == keys[i]->demux_index)
+            if (k->demux_index == keys[j]->demux_index)
                 ed++;
         }
     if (!ek) {


### PR DESCRIPTION
Because an incorrect slection of the index ("i" instead of "j") when decoding multiple channels using different sources in some cases all the decoding is stoped.

Fixes the bug  #932.