### PR TITLE
Fix -A in combination with -S for AXE devices

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -667,9 +667,6 @@ int source_enabled_for_adapter(adapter *ad, transponder *tp) {
         return 1;
     if (tp->sys != SYS_DVBS && tp->sys != SYS_DVBS2)
         return 1;
-#ifdef AXE
-    return 1;
-#endif
     return ad->absolute_table[tp->diseqc - 1];
 }
 

--- a/src/axe.c
+++ b/src/axe.c
@@ -459,10 +459,7 @@ int axe_setup_switch(adapter *ad) {
         }
     } else {
         aid = ad->id & 3;
-        if (diseqc_param->switch_type == SWITCH_UNICABLE ||
-            diseqc_param->switch_type == SWITCH_JESS) {
-            input = ad->master_source < 0 ? 0 : ad->master_source;
-        }
+        input = ad->master_source < 0 ? 0 : ad->master_source;
         frontend_fd = ad->fe;
         ad = axe_use_adapter(input);
         if (ad == NULL) {


### PR DESCRIPTION
Since `source_enabled_for_adapter` always returned `1`, the wrong adapter ended up being chosen if the list of sources per adapter has been modified using `-S` (useful when having two Unicable inputs).