### PR TITLE
Use Gold mode for dvb-s2 if nothing specified #978

### DIFF
--- a/src/dvb.c
+++ b/src/dvb.c
@@ -1171,7 +1171,7 @@ int dvb_tune(int aid, transponder *tp) {
 #endif
 #endif
 #if DVBAPIVERSION >= 0x050b /* 5.11 */
-        if (tp->pls_mode != TP_VALUE_UNSET)
+        if (tp->pls_code >= 0)  // Use Gold plp_mode by default if plsc specified
             ADD_PROP(DTV_SCRAMBLING_SEQUENCE_INDEX, pls_scrambling_index(tp))
 #endif
 


### PR DESCRIPTION
Before this PR to set correctly the DTV_SCRAMBLING_SEQUENCE_INDEX you need to send also plsm=[root|gold]. If pls_code is specified then there is no need to specify root or gold and can use the pls_code directly for DTV_SCRAMBLING_SEQUENCE_INDEX