### PR TITLE
Obey -M when parsing SAT>IP signal strength values too

### DIFF
--- a/src/satipc.c
+++ b/src/satipc.c
@@ -435,41 +435,41 @@ int satipc_timeout(sockets *s) {
 }
 
 void set_adapter_signal(adapter *ad, char *b, int rlen) {
-    int strength, status, snr;
+    int strength, status, quality;
     char *tun, *signal = NULL;
 
     tun = strstr((const char *)b, "tuner=");
     if (tun)
         signal = strchr(tun, ',');
     if (signal) {
-        sscanf(signal + 1, "%d,%d,%d", &strength, &status, &snr);
+        sscanf(signal + 1, "%d,%d,%d", &strength, &status, &quality);
         // Workaround for faulty servers (level=0)
         // Ex. XORO:
         // "SES1....ver=1.0;src=1;tuner=1,0,1,15,10744,h,dvbs,qpsk,off,0.35,22000,56;pids=0,100,200,400,500,600,17,16"
-        if (strength == 0 && status > 0 && snr > 0)
+        if (strength == 0 && status > 0 && quality > 0)
             strength = 1;
         // Workaround for faulty servers (quality=0)
         // Ex. AVM 6490:
         // "SES1....ver=1.2;src=1;tuner=1,106,1,0,538.00,8,dvbc,256qam,6900,,,,1;pids=0,118,2351,2352"
-        if (snr == 0 && strength > 0 && status > 0)
-            snr = 7;
+        if (quality == 0 && strength > 0 && status > 0)
+            quality = 7;
 
         // Ignore server signal strength if multipliers are set to 0
         if (!ad->strength_multiplier && !ad->snr_multiplier) {
             LOG("satipc: Ignoring server signal status since both strength_multiplier and snr_multiplier are 0");
-            strength = 255;
-            snr = 15;
+            strength = SATIP_MAX_STRENGTH;
+            quality = SATIP_MAX_QUALITY;
         }
 
-        if (ad->strength != strength || ad->snr != snr)
+        if (ad->strength != strength || ad->snr != quality)
             LOG("satipc: Received signal status from the server for adapter "
                 "%d, "
-                "stength=%d status=%d snr=%d",
-                ad->id, strength, status, snr);
+                "stength=%d status=%d quality=%d",
+                ad->id, strength, status, quality);
 
         ad->strength = strength;
         ad->status = status ? FE_HAS_LOCK : 0;
-        ad->snr = snr;
+        ad->snr = quality;
     }
 }
 

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -453,11 +453,20 @@ void set_adapter_signal(adapter *ad, char *b, int rlen) {
         // "SES1....ver=1.2;src=1;tuner=1,106,1,0,538.00,8,dvbc,256qam,6900,,,,1;pids=0,118,2351,2352"
         if (snr == 0 && strength > 0 && status > 0)
             snr = 7;
+
+        // Ignore server signal strength if multipliers are set to 0
+        if (!ad->strength_multiplier && !ad->snr_multiplier) {
+            LOG("satipc: Ignoring server signal status since both strength_multiplier and snr_multiplier are 0");
+            strength = 255;
+            snr = 15;
+        }
+
         if (ad->strength != strength || ad->snr != snr)
             LOG("satipc: Received signal status from the server for adapter "
                 "%d, "
                 "stength=%d status=%d snr=%d",
                 ad->id, strength, status, snr);
+
         ad->strength = strength;
         ad->status = status ? FE_HAS_LOCK : 0;
         ad->snr = snr;

--- a/src/satipc.h
+++ b/src/satipc.h
@@ -2,7 +2,10 @@
 #define SATIPCLIENT_H
 
 #include "adapter.h"
+
 #define SATIP_STR_LEN 500
+#define SATIP_MAX_STRENGTH 255
+#define SATIP_MAX_QUALITY 15
 
 void find_satip_adapter(adapter **a);
 int satip_getxml(void *);


### PR DESCRIPTION
Fixes #965 

Renamed `snr` to `quality` to make it clear where the odd maximum value (15) comes from (the spec).

@retrofan1979 this should really work now, can you test it?

Server:
![Screenshot-20220807112504-166x108](https://user-images.githubusercontent.com/1106133/183282302-0bcb4ec1-cb51-405c-8dd0-fadfb32601d1.png)
Client (using server via `-s`):
![Screenshot-20220807112455-177x121](https://user-images.githubusercontent.com/1106133/183282304-e3feb007-177b-4d5b-81d3-fe0ee679e335.png)

