### PR TITLE
Fix satipc module

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -947,8 +947,8 @@ int update_pids(int aid) {
 void post_tune(adapter *ad) {
 #if !defined(DISABLE_PMT) || !defined(DISABLE_T2MI)
     int aid = ad->id;
-#endif
     LOGM("adapter post_tune: aid %d", aid);
+#endif
 #ifndef DISABLE_PMT
     SPid *p_all = find_pid(aid, 8192);
     if (!p_all || p_all->flags == 3) { // add pids if not explicitly added

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -948,6 +948,7 @@ void post_tune(adapter *ad) {
 #if !defined(DISABLE_PMT) || !defined(DISABLE_T2MI)
     int aid = ad->id;
 #endif
+    LOGM("adapter post_tune: aid %d", aid);
 #ifndef DISABLE_PMT
     SPid *p_all = find_pid(aid, 8192);
     if (!p_all || p_all->flags == 3) { // add pids if not explicitly added
@@ -977,6 +978,8 @@ void post_tune(adapter *ad) {
 int tune(int aid, int sid) {
     adapter *ad = get_adapter(aid);
     int rv = 0, flush_data = 0;
+
+    LOGM("adapter tune: sid %d aid %d => sock: %d ", sid, aid, ad ? ad->sock : -1);
 
     if (!ad)
         return -400;

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -365,6 +365,7 @@ void satipc_close_rtsp_socket(adapter *ad, satipc *sip) {
         ad->fe = -1;
     ad->sock = -1;
     sip->wp = sip->qp = 0;
+    sip->option_no_option = 0;  // Clear this flag from any previous connection
 }
 
 void satipc_open_rtsp_socket(adapter *ad, satipc *sip) {
@@ -583,6 +584,8 @@ int satipc_open_device(adapter *ad) {
         }
     } else {
         ad->dvr = ad->fe;
+        if (ad->dvr >= 0)
+            set_socket_receive_buffer(ad->dvr, opts.dvr_buffer);
         ad->fe = -1;
         ad->fe_sock = sockets_add(SOCK_TIMEOUT, NULL, ad->id, TYPE_UDP, NULL,
                                   NULL, (socket_action)satipc_timeout);
@@ -614,6 +617,7 @@ int satipc_open_device(adapter *ad) {
     sip->enabled = 1;
     sip->rtsp_socket_closed = 0;
     sip->last_close = 0;
+    sip->option_no_option = 0;  // Clear this flag from any previous connection
     return 0;
 }
 
@@ -1053,7 +1057,6 @@ int satip_post_init(adapter *ad) {
     }
 
     sockets_setclose(ad->sock, satipc_close_rtsp);
-    set_socket_thread(ad->fe_sock, ad->thread);
     set_socket_thread(ad->fe_sock, ad->thread);
 
     if (!sip->option_no_option)


### PR DESCRIPTION
This patch fixes some small issues in the "satipc" module:
- Removes redundant thread call.
- Set correct DVR demux buffer size when using RTSP_OVER_TCP.
- When reopening the RTSP channel to a minisatip SAT>IP server send anyway the initial OPTIONS message.

In addition it adds two simple new logs to the adapter module.