### PR TITLE
Implementation of smooth undecrypted packets

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -348,6 +348,7 @@ Help\n\
 	- note: * as adapter means apply to all adapters\n\
 \n\
 * -E Allows encrypted stream to be sent to the client even if the decrypting is unsuccessful\n \
+       Duplicating it (-E -E) all unencrypted packets are send as stuffing TS packets. Usefull for regular player clients.\n\
 	- note: when pids=all is emulated this pass NULLs too\n\
 \n\
 * -Y --delsys ADAPTER1:DELIVERY_SYSTEM1[,ADAPTER2:DELIVERY_SYSTEM2[,..]] - specify the delivery system of the adapters (0 is the first adapter)	\n\
@@ -1054,7 +1055,7 @@ void set_options(int argc, char *argv[]) {
             break;
 
         case DROP_ENCRYPTED_OPT:
-            opts.drop_encrypted = 1 - opts.drop_encrypted;
+            opts.drop_encrypted = (opts.drop_encrypted == 0) ? 2 : (opts.drop_encrypted - 1);
             break;
 
         case XML_OPT:

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -348,7 +348,7 @@ Help\n\
 	- note: * as adapter means apply to all adapters\n\
 \n\
 * -E Allows encrypted stream to be sent to the client even if the decrypting is unsuccessful\n \
-       Duplicating it (-E -E) all unencrypted packets are send as stuffing TS packets. Usefull for regular player clients.\n\
+       Duplicating it (-E -E) all undecrypted packets are send as stuffing TS packets. Usefull for regular player clients.\n\
 	- note: when pids=all is emulated this pass NULLs too\n\
 \n\
 * -Y --delsys ADAPTER1:DELIVERY_SYSTEM1[,ADAPTER2:DELIVERY_SYSTEM2[,..]] - specify the delivery system of the adapters (0 is the first adapter)	\n\


### PR DESCRIPTION
Now when "drop_encrypted == 2" instead of filter out all non-PCR packets, we convert all undecrypted packets to TS packets with stuffing removing the PES payload. This will maintain the number of TS packets and the CC counters. Therefore, the resulting bitrate is identical to that of the original encrypted stream. And that it's more easy to handle for regular hardware and software decoders. Producing then a more smooth play when some part of the stream can't be decrypted.