### PR TITLE
Define character encoding when serving state.json

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -1558,8 +1558,10 @@ int read_http(sockets *s) {
     if (strcmp(arg[1], "/state.json") == 0) {
         char *buf = malloc1(JSON_STATE_MAXLEN);
         int len = get_json_state(buf, JSON_STATE_MAXLEN);
+        // Browsers will default to UTF-8 if no character set is specified, and 
+        // DVB networks rarely seem to use UTF-8 so let's go with ISO-8859-1 here.
         http_response(s, 200,
-                      "Content-Type: application/json\r\nConnection: close",
+                      "Content-Type: application/json; charset=ISO-8859-1\r\nConnection: close",
                       buf, 0, len);
         free(buf);
         return 0;


### PR DESCRIPTION
Fixes #398

Before:
![Screenshot-20221011145440-1245x388](https://user-images.githubusercontent.com/1106133/195083747-5a4bef51-e79e-4905-afd6-f105f08b7b5d.png)

After:
![Screenshot-20221011145139-1243x348](https://user-images.githubusercontent.com/1106133/195083762-dec322de-6dee-45c2-90ef-c012f2aec3c9.png)


