### PR TITLE
Use demux filters for pmts as previously. This fixes PMT processing on vu+

### DIFF
--- a/src/ddci.c
+++ b/src/ddci.c
@@ -425,7 +425,7 @@ int ddci_process_pmt(adapter *ad, SPMT *pmt) {
     {
         LOG("Mapping CAT to PMT %d from transponder %d, DDCI transponder %d",
             pmt->id, ad->transponder_id, d->tid)
-        add_pid_mapping_table(ad->id, 1, pmt->id, d, 1); // add pid 1
+        add_pid_mapping_table(ad->id, 1, pmt->id, d, 1);  // add pid 1
         d->cat_processed = 0;
     }
 

--- a/src/dvb.c
+++ b/src/dvb.c
@@ -1589,13 +1589,8 @@ int dvb_is_psi(adapter *ad, int pid) {
     if (pid < 32)
         return 1;
 #ifndef DISABLE_PMT
-    int fid = get_pid_filter(ad->id, pid);
-    if (fid < 0)
-        return 0;
-    SFilter *f = get_filter(fid);
-    if (f && (f->flags & FILTER_ADD_REMOVE))
-        return 0;
-    return 1;
+    if (get_pid_filter(ad->id, pid) >= 0)
+        return 1;
 #endif
     return 0;
 }

--- a/tests/test_ddci.c
+++ b/tests/test_ddci.c
@@ -474,8 +474,9 @@ int test_create_pmt() {
     f.id = 0;
     f.adapter = 0;
     filters[0] = &f;
-    d.pmt[0].id = 1; // set to pmt 1
-    pmts[1] = &pmt;  // enable pmt 1
+    pmt.id = 1;
+    d.pmt[0].id = pmt.id; // set to pmt 1
+    pmts[pmt.id] = &pmt;  // enable pmt 1
     npmts = 2;
     pmt.enabled = 1;
     pmt.sid = 0x66;
@@ -531,6 +532,8 @@ int test_create_pmt() {
     a[0] = &ad;
     ad.pids[0].pid = 0x99;
     ad.pids[0].flags = 1;
+    ad.active_pmts = 1;
+    ad.active_pmt[0] = pmt.id;
     process_pmt(0, psi + 1, psi_len, &new_pmt);
     filters[0] = NULL;
     ASSERT(new_pmt.stream_pids == pmt.stream_pids,


### PR DESCRIPTION
This also fixes ddci tests.