### PR TITLE
Add Tuner status type enforcement

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -1964,7 +1964,7 @@ void set_signal_multiplier(char *o) {
     int i, la, a_id;
     float strength_multiplier, snr_multiplier;
     char force_tuner_signal = TUNER_FORCE_NO;
-    char force_str[32];
+    char force_str[128];
     char buf[1000], *arg[40], *sep1, *sep2;
     adapter *ad;
     SAFE_STRCPY(buf, o);

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -64,6 +64,8 @@ struct struct_adapter {
     uint16_t db;  // if MAX_DB then no value, else value is dB*10 of the adapter
     float strength_multiplier, // final value: strength * strength_multipler,
         snr_multiplier;        // same for snr
+    char force_strength_mode,  // 0: No force (default) 1: Force Relative 2: Force Decibel
+        force_snr_mode;        // same for snr
     float db_snr_map;          // modulation scale value for dB SNR conversion
     uint32_t pid_err, dec_err; // detect pids received but not part of any
                                // stream, decrypt errors

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -15,10 +15,17 @@ typedef struct ca_device ca_device_t;
 #define RTSP_OPTIONS 3
 #define RTSP_TEARDOWN 4
 #define RTSP_DESCRIBE 5
+
 #define ADAPTER_DVB 1
 #define ADAPTER_SATIP 2
 #define ADAPTER_NETCV 3
 #define ADAPTER_CI 4
+
+#define TUNER_FORCE_NO 0
+#define TUNER_FORCE_STRENGTH_PERCENT 1
+#define TUNER_FORCE_STRENGTH_DECIBEL 2
+#define TUNER_FORCE_SNR_PERCENT 4
+#define TUNER_FORCE_SNR_DECIBEL 8
 
 #define MAX_DB 65535
 
@@ -64,8 +71,7 @@ struct struct_adapter {
     uint16_t db;  // if MAX_DB then no value, else value is dB*10 of the adapter
     float strength_multiplier, // final value: strength * strength_multipler,
         snr_multiplier;        // same for snr
-    char force_strength_mode,  // 0: No force (default) 1: Force Relative 2: Force Decibel
-        force_snr_mode;        // same for snr
+    char force_tuner_signal;   // Values: TUNER_FORCE_*
     float db_snr_map;          // modulation scale value for dB SNR conversion
     uint32_t pid_err, dec_err; // detect pids received but not part of any
                                // stream, decrypt errors

--- a/src/dvb.c
+++ b/src/dvb.c
@@ -1779,8 +1779,8 @@ void adapt_signal(adapter *ad, int *status, uint32_t *ber, uint16_t *strength,
     *snr = (int)snr_new;
     *db  = (int)db_new;
 
-    LOGM("adapt_signal adapter %d: strength %d (raw: %d),"
-         "snr %d (raw: %d), dB %d (raw: %d)",
+    LOGM("adapt_signal adapter %d: strength %d (raw: %lld),"
+         "snr %d (raw: %lld), dB %d (raw: %lld)",
          ad->id, *strength, strength_init, *snr, snr_init, *db, db_init);
 }
 

--- a/src/dvb.c
+++ b/src/dvb.c
@@ -1866,11 +1866,15 @@ int get_signal_new(adapter *ad, int *status, uint32_t *ber, uint16_t *strength,
     if (enum_cmdargs[1].u.st.stat[0].scale == FE_SCALE_RELATIVE) {
         snr_s = "%";
         snrd =
-            enum_cmdargs[1].u.st.stat[0].uvalue;
+            enum_cmdargs[1]
+                .u.st.stat[0]
+                .uvalue;
     } else if (enum_cmdargs[1].u.st.stat[0].scale == FE_SCALE_DECIBEL) {
         snr_s = "dB";
         init_snr =
-            enum_cmdargs[1].u.st.stat[0].svalue; // dB * 1000
+            enum_cmdargs[1]
+                .u.st.stat[0]
+                .svalue; // dB * 1000
         *db = (int)get_snr_decibels(&init_snr, ad->db_snr_map);
     }
     //	else if (enum_cmdargs[1].u.st.stat[0].scale == 0)

--- a/src/dvb.c
+++ b/src/dvb.c
@@ -1712,7 +1712,7 @@ int64_t get_strength_decibels(int64_t init_strength) {
 int64_t get_strength_percent(int64_t init_strength) {
     int64_t strength_pc;
 
-    strength_pc = (init_strength * 65535) / 100.0;
+    strength_pc = init_strength * 655.35; // (X * 65535) / 100.0
 
     return strength_pc;
 }
@@ -1735,7 +1735,7 @@ int64_t get_snr_decibels(int64_t init_snr, int64_t* snrd, float db_snr_map) {
 int64_t get_snr_percent(int64_t init_snr) {
     int64_t snr_pc;
 
-    snr_pc = (init_snr * 65535) / 100.0;
+    snr_pc = init_snr * 655.35; // (X * 65535) / 100.0
 
     return snr_pc;
 }

--- a/src/dvb.c
+++ b/src/dvb.c
@@ -1930,11 +1930,11 @@ int dvb_get_signal(adapter *ad) {
         if (!start && ad->new_gs == NEW_SIGNAL)
             get_signal_new(ad, &status, &ber, &strength, &snr, &dbvalue);
 
-        if (ad->new_gs == OLD_SIGNAL)
+        if (ad->new_gs == OLD_SIGNAL) {
             get_signal(ad, &status, &ber, &strength, &snr, &dbvalue);
-
-        if (ad->force_tuner_signal != TUNER_FORCE_NO)
-            adapt_signal(ad, &status, &ber, &strength, &snr, &dbvalue);
+            if (ad->force_tuner_signal != TUNER_FORCE_NO)
+                adapt_signal(ad, &status, &ber, &strength, &snr, &dbvalue);
+        }
     } else {
         status = 1;
         LOGM("Signal is not retrieved from the adapter as both signal "

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -402,9 +402,9 @@ Help\n\
 	* If the snr or the strength multipliers are set to 0, minisatip will override the value received from the adapter and will report always full signal 100%% \n\
 	* eg: -M 4-6:1.2-1.3 - multiplies the strength with 1.2 and the snr with 1.3 for adapter 4, 5 and 6\n\
 	* eg: -M *:1.5-1.6 - multiplies the strength with 1.5 and the snr with 1.6 for all adapters\n\
-	* [#] This symbol forces to read values as percentage\n\
-	* [@] This symbol forces to read values as decibels\n\
-	* eg: -M *:#1.0-@1.0 - not multiply the strength but force it as percentage and for the snr interpret it as decibels\n\
+	* [%] This symbol forces to read values as percentage\n\
+	* [#] This symbol forces to read values as decibels\n\
+	* eg: -M *:%1.0-#1.0 - not multiply the strength but force it as percentage and for the snr interpret it as decibels\n\
 \n\
 * -N --disable-dvb disable DVB adapter detection\n \
 \n\

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -402,6 +402,9 @@ Help\n\
 	* If the snr or the strength multipliers are set to 0, minisatip will override the value received from the adapter and will report always full signal 100%% \n\
 	* eg: -M 4-6:1.2-1.3 - multiplies the strength with 1.2 and the snr with 1.3 for adapter 4, 5 and 6\n\
 	* eg: -M *:1.5-1.6 - multiplies the strength with 1.5 and the snr with 1.6 for all adapters\n\
+	* [#] This symbol forces to read values as percentage\n\
+	* [@] This symbol forces to read values as decibels\n\
+	* eg: -M *:#1.0-@1.0 - not multiply the strength but force it as percentage and for the snr interpret it as decibels\n\
 \n\
 * -N --disable-dvb disable DVB adapter detection\n \
 \n\


### PR DESCRIPTION
For some adapters the DVB API version 5.5 is not available. In these cases the software can't distinguish the status reporting of the tuners. Therefore, the values of Strength and/or SNR could be incorrect. If you know how the driver of the tuner reports the data (in percentage or in dB), then you could tweak the values with the `-M --multiplier` parameter.

This patch adds the option to enforce percentage or decibel modes at tuner level (because you can mix different hardware and drivers in the same machine). Example:

`-M 0:%1.0-#1.0 -M 1:%1.0-#1.0 -M 2:2.0-1.0 -M 3:2.0-1.0`

In this case the first two tuners (DVB-S) use default values enforcing "percentage" for Strength and "dB" for SNR. And for the other two tuners (DVB-T2) the types aren't enforced but the Strength is doubled.

This removes all dependencies for Enigma2 boxes, and you will have the opportunity to set the correct types/values for all of your tuners.