### PR TITLE
Hide HTTP response of a reGET

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -2020,6 +2020,14 @@ void http_response(sockets *s, int rc, char *ah, char *desc, int cseq, int lr) {
     else
         proto = "RTSP";
 
+    // Check if the request is a "reGET" (successive non-standard HTTP request while streaming)
+    // Used when one HTTP client wants to change pids with a new GET request. This doesn't interrupts the streaming.
+    if (s->type == TYPE_HTTP && s->iteration > 1 && rc == 200) {
+        LOG("Reply hidden because another GET while streaming (handle %d) [%s:%d] iteration:%d, sock %d", s->sock,
+            get_sockaddr_host(s->sa, ra, sizeof(ra)), get_sockaddr_port(s->sa), s->iteration, s->id);
+        return;
+    }
+
     if (!ah || !ah[0])
         ah = public_str;
     if (!desc)


### PR DESCRIPTION
When one HTTP client wants to change the pid list it could send a new GET command identical to the first one with different pids. The current sever code can handle this non-standard use of the HTTP protocol. But without this extension the HTTP response is introduced in the middle of the streaming. And this generates noise from the client point of view. This new implementation changes the behaviour checking if the client sends multiple GET commands. In this case the response for the successive requests is automatically hidden. The result is that the streaming continues from the server to the client without any interruption.