### PR TITLE
Send all ECMs optionally

### DIFF
--- a/src/dvbapi.c
+++ b/src/dvbapi.c
@@ -643,7 +643,7 @@ int send_ecm(int filter_id, unsigned char *b, int len, void *opaque) {
         k->ecm_parity[i] = -1;
 
     if ((b[0] == 0x80 || b[0] == 0x81) && (b[0] & 1) == k->ecm_parity[i])
-        if !(opts.resend_ecm && (getTick() - k->last_ecm > 1000))
+        if (!(opts.resend_ecm && (getTick() - k->last_ecm > 1000)))
             return 0;
 
     old_parity = k->ecm_parity[i];

--- a/src/dvbapi.c
+++ b/src/dvbapi.c
@@ -643,7 +643,8 @@ int send_ecm(int filter_id, unsigned char *b, int len, void *opaque) {
         k->ecm_parity[i] = -1;
 
     if ((b[0] == 0x80 || b[0] == 0x81) && (b[0] & 1) == k->ecm_parity[i])
-        return 0;
+        if !(opts.resend_ecm && (getTick() - k->last_ecm > 1000))
+            return 0;
 
     old_parity = k->ecm_parity[i];
     k->ecm_parity[i] = b[0] & 1;

--- a/src/dvbapi.c
+++ b/src/dvbapi.c
@@ -643,7 +643,7 @@ int send_ecm(int filter_id, unsigned char *b, int len, void *opaque) {
         k->ecm_parity[i] = -1;
 
     if ((b[0] == 0x80 || b[0] == 0x81) && (b[0] & 1) == k->ecm_parity[i])
-        if (!(opts.resend_ecm && (getTick() - k->last_ecm > 1000)))
+        if (!opts.resend_ecm || (getTick() - k->last_ecm < 1000))
             return 0;
 
     old_parity = k->ecm_parity[i];

--- a/src/dvbapi.c
+++ b/src/dvbapi.c
@@ -642,9 +642,8 @@ int send_ecm(int filter_id, unsigned char *b, int len, void *opaque) {
     if ((getTick() - k->last_ecm > 1000) && !valid_cw)
         k->ecm_parity[i] = -1;
 
-    if ((b[0] == 0x80 || b[0] == 0x81) && (b[0] & 1) == k->ecm_parity[i])
-        if (!opts.resend_ecm || (getTick() - k->last_ecm < 1000))
-            return 0;
+    if (!opts.send_all_ecm && (b[0] == 0x80 || b[0] == 0x81) && (b[0] & 1) == k->ecm_parity[i])
+        return 0;
 
     old_parity = k->ecm_parity[i];
     k->ecm_parity[i] = b[0] & 1;

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -136,6 +136,7 @@ int rtsp, http, si, si1, ssdp1;
 // Options that don't have a short option available
 #define LONG_OPT_ONLY_START 1024
 #define VERSION_OPT (LONG_OPT_ONLY_START + 1)
+#define RESENDECM_OPT (LONG_OPT_ONLY_START + 2)
 
 static const struct option long_options[] = {
     {"adapters", required_argument, NULL, ADAPTERS_OPT},
@@ -146,6 +147,7 @@ static const struct option long_options[] = {
     {"bind-dev", required_argument, NULL, BIND_DEV_OPT},
     {"cache-dir", required_argument, NULL, CACHE_DIR_OPT},
     {"clean-psi", no_argument, NULL, CLEANPSI_OPT},
+    {"resend-ecm", no_argument, NULL, RESENDECM_OPT},
     {"delsys", required_argument, NULL, DELSYS_OPT},
     {"debug", required_argument, NULL, DEBUG_OPT},
     {"device-id", required_argument, NULL, DEVICEID_OPT},
@@ -440,6 +442,7 @@ Help\n\
 	192.168.9.9 is the host where oscam is running and 9000 is the port configured in dvbapi section in oscam.conf.\n\
 	* eg: -o /tmp/camd.socket \n\
 	/tmp/camd.socket is the local socket that can be used \n\
+* --resend-ecm When a key is invalid resend the same ECM to the server.\n\
 \n\
 "
 #endif
@@ -476,7 +479,7 @@ Help\n\
 	address 192.168.1.100 needs to be assigned to an interface on the server running minisatip.\n\
 	This feature is useful for AVM FRITZ!WLAN Repeater\n\
 	\n\
-*  --satip-xml <URL> Use the xml retrieved from a satip server to configure satip adapters \n\
+* -6 --satip-xml <URL> Use the xml retrieved from a satip server to configure satip adapters \n\
 	eg: --satip-xml http://localhost:8080/desc.xml \n\
 \n\
 * -O --satip-tcp Use RTSP over TCP instead of UDP for data transport \n\
@@ -856,6 +859,11 @@ void set_options(int argc, char *argv[]) {
 
         case CLEANPSI_OPT: {
             opts.clean_psi = 1;
+            break;
+        }
+
+        case RESENDECM_OPT: {
+            opts.resend_ecm = 1;
             break;
         }
 

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -136,7 +136,7 @@ int rtsp, http, si, si1, ssdp1;
 // Options that don't have a short option available
 #define LONG_OPT_ONLY_START 1024
 #define VERSION_OPT (LONG_OPT_ONLY_START + 1)
-#define RESENDECM_OPT (LONG_OPT_ONLY_START + 2)
+#define SENDALLECM_OPT (LONG_OPT_ONLY_START + 2)
 
 static const struct option long_options[] = {
     {"adapters", required_argument, NULL, ADAPTERS_OPT},
@@ -147,7 +147,7 @@ static const struct option long_options[] = {
     {"bind-dev", required_argument, NULL, BIND_DEV_OPT},
     {"cache-dir", required_argument, NULL, CACHE_DIR_OPT},
     {"clean-psi", no_argument, NULL, CLEANPSI_OPT},
-    {"resend-ecm", no_argument, NULL, RESENDECM_OPT},
+    {"send-all-ecm", no_argument, NULL, SENDALLECM_OPT},
     {"delsys", required_argument, NULL, DELSYS_OPT},
     {"debug", required_argument, NULL, DEBUG_OPT},
     {"device-id", required_argument, NULL, DEVICEID_OPT},
@@ -442,7 +442,7 @@ Help\n\
 	192.168.9.9 is the host where oscam is running and 9000 is the port configured in dvbapi section in oscam.conf.\n\
 	* eg: -o /tmp/camd.socket \n\
 	/tmp/camd.socket is the local socket that can be used \n\
-* --resend-ecm When a key is invalid resend the same ECM to the server.\n\
+* --send-all-ecm Pass all received ECM to the DVBAPI server. Warning: This option may overload your server. Use with caution. Not necessary for regular use.\n\
 \n\
 "
 #endif
@@ -863,8 +863,8 @@ void set_options(int argc, char *argv[]) {
             break;
         }
 
-        case RESENDECM_OPT: {
-            opts.resend_ecm = 1;
+        case SENDALLECM_OPT: {
+            opts.send_all_ecm = 1;
             break;
         }
 

--- a/src/opts.h
+++ b/src/opts.h
@@ -36,6 +36,7 @@ struct struct_opts {
     int tcp_threshold;
     int force_scan;
     int clean_psi;
+    int resend_ecm;
     int file_line;
     char *last_log;
     int dvbapi_port;

--- a/src/opts.h
+++ b/src/opts.h
@@ -36,7 +36,7 @@ struct struct_opts {
     int tcp_threshold;
     int force_scan;
     int clean_psi;
-    int resend_ecm;
+    int send_all_ecm;
     int file_line;
     char *last_log;
     int dvbapi_port;


### PR DESCRIPTION
~~By default when a key is invalid the same ECM is not resended to the server. This default behaviour has sense when the server has returned an invalid key for the ECM. However, with some busy cards resending the same ECM to the server will obtain a valid key. A new option is added to handle this specific case.~~

This new optionally parameter enables the passthrough of all received ECMs for a running service. By default only required ECM are passed to the DVBAPI server. This limits the bandwith and it's the common behaviour. However, in some specific cases it's preferable that the DVBAPI handles all ECMs. This option enables this. But take note that this could overload your server. Use with caution and only if it's necessary.
