### PR TITLE
Fix compare tunning if SR=auto in current tunning

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -1218,7 +1218,7 @@ int compare_tunning_parameters(int aid, transponder *tp) {
         get_absolute_source_for_adapter(aid, tp->diseqc, tp->sys) !=
             ad->tp.diseqc ||
         (tp->pol > 0 && tp->pol != ad->tp.pol) ||
-        (tp->sr > 1000 && tp->sr != ad->tp.sr) ||
+        (tp->sr > 1000 && ad->tp.sr > 1000 && tp->sr != ad->tp.sr) ||
         (tp->mtype != 6 && ad->tp.mtype != 6 && tp->mtype != ad->tp.mtype))
 
         return 1;


### PR DESCRIPTION
When comparing new and current tunning values, the SR could be AUTO. Not only for the "new" tunning, but also for the "current" tunning. This fixes the tunning when the "current" adapter tuning is using AUTO mode for SR, and the "new" request is forcing some value. In this edge case, we can consider that the current running value is the one corresponding to the current tunning mode. That's we trust the new request.