### PR TITLE
Fix "No data from server" when STATS ON

### DIFF
--- a/src/api/variables.c
+++ b/src/api/variables.c
@@ -314,8 +314,8 @@ int get_json_bandwidth(char *buf, int len) {
 \"writes\":%u,\n\
 \"fwrites\":%u,\n\
 \"ns_read\":%jd,\n\
-\"tt\":%jd\n\
-\"buffered\":%jd\n\
+\"tt\":%jd,\n\
+\"buffered\":%jd,\n\
 \"dropped\":%jd\n\
 }",
              c_bw, c_bw_dmx, c_tbw, c_reads, c_writes, c_failed_writes,


### PR DESCRIPTION
The commit https://github.com/catalinii/minisatip/commit/7e2d4181a6dc36bf9e043fdb1e128f3c4099c05a has introduced a bug in the generation of the `bandwidth.json` output. Therefore when enabling the Stats button in the UI a message with "No data from server" will be shown. The web browser indicates a syntax error parsing the received JSON data.

This PR fixes the incorrect JSON format typo.