### PR TITLE
Allow 64 instead of 20 PIDs per CI adapter

### DIFF
--- a/src/ddci.c
+++ b/src/ddci.c
@@ -1152,7 +1152,6 @@ int ddci_open_device(adapter *ad) {
     ad->sys[0] = 0;
     ad->adapter_timeout = 0;
     memset(d->pmt, -1, sizeof(d->pmt));
-    d->ncapid = 0;
     d->max_channels = MAX_CHANNELS_ON_CI;
     d->channels = 0;
     d->wo = 0;
@@ -1231,7 +1230,6 @@ int ddci_process_cat(int filter, unsigned char *b, int len, void *opaque) {
         add_pid_mapping_table(f->adapter, d->capid[i], d->pmt[0].id, d, 1);
     }
     d->cat_processed = 1;
-    d->ncapid = id;
     mutex_unlock(&d->mutex);
     update_pids(f->adapter);
     update_pids(d->id);

--- a/src/ddci.c
+++ b/src/ddci.c
@@ -1206,6 +1206,8 @@ int ddci_process_cat(int filter, unsigned char *b, int len, void *opaque) {
         caid = b[i + 2] * 256 + b[i + 3];
         if (id < MAX_CA_PIDS) {
             d->capid[id] = (b[i + 4] & 0x1F) * 256 + b[i + 5];
+        } else {
+            LOG("MAX_CA_PIDS (%d) reached for adapter %d", MAX_CA_PIDS, d->id);
         }
 
         LOG("CAT pos %d caid %04X, pid %d", id, caid, d->capid[id]);

--- a/src/ddci.c
+++ b/src/ddci.c
@@ -1205,10 +1205,11 @@ int ddci_process_cat(int filter, unsigned char *b, int len, void *opaque) {
             continue;
         caid = b[i + 2] * 256 + b[i + 3];
         if (id < MAX_CA_PIDS) {
-            d->capid[id++] = (b[i + 4] & 0x1F) * 256 + b[i + 5];
+            d->capid[id] = (b[i + 4] & 0x1F) * 256 + b[i + 5];
         }
 
-        LOG("CAT pos %d caid %04X, pid %d", id, caid, d->capid[id - 1]);
+        LOG("CAT pos %d caid %04X, pid %d", id, caid, d->capid[id]);
+        id++;
     }
 
     add_cat = 1;

--- a/src/ddci.h
+++ b/src/ddci.h
@@ -30,7 +30,7 @@ typedef struct ddci_device {
     int max_channels;
     ddci_pmt_t pmt[MAX_CHANNELS_ON_CI + 1];
     int cat_processed;
-    int capid[MAX_CA_PIDS + 1];
+    int capid[MAX_CA_PIDS];
     unsigned char *out;
     int ro[MAX_ADAPTERS], wo; // read offset per adapter
     uint64_t last_pat, last_pmt;

--- a/src/ddci.h
+++ b/src/ddci.h
@@ -8,7 +8,7 @@
 // number of pids for each ddci adapter to be stored in the mapping table
 #define MAX_CHANNELS_ON_CI 4
 #define PIDS_FOR_ADAPTER 128
-#define MAX_CA_PIDS 20
+#define MAX_CA_PIDS 64
 
 #define DDCI_BUFFER (100000 * 188)
 

--- a/src/ddci.h
+++ b/src/ddci.h
@@ -31,7 +31,6 @@ typedef struct ddci_device {
     ddci_pmt_t pmt[MAX_CHANNELS_ON_CI + 1];
     int cat_processed;
     int capid[MAX_CA_PIDS + 1];
-    int ncapid;
     unsigned char *out;
     int ro[MAX_ADAPTERS], wo; // read offset per adapter
     uint64_t last_pat, last_pmt;


### PR DESCRIPTION
20 PIDs is easily hit with a few channels. Not sure why I didn't catch this earlier.