### PR TITLE
Handle CWs out of cycle

### DIFF
--- a/src/pmt.c
+++ b/src/pmt.c
@@ -934,6 +934,11 @@ int send_cw(int pmt_id, int algo, int parity, uint8_t *cw, uint8_t *iv,
     c->pmt = master_pmt;
     c->cw_len = 16;
     c->time = getTick();
+    if (parity == pmt->parity && pmt->cw && pmt->last_update_cw > 0) {
+        LOG("CW %d for PMT %d (%s) Warning! New CW using the current parity",
+            c->id, pmt_id, pmt->name);
+        c->time = pmt->cw->time - 1000; // We set the time before the active CW
+    }
     c->set_time = 0;
     c->opaque = opaque;
     if (expiry == 0)
@@ -958,8 +963,9 @@ int send_cw(int pmt_id, int algo, int parity, uint8_t *cw, uint8_t *iv,
         ncws = i + 1;
 
     mutex_unlock(&cws_mutex);
-    LOG("CW %d for PMT %d (%s), master %d, pid %d, %s", c->id, pmt_id,
-        pmt->name, master_pmt, pmt->pid, cw_to_string(c, buf));
+    LOG("CW %d for PMT %d (%s), master %d, pid %d, for %s parity, %s", c->id, pmt_id,
+        pmt->name, master_pmt, pmt->pid,
+        c->parity != pmt->parity ? "next":"current", cw_to_string(c, buf));
     return 0;
 }
 

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -934,17 +934,18 @@ int send_cw(int pmt_id, int algo, int parity, uint8_t *cw, uint8_t *iv,
     c->pmt = master_pmt;
     c->cw_len = 16;
     c->time = getTick();
-    if (parity == pmt->parity && pmt->cw && pmt->last_update_cw > 0) {
-        LOG("CW %d for PMT %d (%s) Warning! New CW using the current parity",
-            c->id, pmt_id, pmt->name);
-        c->time = pmt->cw->time - 1000; // We set the time before the active CW
-    }
     c->set_time = 0;
     c->opaque = opaque;
     if (expiry == 0)
         c->expiry = c->time + MAX_CW_TIME;
     else
         c->expiry = c->time + expiry * 1000;
+
+    if (parity == pmt->parity && pmt->cw && pmt->last_update_cw > 0) {
+        LOG("CW %d for PMT %d (%s) Warning! New CW using the current parity",
+            c->id, pmt_id, pmt->name);
+        c->time = pmt->cw->time - 1000; // We set the time before the active CW
+    }
 
     if (algo < 2)
         c->cw_len = 8;


### PR DESCRIPTION
This patch handles a very edge case: When you receive a CW with the same parity of the current one.

The standard behavior is to only receive keys for the next parity cycle. However, in some rare cases a key using the same parity can be received. In principle we do not need to discard this key because we will do a check on the next key change. However, in some special case this could generate an error. This potential case appears when during the key change the buffer does not contain any PUSI packets to validate the key AND the packets are mixing both parities. In this special case, the selection of the "new" key for the "old" parity will not work. Therefore, in this case (and only in this case) it is preferable to use the old key that actually was working.
