### PR TITLE
Reduce pmt/ddci memory footprint and add ability to track it

### DIFF
--- a/html/status.html
+++ b/html/status.html
@@ -358,6 +358,45 @@
 			}
 		}
 
+		function getMemInfo(mem_info) {
+			var all_mem = 0
+			var module_mem = {}
+			var line_mem = {}
+			var i = 0
+			while (i < mem_info.length) {
+				if (mem_info[i].length > 0) {
+					const myArray = mem_info[i].split(":")
+					var file = myArray[0]
+					var line = myArray[1]
+					var size = parseInt(myArray[2])
+					if (!(file in module_mem)) {
+						module_mem[file] = size
+					} else {
+						module_mem[file] += size
+					}
+					var key = [file, line].join(':')
+					if (!(key in line_mem)) {
+						line_mem[key] = [size, 1]
+					} else {
+						var s, n
+						[s, n] = line_mem[key]
+						line_mem[key] = [s + size, n + 1]
+					}
+
+					all_mem += size
+
+				}
+				i++;
+			}
+			console.log(module_mem)
+			console.log(line_mem)
+			let all_mb = all_mem / 1048576
+			let s_mb = module_mem["socketworks.c"] / 1048576
+			return `Using ${all_mb.toPrecision(4)} MB, socketworks ${s_mb.toPrecision(4)} MB`
+
+		}
+
+
 		function getTable(state, oldstate) {
 
 			if (!state)
@@ -618,6 +657,7 @@
 			myTable += "<li><B>RTSP address:</B> " + state['rtsp_host'] + " -- <B>UUID:</B> " + state['uuid'] + " -- <B>BOOTID:</B> " + state['bootid'] + " -- <B>DEVICE-ID:</B> " + state['deviceid'] + "</li>"
 			myTable += "<li><B>Service Name:</B> " + state['name_app'] + " -- <B>Process ID:</B> " + state['run_pid'] + " -- <B>Run as ID:</B> " + state['run_user'] + "</span></li>"
 			myTable += "<li><b>Command line:</b> " + state['command_line'] + "</li>"
+			myTable += "<li><b>Mem Info:</b> " + getMemInfo(state['alloc']) + "</li>"
 			myTable += "<p style='text-align:center'><a href='satfinder.html'>Show satfinder page</a></p>";
 			myTable += "</ul></div>"
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -47,6 +47,7 @@ SOURCES=\
 	api/symbols.c \
 	api/variables.c \
 	utils/logging/logging.c \
+	utils/alloc.c \
 	utils/hash_table.c \
 	utils/mutex.c \
 	utils/ticks.c

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -27,6 +27,7 @@
 #include <time.h>
 #include <unistd.h>
 // #include <linux/ioctl.h>
+#include "utils/alloc.h"
 #include <sys/ioctl.h>
 
 #include "adapter.h"
@@ -73,7 +74,7 @@ char fe_map[2 * MAX_ADAPTERS];
 void find_dvb_adapter(adapter **a);
 
 adapter *adapter_alloc() {
-    adapter *ad = malloc1(sizeof(adapter));
+    adapter *ad = _malloc(sizeof(adapter));
     memset(ad, 0, sizeof(adapter));
 
     /* diseqc setup */
@@ -115,14 +116,13 @@ adapter *adapter_alloc() {
 
     if (!ad->buf) {
         ad->lbuf = opts.adapter_buffer;
-        ad->buf = malloc1(ad->lbuf + 10);
+        ad->buf = _malloc(ad->lbuf + 10);
     }
 
 #ifndef DISABLE_PMT
     // filter for pid 0
     ad->pat_filter = -1;
     ad->sdt_filter = -1;
-    ad->cache_pmts = 1;
 #endif
     return ad;
 }
@@ -441,7 +441,6 @@ int close_adapter(int na) {
         set_sockets_sid(sock, -1);
     }
     mutex_destroy(&ad->mutex);
-    //      if(a[na]->buf)free1(a[na]->buf);a[na]->buf=NULL;
     LOG("done closing adapter %d", na);
     for (i = 0; i < MAX_ADAPTERS; i++)
         if (a[i] && (a[i]->master_source == ad->id) && ad->enabled &&
@@ -1446,8 +1445,8 @@ void free_all_adapters() {
             if (a[i]->free)
                 a[i]->free(a[i]);
             if (a[i]->buf)
-                free1(a[i]->buf);
-            free(a[i]);
+                _free(a[i]->buf);
+            _free(a[i]);
             a[i] = NULL;
         }
 

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -102,7 +102,6 @@ struct struct_adapter {
     // keeps the PMTs that are present in the PAT
     int active_pmt[MAX_PMT_FOR_ADAPTER];
     int active_pmts;
-    int cache_pmts;
 #endif
 #ifdef AXE
     int fe2;

--- a/src/aes.c
+++ b/src/aes.c
@@ -17,7 +17,6 @@
  * USA
  *
  */
-
 #include "openssl/aes.h"
 #include "adapter.h"
 #include "aes.h"
@@ -27,6 +26,7 @@
 #include "socketworks.h"
 #include "tables.h"
 #include "utils.h"
+#include "utils/alloc.h"
 #include <arpa/inet.h>
 #include <ctype.h>
 #include <errno.h>
@@ -51,9 +51,9 @@
 
 #define DEFAULT_LOG LOG_PMT
 
-void dvbaes_create_key(SCW *cw) { cw->key = malloc1(sizeof(AES_KEY)); }
+void dvbaes_create_key(SCW *cw) { cw->key = _malloc(sizeof(AES_KEY)); }
 
-void dvbaes_delete_key(SCW *cw) { free1(cw->key); }
+void dvbaes_delete_key(SCW *cw) { _free(cw->key); }
 
 void dvbaes_set_cw(SCW *cw, SPMT *pmt) {
     AES_set_decrypt_key(cw->cw, 128, (AES_KEY *)cw->key);
@@ -263,7 +263,7 @@ int pkcs_1_mgf1(const uint8_t *seed, unsigned long seedlen, uint8_t *mask,
     hLen = 20; /* SHA1 */
 
     /* allocate memory */
-    buf = malloc(hLen);
+    buf = _malloc(hLen);
     if (buf == NULL) {
         LOG("error mem");
         return -1;
@@ -288,7 +288,7 @@ int pkcs_1_mgf1(const uint8_t *seed, unsigned long seedlen, uint8_t *mask,
             *mask++ = buf[x];
     }
 
-    free(buf);
+    _free(buf);
     return 0;
 }
 
@@ -305,13 +305,13 @@ int pkcs_1_pss_encode(const uint8_t *msghash, unsigned int msghashlen,
     modulus_len = (modulus_bitlen >> 3) + (modulus_bitlen & 7 ? 1 : 0);
 
     /* allocate ram for DB/mask/salt/hash of size modulus_len */
-    DB = malloc(modulus_len);
-    mask = malloc(modulus_len);
-    salt = malloc(modulus_len);
-    hash = malloc(modulus_len);
+    DB = _malloc(modulus_len);
+    mask = _malloc(modulus_len);
+    salt = _malloc(modulus_len);
+    hash = _malloc(modulus_len);
 
     hashbuflen = 8 + msghashlen + saltlen;
-    hashbuf = malloc(hashbuflen);
+    hashbuf = _malloc(hashbuflen);
 
     if (!(DB && mask && salt && hash && hashbuf)) {
         LOG("out of memory");
@@ -373,11 +373,11 @@ int pkcs_1_pss_encode(const uint8_t *msghash, unsigned int msghashlen,
 
     err = 0;
 LBL_ERR:
-    free(hashbuf);
-    free(hash);
-    free(salt);
-    free(mask);
-    free(DB);
+    _free(hashbuf);
+    _free(hash);
+    _free(salt);
+    _free(mask);
+    _free(DB);
 
     return err;
 }

--- a/src/api/symbols.c
+++ b/src/api/symbols.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2022 Catalin Toda <catalinii@yahoo.com>, 
+ * Copyright (C) 2014-2022 Catalin Toda <catalinii@yahoo.com>,
                            Sam Stenvall <neggelandia@gmail.com>,
                            et al.
  *
@@ -24,7 +24,7 @@
 #include "stdlib.h"
 
 // Define all symbols
-_symbols *sym[] = {adapters_sym, stream_sym, minisatip_sym,
+_symbols *sym[] = {adapters_sym, stream_sym, minisatip_sym, alloc_sym,
 #ifndef DISABLE_DVBCA
                    ca_sym,
 #endif
@@ -40,4 +40,5 @@ _symbols *sym[] = {adapters_sym, stream_sym, minisatip_sym,
 #ifdef AXE
                    axe_sym,
 #endif
+
                    NULL};

--- a/src/api/symbols.h
+++ b/src/api/symbols.h
@@ -14,6 +14,7 @@ typedef struct struct_symbols {
 extern _symbols adapters_sym[];
 extern _symbols minisatip_sym[];
 extern _symbols stream_sym[];
+extern _symbols alloc_sym[];
 #ifndef DISABLE_DVBCA
 extern _symbols ca_sym[];
 #endif

--- a/src/ddci.h
+++ b/src/ddci.h
@@ -10,7 +10,7 @@
 #define PIDS_FOR_ADAPTER 128
 #define MAX_CA_PIDS 64
 
-#define DDCI_BUFFER (100000 * 188)
+#define DDCI_BUFFER (20000 * 188)
 
 // keeps PMT informations for the channels that are enabled on this ddci_device
 typedef struct ddci_pmt {

--- a/src/minisatip.h
+++ b/src/minisatip.h
@@ -13,7 +13,7 @@
 #define EMU_PIDS_ALL_ENFORCED_PIDS_LIST 1, 16, 17, 18, 20, 21
 
 void set_options(int argc, char *argv[]);
-char* get_command_line_string(int argc, char *argv[]);
+char *get_command_line_string(int argc, char *argv[]);
 
 extern char pid_file[];
 extern char app_name[], version[];
@@ -42,15 +42,14 @@ extern char app_name[], version[];
 
 #define copy32r(v, a, i)                                                       \
     {                                                                          \
-        v = ((a[i] & 0xFF) << 24) | ((a[i + 1] & 0xFF) << 16) |                \
-            ((a[i + 2] & 0xFF) << 8) | (a[i + 3] & 0xFF);                      \
+        v = ((unsigned int)a[i] << 24) | ((unsigned int)a[i + 1] << 16) |      \
+            ((unsigned int)a[i + 2] << 8) | (unsigned int)a[i + 3];            \
     }
 #define copy32rr(v, a, i)                                                      \
     {                                                                          \
-        v = ((a[i + 3] & 0xFF) << 24) | ((a[i + 2] & 0xFF) << 16) |            \
-            ((a[i + 1] & 0xFF) << 8) | (a[i] & 0xFF);                          \
+        v = ((unsigned int)a[i + 3] << 24) | ((unsigned int)a[i + 2] << 16) |  \
+            ((unsigned int)a[i + 1] << 8) | (unsigned int)a[i];                \
     }
-
 int ssdp_discovery(sockets *s);
 int readBootID();
 void http_response(sockets *s, int rc, char *ah, char *desc, int cseq, int lr);

--- a/src/netceiver.c
+++ b/src/netceiver.c
@@ -433,7 +433,7 @@ void find_netcv_adapter(adapter **a) {
         if (!a[na])
             a[na] = adapter_alloc();
         if (!sn[na])
-            sn[na] = malloc1(sizeof(SNetceiver));
+            sn[na] = _malloc(sizeof(SNetceiver));
 
         ad = a[na];
         ad->pa = 0;

--- a/src/satipc.c
+++ b/src/satipc.c
@@ -28,6 +28,7 @@
 #include "minisatip.h"
 #include "pmt.h"
 #include "utils.h"
+#include "utils/alloc.h"
 #include "utils/hash_table.h"
 #include "utils/ticks.h"
 
@@ -878,7 +879,7 @@ int satipc_tcp_read(int socket, void *buf, int len, sockets *ss, int *rb) {
            sip->tcp_pos, sip->tcp_len, sip->tcp_size, len);
     if (!sip->tcp_data) {
         sip->tcp_size = TCP_DATA_SIZE;
-        sip->tcp_data = malloc1(sip->tcp_size + 3);
+        sip->tcp_data = _malloc(sip->tcp_size + 3);
         if (!sip->tcp_data)
             LOG_AND_RETURN(-1, "Cannot alloc memory for tcp_data with size %d",
                            sip->tcp_size);
@@ -1545,7 +1546,7 @@ int add_satip_server(char *host, int port, int fe, char delsys, char *source_ip,
             if (!a[i])
                 a[i] = adapter_alloc();
             if (!satip[i]) {
-                satip[i] = malloc1(sizeof(satipc));
+                satip[i] = _malloc(sizeof(satipc));
                 if (satip[i])
                     memset(satip[i], 0, sizeof(satipc));
             }
@@ -1813,7 +1814,7 @@ int satip_getxml(void *x) {
 }
 
 char *init_satip_pointer(int len) {
-    char *p = malloc1(len);
+    char *p = _malloc(len);
     if (p)
         p[0] = 0;
     else

--- a/src/stream.c
+++ b/src/stream.c
@@ -45,6 +45,7 @@
 #include "socketworks.h"
 #include "stream.h"
 #include "t2mi.h"
+#include "utils/alloc.h"
 #include "utils/ticks.h"
 
 #define DEFAULT_LOG LOG_STREAM
@@ -1220,7 +1221,7 @@ void free_all_streams() {
 
     for (i = 0; i < MAX_STREAMS; i++) {
         if (st[i])
-            free1(st[i]);
+            _free(st[i]);
         st[i] = NULL;
     }
 }

--- a/src/t2mi.c
+++ b/src/t2mi.c
@@ -42,6 +42,7 @@
 #include "t2mi.h"
 #include "tables.h"
 #include "utils.h"
+#include "utils/alloc.h"
 
 #define DEFAULT_LOG LOG_STREAM
 
@@ -55,7 +56,7 @@ t2mi_device_t *get_or_alloc_t2mi(int id) {
         return NULL;
 
     LOG("Allocating t2mi for device %d", id);
-    t2[id] = malloc1(sizeof(t2mi_device_t));
+    t2[id] = _malloc(sizeof(t2mi_device_t));
     return t2[id];
 }
 
@@ -110,7 +111,7 @@ void free_t2mi() {
     int i;
     for (i = 0; i < MAX_ADAPTERS; i++)
         if (t2[i]) {
-            free1(t2[i]);
+            _free(t2[i]);
             t2[i] = NULL;
         }
 }

--- a/src/tables.c
+++ b/src/tables.c
@@ -175,9 +175,9 @@ int tables_init_ca_for_device(int i, adapter *ad) {
 int match_caid(SPMT *pmt, int caid, int mask) {
     int i;
     for (i = 0; i < pmt->caids; i++)
-        if ((pmt->ca[i].id & mask) == caid) {
+        if ((pmt->ca[i]->id & mask) == caid) {
             LOGM("%s: match caid %04X (%d/%d) with CA caid %04X and mask %04X",
-                 __FUNCTION__, pmt->ca[i].id, i, pmt->caids, caid, mask);
+                 __FUNCTION__, pmt->ca[i]->id, i, pmt->caids, caid, mask);
             return 1;
         }
     return 0;

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,9 +15,6 @@ int map_int(char *s, char **v);
 int map_intd(char *s, char **v, int dv);
 int map_float(char *s, int mul);
 int check_strs(char *s, char **v, int dv);
-void *mymalloc(int a, char *f, int l);
-void *myrealloc(void *p, int a, char *f, int l);
-void myfree(void *x, char *f, int l);
 char *header_parameter(char **arg, int i);
 char *get_current_timestamp();
 char *strip(char *s);
@@ -54,10 +51,6 @@ void _strncpy(char *a, char *b, int len);
 #define hexdump(message, b, len)                                               \
     if (DEFAULT_LOG & opts.debug)                                              \
     _hexdump(message, b, len)
-
-#define malloc1(a) mymalloc(a, __FILE__, __LINE__)
-#define free1(a) myfree(a, __FILE__, __LINE__)
-#define realloc1(a, b) myrealloc(a, b, __FILE__, __LINE__)
 
 #define strlcatf(buf, size, ptr, fmt...)                                       \
     do {                                                                       \

--- a/src/utils/alloc.c
+++ b/src/utils/alloc.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2014-2022 Catalin Toda <catalinii@yahoo.com> et al
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+ * USA
+ *
+ */
+#include "api/symbols.h"
+#include "api/variables.h"
+#include "utils/hash_table.h"
+#include "utils/logging/logging.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+SHashTable mem_alloc_table;
+#define DEFAULT_LOG LOG_UTILS
+
+typedef struct struct_memory_allocation {
+    void *data;
+    char *file;
+    int line;
+    int struct_size;
+    int pointer_size;
+    int current_size;
+    int min_size;
+    int size_bytes;
+} SMEMALLOC;
+static __thread int running;
+
+int record_allocation(void *old, void *x, int size_bytes, int current_size,
+                      int min_len, int pointer_size, int struct_size, char *f,
+                      int l) {
+    int rv = 0;
+    if (running)
+        return 0;
+    // prevent hash table from calling record_allocation multiple times
+    running = 1;
+    if (old) {
+        SMEMALLOC *s = getItem(&mem_alloc_table, (uintptr_t)old);
+        if (s)
+            rv = s->size_bytes;
+        delItem(&mem_alloc_table, (uintptr_t)old);
+    }
+    SMEMALLOC s = {.data = x,
+                   .file = f,
+                   .line = l,
+                   .size_bytes = size_bytes,
+                   .current_size = current_size,
+                   .min_size = min_len,
+                   .pointer_size = pointer_size,
+                   .struct_size = struct_size};
+    _setItem(&mem_alloc_table, (uintptr_t)x, &s, sizeof(s), 1);
+    running = 0;
+    return rv;
+}
+void *malloc1(int a, char *f, int l, int record) {
+    void *x = malloc(a);
+    if (x)
+        memset(x, 0, a);
+    if (!mem_alloc_table.init)
+        return x;
+    alloc_sym[0].len = mem_alloc_table.size;
+    if (record) {
+        record_allocation(NULL, x, a, a, a, 1, 0, f, l);
+    }
+    LOGM("%s:%d malloc allocated %d bytes at %p", f, l, a, x);
+    if (!x)
+        LOG0("Failed allocating %d bytes of memory", a)
+    return x;
+}
+
+void *realloc1(void *p, int a, char *f, int l, int record) {
+    int old_mem = 0;
+    void *x = realloc(p, a);
+    if (record) {
+        old_mem = record_allocation(p, x, a, a, a, 1, 0, f, l);
+    }
+    LOGM("%s:%d realloc allocated %d bytes from %d: %p -> %p", f, l, a, old_mem,
+         p, x);
+    if (!x) {
+        LOG0("Failed allocating %d bytes of memory", a)
+        if (!strcmp(f, "socketworks.c"))
+            LOG0("Try to decrease the parameters -b and/or -B")
+    }
+    return x;
+}
+
+void free1(void *x, char *f, int l) {
+    LOGM("%s:%d free called with argument %p", f, l, x);
+    if (mem_alloc_table.init)
+        delItem(&mem_alloc_table, (uintptr_t)x);
+    free(x);
+}
+
+int _ensure_allocated(void **x, int struct_size, int pointer_size,
+                      int ensure_length, int min_elements, char *file,
+                      int line) {
+    int do__realloc = 0, new_size = 0, current_size = 0;
+    void *result = NULL;
+    SMEMALLOC *s = getItem(&mem_alloc_table, (uintptr_t)*x);
+    if (!*x || !s) {
+        if (*x)
+            LOG("%s:%d expected to find pointer %p in allocation table", file,
+                line, x);
+        do__realloc = 1;
+        new_size = ((ensure_length / min_elements) + 1) * min_elements;
+    }
+    if (s && s->current_size >= ensure_length)
+        return 0;
+
+    if (s && s->current_size < ensure_length) {
+        do__realloc = 1;
+        new_size = 2 * s->current_size;
+        current_size = s->current_size;
+    }
+    if (do__realloc) {
+        int cs = struct_size + pointer_size * current_size;
+        int ns = struct_size + pointer_size * new_size;
+        if (current_size == 0)
+            cs = 0;
+        result =
+            realloc1(*x, struct_size + pointer_size * new_size, file, line, 0);
+        if (!result)
+            LOG_AND_RETURN(1, "Could not _reallocate %d bytes of memory to %d",
+                           cs, ns);
+
+        if (current_size > 0 || !*x) {
+            memset(result + cs, 0, ns - cs);
+        }
+        record_allocation(*x, result, ns, new_size, min_elements, pointer_size,
+                          struct_size, file, line);
+        *x = result;
+        LOGM("%s:%d _reallocated %d (%d) [struct %d, pointer %d] records from "
+             "%d (%d) for "
+             "index %d",
+             file, line, new_size, ns, struct_size, pointer_size, current_size,
+             cs, ensure_length);
+    }
+    return 0;
+}
+
+void init_alloc() { create_hash_table(&mem_alloc_table, 100); }
+void free_alloc() { free_hash(&mem_alloc_table); }
+
+char *get_alloc_info(int id, char *dest, int max_size) {
+    dest[0] = 0;
+    if (mem_alloc_table.items[id].len > 0) {
+        SMEMALLOC *s = (SMEMALLOC *)mem_alloc_table.items[id].data;
+        snprintf(dest, max_size, "%s:%d:%d", s->file, s->line, s->size_bytes);
+    }
+
+    return dest;
+}
+
+_symbols alloc_sym[] = {
+    {"alloc", VAR_FUNCTION_STRING, (void *)&get_alloc_info, 0, 1, 0},
+    {NULL, 0, NULL, 0, 0, 0}};

--- a/src/utils/alloc.h
+++ b/src/utils/alloc.h
@@ -1,0 +1,21 @@
+#ifndef ALLOC_H
+#define ALLOC_H
+#define _GNU_SOURCE
+
+void *malloc1(int a, char *f, int l, int r);
+void *realloc1(void *p, int a, char *f, int l, int r);
+void free1(void *x, char *f, int l, int r);
+int _ensure_allocated(void **x, int struct_size, int pointer_size,
+                      int ensure_length, int min_elements, char *file,
+                      int line);
+
+void init_alloc();
+void free_alloc();
+
+#define _malloc(a) malloc1(a, __FILE__, __LINE__, 1)
+#define _free(a) free1(a, __FILE__, __LINE__, 1)
+#define _realloc(a, b) realloc1(a, b, __FILE__, __LINE__, 1)
+#define ensure_allocated(a, b, c, d, e)                                        \
+    _ensure_allocated(a, b, c, d, e, __FILE__, __LINE__)
+
+#endif

--- a/src/utils/hash_table.h
+++ b/src/utils/hash_table.h
@@ -26,6 +26,8 @@ typedef struct hash_table {
     SHashItem *items;
     int64_t conflicts;
     SMutex mutex;
+    char *file;
+    int line;
 } SHashTable;
 
 #define HASH_ITEM_ENABLED(h) (h.len)
@@ -33,16 +35,21 @@ typedef struct hash_table {
     for (i = 0; i < (h)->size; i++)                                            \
         if (HASH_ITEM_ENABLED((h)->items[i]) && (a = (h)->items[i].data))
 
-int create_hash_table(SHashTable *hash, int no);
+int _create_hash_table(SHashTable *hash, int no, char *f, int l);
 void copy_hash_table(SHashTable *s, SHashTable *d);
 void free_hash(SHashTable *hash);
-void *getItem(SHashTable *hash, uint32_t key);
-int getItemLen(SHashTable *hash, uint32_t key);
+void *getItem(SHashTable *hash, uint64_t key);
+int getItemLen(SHashTable *hash, uint64_t key);
 #define setItem(a, b, c, d) _setItem(a, b, c, d, 1)
-int _setItem(SHashTable *hash, uint32_t key, void *data, int len, int copy);
-int delItem(SHashTable *hash, uint32_t key);
+int _setItem(SHashTable *hash, uint64_t key, void *data, int len, int copy);
+int delItem(SHashTable *hash, uint64_t key);
 int delItemP(SHashTable *hash, void *p);
-int getItemSize(SHashTable *hash, uint32_t key);
-int setItemLen(SHashTable *hash, uint32_t key, int len);
+int getItemSize(SHashTable *hash, uint64_t key);
+int setItemLen(SHashTable *hash, uint64_t key, int len);
+
+void init_alloc();
+void free_alloc();
+
+#define create_hash_table(a, b) _create_hash_table(a, b, __FILE__, __LINE__)
 
 #endif

--- a/tests/test_ca.c
+++ b/tests/test_ca.c
@@ -25,6 +25,7 @@
 #include "minisatip.h"
 #include "socketworks.h"
 #include "utils.h"
+#include "utils/alloc.h"
 #include "utils/testing.h"
 #include <arpa/inet.h>
 #include <ctype.h>
@@ -84,23 +85,27 @@ int test_multiple_pmt() {
 
 int test_create_capmt() {
     uint8_t clean[1500];
-    pmt_add(5, 0, 500, 500);
-    pmt_add(6, 0, 600, 600);
-    add_pmt_to_capmt(&d, get_pmt(5), 1);
-    add_pmt_to_capmt(&d, get_pmt(6), 1);
-    SPMT *pmt = get_pmt(5);
+    int p1 = pmt_add(0, 500, 500, 0);
+    int p2 = pmt_add(0, 600, 600, 0);
+    add_pmt_to_capmt(&d, get_pmt(p1), 1);
+    add_pmt_to_capmt(&d, get_pmt(p2), 1);
+    SPMT *pmt = get_pmt(p1);
     pmt->stream_pids = 2;
-    pmt->stream_pid[0].pid = 501;
-    pmt->stream_pid[0].type = 2;
-    pmt->stream_pid[0].pid = 502;
-    pmt->stream_pid[0].type = 3;
+    pmt->stream_pid[0] = _malloc(sizeof(SStreamPid));
+    pmt->stream_pid[0]->pid = 501;
+    pmt->stream_pid[0]->type = 2;
+    pmt->stream_pid[0]->pid = 502;
+    pmt->stream_pid[0]->type = 3;
+    pmt->stream_pid[1] = _malloc(sizeof(SStreamPid));
 
-    pmt = get_pmt(6);
+    pmt = get_pmt(p2);
     pmt->stream_pids = 2;
-    pmt->stream_pid[0].pid = 601;
-    pmt->stream_pid[0].type = 2;
-    pmt->stream_pid[0].pid = 602;
-    pmt->stream_pid[0].type = 3;
+    pmt->stream_pid[0] = _malloc(sizeof(SStreamPid));
+    pmt->stream_pid[0]->pid = 601;
+    pmt->stream_pid[0]->type = 2;
+    pmt->stream_pid[0]->pid = 602;
+    pmt->stream_pid[0]->type = 3;
+    pmt->stream_pid[1] = _malloc(sizeof(SStreamPid));
 
     int len = create_capmt(d.capmt, 1, clean, sizeof(clean), 0, 0);
     if (len <= 0)

--- a/tests/test_ddci.c
+++ b/tests/test_ddci.c
@@ -26,6 +26,7 @@
 #include "minisatip.h"
 #include "socketworks.h"
 #include "utils.h"
+#include "utils/alloc.h"
 #include "utils/testing.h"
 #include "utils/ticks.h"
 #include <arpa/inet.h>
@@ -58,32 +59,20 @@ extern ddci_device_t *ddci_devices[MAX_ADAPTERS];
 extern adapter *a[MAX_ADAPTERS];
 extern SPMT *pmts[MAX_PMT];
 extern int npmts;
-extern int dvbca_id;
+extern SCA_op dvbca;
 extern ca_device_t *ca_devices[MAX_ADAPTERS];
 extern SHashTable channels;
 extern SFilter *filters[MAX_FILTERS];
 
-void create_pmt(SPMT *pmt, int id, int ad, int sid, int pid1, int pid2,
-                int caid1, int caid2) {
-    memset(pmt, 0, sizeof(*pmt));
-    pmt->id = id;
-    pmt->sid = sid;
-    pmt->adapter = ad;
-    pmt->pid = id * 1000;
-    pmt->stream_pid[0].pid = pid1;
-    pmt->stream_pid[0].type = 2;
-    pmt->stream_pid[1].pid = pid2;
-    pmt->stream_pid[0].type = 6;
-    pmt->stream_pids = 2;
-    pmt->ca[0].id = caid1;
-    pmt->ca[0].pid = caid1;
-    pmt->ca[1].id = caid2;
-    pmt->ca[1].pid = caid2;
-    pmt->caids = 2;
-    pmts[id] = pmt;
-    if (npmts <= id) {
-        npmts = id + 1;
-    }
+SPMT *create_pmt(int ad, int sid, int pid1, int pid2, int caid1, int caid2) {
+    int pmt_id = pmt_add(ad, sid, 1000, 10);
+    SPMT *pmt = get_pmt(pmt_id);
+    pmt->pid = pmt_id * 1000;
+    pmt_add_stream_pid(pmt, pid1, 2, 0, 1, 0);
+    pmt_add_stream_pid(pmt, pid2, 6, 1, 0, 0);
+    pmt_add_caid(pmt, caid1, caid1, NULL, 0);
+    pmt_add_caid(pmt, caid2, caid2, NULL, 0);
+    return pmt;
 }
 
 void create_adapter(adapter *ad, int id) {
@@ -118,7 +107,7 @@ int test_channels() {
 
 int test_add_del_pmt() {
     int i;
-    SPMT pmt0, pmt1, pmt2, pmt3;
+    SPMT *pmt0, *pmt1, *pmt2, *pmt3;
     ddci_device_t d0, d1;
     ca_device_t ca0, ca1;
     adapter ad, a0, a1;
@@ -127,10 +116,10 @@ int test_add_del_pmt() {
     create_adapter(&a0, 0);
     create_adapter(&a1, 1);
 
-    create_pmt(&pmt0, 0, 8, 100, 101, 102, 0x100, 0x1800);
-    create_pmt(&pmt1, 1, 8, 200, 201, 202, 0x100, 0x500);
-    create_pmt(&pmt2, 2, 8, 300, 301, 302, 0x500, 0x100);
-    create_pmt(&pmt3, 3, 8, 400, 401, 402, 0x600, 0x601);
+    pmt0 = create_pmt(8, 100, 101, 102, 0x100, 0x1800);
+    pmt1 = create_pmt(8, 200, 201, 202, 0x100, 0x500);
+    pmt2 = create_pmt(8, 300, 301, 302, 0x500, 0x100);
+    pmt3 = create_pmt(8, 400, 401, 402, 0x600, 0x601);
     memset(&d0, 0, sizeof(d0));
     memset(&d1, 0, sizeof(d1));
     memset(&d0.pmt, -1, sizeof(d0.pmt));
@@ -144,7 +133,7 @@ int test_add_del_pmt() {
     create_hash_table(&d1.mapping, 30);
     create_hash_table(&channels, 30);
 
-    dvbca_init();
+    int dvbca_id = add_ca(&dvbca, 0xFFFFFFFF);
     // DD 0 - 0x100, DD 1 - 0x500
     add_caid_mask(dvbca_id, 0, 0x100, 0xFFFF);
     add_caid_mask(dvbca_id, 1, 0x500, 0xFFFF);
@@ -159,19 +148,19 @@ int test_add_del_pmt() {
     ca_devices[0] = &ca0;
     ca_devices[1] = &ca1;
     // No matching DDCI
-    ASSERT(ddci_process_pmt(&ad, &pmt3) == TABLES_RESULT_ERROR_RETRY,
+    ASSERT(ddci_process_pmt(&ad, pmt3) == TABLES_RESULT_ERROR_RETRY,
            "DDCI not ready, expected retry");
 
     ca0.state = CA_STATE_INITIALIZED;
-    ASSERT(ddci_process_pmt(&ad, &pmt3) == TABLES_RESULT_ERROR_NORETRY,
+    ASSERT(ddci_process_pmt(&ad, pmt3) == TABLES_RESULT_ERROR_NORETRY,
            "DDCI ready, expected no retry");
 
     // One matching channel
-    ASSERT(ddci_process_pmt(&ad, &pmt0) == TABLES_RESULT_OK,
+    ASSERT(ddci_process_pmt(&ad, pmt0) == TABLES_RESULT_OK,
            "DDCI matching DD 0");
     ASSERT(d0.pmt[0].id == 0, "PMT 0 using DDCI 0");
 
-    ASSERT(ddci_process_pmt(&ad, &pmt1) == TABLES_RESULT_OK,
+    ASSERT(ddci_process_pmt(&ad, pmt1) == TABLES_RESULT_OK,
            "DDCI matching DD 1");
     ASSERT(d1.pmt[0].id == 1, "PMT 1 using DDCI 1");
     d0.max_channels = d1.max_channels = 2;
@@ -179,19 +168,15 @@ int test_add_del_pmt() {
     // Multiple PMTs
     Sddci_channel c;
     memset(&c, 0, sizeof(c));
-    c.sid = pmt2.sid;
+    c.sid = pmt2->sid;
     c.locked = 1;
     c.ddci[c.ddcis++].ddci = 1;
     setItem(&channels, c.sid, &c, sizeof(c));
 
-    int s = pmt2.stream_pids++;
-    int c2 = pmt2.caids++;
-    pmt2.stream_pid[s].pid = 0xFF;
-    pmt2.stream_pid[s].type = 2;
-    pmt2.ca[c2].id = 0x502;
-    pmt2.ca[c2].pid = 0xFE;
+    pmt_add_stream_pid(pmt2, 0xFF, 2, 0, 1, 0);
+    pmt_add_caid(pmt2, 0x502, 0xFE, NULL, 0);
 
-    ASSERT(ddci_process_pmt(&ad, &pmt2) == TABLES_RESULT_OK,
+    ASSERT(ddci_process_pmt(&ad, pmt2) == TABLES_RESULT_OK,
            "DDCI matching DD 0 for second PMT");
     ASSERT(d1.pmt[1].id == 2, "PMT 2 using DDCI 1");
 
@@ -218,10 +203,9 @@ int test_add_del_pmt() {
     m = get_pid_mapping_allddci(ad.id, 0xFE);
     ASSERT(m != NULL, "Newly added capid not found in mapping table");
 
-    ddci_del_pmt(&ad, &pmt1);
-    ddci_del_pmt(&ad, &pmt0);
-    ddci_del_pmt(&ad, &pmt2);
-
+    ddci_del_pmt(&ad, pmt1);
+    ddci_del_pmt(&ad, pmt0);
+    ddci_del_pmt(&ad, pmt2);
     ec = 0;
     FOREACH_ITEM(&d0.mapping, m) { ec++; }
     FOREACH_ITEM(&d1.mapping, m) { ec++; }
@@ -230,17 +214,15 @@ int test_add_del_pmt() {
     free_hash(&d1.mapping);
     free_hash(&channels);
     free_filters();
-
     return 0;
 }
-
 int test_push_ts_to_ddci() {
     ddci_device_t d;
     adapter ad;
     uint8_t buf[188 * 10];
     d.id = 0;
     d.enabled = 1;
-    d.out = malloc1(DDCI_BUFFER + 10);
+    d.out = _malloc(DDCI_BUFFER + 10);
     d.wo = DDCI_BUFFER - 188;
     memset(d.ro, -1, sizeof(d.ro));
     d.ro[0] = 188;
@@ -258,7 +240,7 @@ int test_push_ts_to_ddci() {
     push_ts_to_ddci_buffer(&d, buf, 376);
     if (d.wo != 376 || d.ro[0] != 752)
         LOG_AND_RETURN(1, "push 376 bytes");
-    free1(d.out);
+    _free(d.out);
     return 0;
 }
 
@@ -272,7 +254,7 @@ int test_copy_ts_from_ddci() {
     memset(buf2, 0, sizeof(buf2));
     d.id = 0;
     d.enabled = 1;
-    d.out = malloc1(DDCI_BUFFER + 10);
+    d.out = _malloc(DDCI_BUFFER + 10);
     create_hash_table(&d.mapping, 30);
     memset(ddci_devices, 0, sizeof(ddci_devices));
     ddci_devices[0] = &d;
@@ -312,7 +294,7 @@ int test_copy_ts_from_ddci() {
     if (1 != push_ts_to_adapter(&ad, buf, pid, &ad_pos))
         LOG_AND_RETURN(1, "buffer full not returned correctly");
 
-    free1(d.out);
+    _free(d.out);
     free_hash(&d.mapping);
     return 0;
 }
@@ -349,7 +331,7 @@ int test_ddci_process_ts() {
     memset(buf, 0, sizeof(buf));
     d.id = 0;
     d.enabled = 1;
-    d.out = malloc1(DDCI_BUFFER + 10);
+    d.out = _malloc(DDCI_BUFFER + 10);
     create_hash_table(&d.mapping, 30);
     memset(ddci_devices, 0, sizeof(ddci_devices));
     ddci_devices[0] = &d;
@@ -364,6 +346,7 @@ int test_ddci_process_ts() {
     a[0]->enabled = 1;
     a[1] = &ad;
     buf[0] = 0x47;
+    SPMT *save = pmts[0];
     pmts[0] = NULL;
     add_pid_mapping_table(5, 1000, 0, &d, 0);
     add_pid_mapping_table(5, 2000, 0, &d, 0);
@@ -398,40 +381,37 @@ int test_ddci_process_ts() {
     if (d.ro[1] != 188 && d.wo != 188 * 2)
         LOG_AND_RETURN(1, "indexes in DDCI devices set wrong ro %d wo %d", d.ro,
                        d.wo);
-    free1(d.out);
+    _free(d.out);
     free_hash(&d.mapping);
+    pmts[0] = save;
     return 0;
 }
 int test_create_pat() {
     ddci_device_t d;
     uint8_t psi[188];
     uint8_t packet[188];
-    SPMT pmt;
+    int pid = 4096;
+    int pmt_id = pmt_add(0, 0x66, pid, 0);
     char cc;
     int psi_len;
     SFilter f;
     adapter ad;
-    memset(&pmt, 0, sizeof(pmt));
     create_adapter(&ad, 0);
 
     memset(&d, 0, sizeof(d));
     d.id = 0;
     d.enabled = 1;
+    SPMT *pmt = get_pmt(pmt_id);
     create_hash_table(&d.mapping, 30);
     memset(ddci_devices, 0, sizeof(ddci_devices));
     ddci_devices[0] = &d;
-    int pid = 4096;
+
     add_pid_mapping_table(9, pid, 0, &d, 0);
     int dpid = add_pid_mapping_table(0, pid, 0, &d, 0);
     f.flags = FILTER_CRC;
     f.id = 0;
     f.adapter = 0;
-    d.pmt[0].id = 1; // set to pmt 1
-    pmts[1] = &pmt;  // enable pmt 1
-    npmts = 2;
-    pmt.enabled = 1;
-    pmt.sid = 0x66;
-    pmt.pid = pid;
+    d.pmt[0].id = pmt->id;
     psi_len = ddci_create_pat(&d, psi);
     cc = 1;
     buffer_to_ts(packet, 188, psi, psi_len, &cc, 0);
@@ -443,8 +423,8 @@ int test_create_pat() {
     new_pid &= 0x1FFF;
     if (new_pid != dpid)
         LOG_AND_RETURN(1, "PAT pid %d != mapping table pid %d", new_pid, dpid);
-    if (new_sid != pmt.sid)
-        LOG_AND_RETURN(1, "PAT sid %d != pmt sid %d", new_sid, pmt.sid);
+    if (new_sid != pmt->sid)
+        LOG_AND_RETURN(1, "PAT sid %d != pmt sid %d", new_sid, pmt->sid);
     free_hash(&d.mapping);
     return 0;
 }
@@ -453,13 +433,11 @@ int test_create_pmt() {
     ddci_device_t d;
     uint8_t psi[188];
     uint8_t packet[188];
-
-    SPMT pmt;
+    adapter ad;
     char cc;
     int psi_len;
     SFilter f;
     memset(&d, 0, sizeof(d));
-    memset(&pmt, 0, sizeof(pmt));
     d.id = 0;
     d.enabled = 1;
     a[0] = 0;
@@ -467,39 +445,25 @@ int test_create_pmt() {
     memset(ddci_devices, 0, sizeof(ddci_devices));
     ddci_devices[0] = &d;
     int pid = 1023;
-    int capid = 7068;
+    int capid = 0x100;
     int dpid = add_pid_mapping_table(0, pid, 0, &d, 0);
     int dcapid = add_pid_mapping_table(0, capid, 0, &d, 0);
     f.flags = FILTER_CRC;
     f.id = 0;
     f.adapter = 0;
+    f.pid = pid;
+    f.next_filter = -1;
+    f.enabled = 1;
     filters[0] = &f;
-    pmt.id = 1;
-    d.pmt[0].id = pmt.id; // set to pmt 1
-    pmts[pmt.id] = &pmt;  // enable pmt 1
-    npmts = 2;
-    pmt.enabled = 1;
-    pmt.sid = 0x66;
-    pmt.pid = pid;
-    strcpy(pmt.name, "TEST CHANNEL HD");
-    pmt.pmt_len = 0;
-    pmt.caids = 1;
-    pmt.ca[0].id = 0x100;
-    pmt.ca[0].pid = capid;
-    pmt.ca[0].private_data_len = 2;
-    pmt.ca[0].private_data[0] = 1;
-    pmt.ca[0].private_data[1] = 2;
-    pmt.stream_pids = 2;
-    pmt.stream_pid[0].type = 0x1B;
-    pmt.stream_pid[0].pid = pid;
-    pmt.stream_pid[0].desc_len = 2;
-    pmt.stream_pid[0].desc[0] = 0x54;
-    pmt.stream_pid[0].desc[1] = 0;
-    pmt.stream_pid[1].type = 3;
-    pmt.stream_pid[1].pid = 0x55;
+    SPMT *pmt = create_pmt(0, 0x66, pid, 0x55, 0x100, 0x500);
+    d.pmt[0].id = pmt->id; // set to pmt 1
+    pmt->pid = pid - 1;
+    pmt->version = 0;
+    strcpy(pmt->name, "TEST CHANNEL HD");
+    pmt->pmt_len = 0;
     ddci_pmt_t dp = {.ver = 0, .pcr_pid = 8191};
 
-    psi_len = ddci_create_pmt(&d, &pmt, psi, sizeof(psi), &dp);
+    psi_len = ddci_create_pmt(&d, pmt, psi, sizeof(psi), &dp);
     cc = 1;
     _hexdump("PACK: ", psi, psi_len);
     buffer_to_ts(packet, 188, psi, psi_len, &cc, 0x63);
@@ -509,7 +473,7 @@ int test_create_pmt() {
         LOG("Assemble packet failed");
         return 1;
     }
-    int new_pid = packet[26] * 256 + packet[27];
+    int new_pid = packet[30] * 256 + packet[31];
     int new_capid = packet[21] * 256 + packet[22];
     new_pid &= 0x1FFF;
     new_capid &= 0x1FFF;
@@ -519,29 +483,24 @@ int test_create_pmt() {
     if (new_capid != dcapid)
         LOG_AND_RETURN(1, "PMT PSI pid %04X != mapping table pid %04X",
                        new_capid, dcapid);
-    SPMT new_pmt;
-    memset(&new_pmt, 0, sizeof(pmt));
-    new_pmt.enabled = 1;
-    f.adapter = 0;
-    f.next_filter = -1;
-    f.pid = 0x99;
-    f.enabled = 1;
-    new_pmt.version = 0;
-    adapter ad;
+
+    SPMT *new_pmt = get_pmt(pmt_add(0, 200, 200, psi_len));
     ad.id = 0;
     ad.enabled = 1;
     a[0] = &ad;
-    ad.pids[0].pid = 0x99;
+    ad.pids[0].pid = pid;
     ad.pids[0].flags = 1;
+
     ad.active_pmts = 1;
-    ad.active_pmt[0] = pmt.id;
-    process_pmt(0, psi + 1, psi_len, &new_pmt);
+    ad.active_pmt[0] = pmt->id;
+
+    process_pmt(0, psi + 1, psi_len, new_pmt);
     filters[0] = NULL;
     ASSERT_EQUAL(
-        pmt.stream_pids, new_pmt.stream_pids,
+        pmt->stream_pids, new_pmt->stream_pids,
         "Number of streampids does not matches between generated PMT and "
         "read PMT");
-    ASSERT_EQUAL(pmt.caids, new_pmt.caids,
+    ASSERT_EQUAL(pmt->caids, new_pmt->caids,
                  "Number of caids does not matches "
                  "between generated PMT and read PMT");
 
@@ -554,6 +513,7 @@ int main() {
     opts.debug = 0;
     opts.cache_dir = "/tmp";
     strcpy(thread_name, "test_ddci");
+    init_alloc();
     TEST_FUNC(test_channels(), "testing test_channels");
     TEST_FUNC(test_add_del_pmt(), "testing adding and removing pmts");
     TEST_FUNC(test_push_ts_to_ddci(), "testing test_push_ts_to_ddci");
@@ -561,6 +521,8 @@ int main() {
     TEST_FUNC(test_ddci_process_ts(), "testing ddci_process_ts");
     TEST_FUNC(test_create_pat(), "testing create_pat");
     TEST_FUNC(test_create_pmt(), "testing create_pmt");
+    free_all_pmts();
+    free_alloc();
     fflush(stdout);
     return 0;
 }

--- a/tests/test_socketworks.c
+++ b/tests/test_socketworks.c
@@ -182,6 +182,7 @@ int test_socket_buffering() {
 int main() {
     opts.log = 1; // LOG_UTILS | LOG_SOCKET;
     strcpy(thread_name, "test_socketworks");
+    init_alloc();
     ;
     _writev = writev;
     int fd[2];


### PR DESCRIPTION
- changed pmt->pmt from a static array of 1500 bytes to dynamically sized array at the end of the struct (new pmt size will be sizeof(pmt)+pmt_len
- changed pmt->ca and pmt->stream_pids from having static desc and private_data to dynamically sized arrays. Also now they hold pointer to struct instead of fixed size array to reduce memory consumption.
- fix the accessing pmt->ca + pmt->stream_pid in all code using it
- allocate a pmt in process_pmt instead of process_pat when we know the size of the pmt_len.
- change active_pmt logic to account for this use case
- refactor alloc1 into _alloc, realloc1 into _realloc, free1 into _free
- track memory usage using a hash_table where the key is the pointer and change key size to 64 bit
- create ensure_allocation which dynamically the size of an allocated pointer based on new size in batches (basically allocate memory every 8 elements to prevent allocation for each element).
- export the hash table to the web page
- calculate statistics in the web page (how many allocations and their sizes)

Most of the relevant changes are in pmt.c.