### PR TITLE
Switch socket buffering to FIFO to reduce memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ make
 Usage:
 -------
 (Message automatically generated from "minisatip --help")
-minisatip version 1.2.34, compiled in Oct 14 2022 09:24:48, with s2api version: 050B
+minisatip version 1.2.~4b5ed89, compiled in Feb 22 2023 08:21:17, with s2api version: 050B
 
 	./minisatip [-[fgtzE]] [-a x:y:z] [-b X:Y] [-B X] [-H X:Y] [-d A:C-U ] [-D device_id] [-e X-Y,Z] [-i prio] 
 	[-[uj] A1:S1-F1[-PIN]] [-m mac] [-P port] [-l module1[,module2]] [-v module1[,module2]] 
@@ -65,6 +65,11 @@ Help
 
 * -B X : set the app socket write buffer to X KB. 
 	* eg: -B 10000 - to set the socket buffer to 10MB
+
+* --client-send-buffer X : set the socket write buffer for client connections to X KB. 
+	- The default value is 0, corresponding to use the kernel default value
+	* eg: --satip-receive-buffer  100 - to set the socket buffer to 100KB
+	* eg: --satip-receive-buffer 1024 - to set the socket buffer to 1MB
 
 * -z --cache-dir dir : set the app cache directory to dir. The directory will be created if it doesn't exist. 
 	* defaults to /var/cache/minisatip 
@@ -90,7 +95,7 @@ Help
 	- note: * as adapter means apply to all adapters
 
 * -E Allows encrypted stream to be sent to the client even if the decrypting is unsuccessful
-	Duplicating it (-E -E) all undecrypted packets are send as stuffing TS packets. Usefull for regular player clients.
+        Duplicating it (-E -E) all undecrypted packets are send as stuffing TS packets. Usefull for regular player clients.
 	- note: when pids=all is emulated this pass NULLs too
 
 * -Y --delsys ADAPTER1:DELIVERY_SYSTEM1[,ADAPTER2:DELIVERY_SYSTEM2[,..]] - specify the delivery system of the adapters (0 is the first adapter)	
@@ -137,6 +142,9 @@ Help
 	* If the snr or the strength multipliers are set to 0, minisatip will override the value received from the adapter and will report always full signal 100% 
 	* eg: -M 4-6:1.2-1.3 - multiplies the strength with 1.2 and the snr with 1.3 for adapter 4, 5 and 6
 	* eg: -M *:1.5-1.6 - multiplies the strength with 1.5 and the snr with 1.6 for all adapters
+	* [%] This symbol forces to read values as percentage
+	* [#] This symbol forces to read values as decibels
+	* eg: -M *:%1.0-#1.0 - not multiply the strength but force it as percentage and for the snr interpret it as decibels
 
 * -N --disable-dvb disable DVB adapter detection
  
@@ -157,6 +165,7 @@ Help
 	192.168.9.9 is the host where oscam is running and 9000 is the port configured in dvbapi section in oscam.conf.
 	* eg: -o /tmp/camd.socket 
 	/tmp/camd.socket is the local socket that can be used 
+* --send-all-ecm Pass all received ECM to the DVBAPI server. Warning: This option may overload your server. Use with caution. Not necessary for regular use.
 
 * -p --playlist url: specify playlist url using X_SATIPM3U header 
 	* eg: -p http://192.168.2.3:8080/playlist
@@ -187,10 +196,16 @@ Help
 	address 192.168.1.100 needs to be assigned to an interface on the server running minisatip.
 	This feature is useful for AVM FRITZ!WLAN Repeater
 	
-*  --satip-xml <URL> Use the xml retrieved from a satip server to configure satip adapters 
+* -6 --satip-xml <URL> Use the xml retrieved from a satip server to configure satip adapters 
 	eg: --satip-xml http://localhost:8080/desc.xml 
 
 * -O --satip-tcp Use RTSP over TCP instead of UDP for data transport 
+
+* --satip-receive-buffer X : set the socket read buffer for connecting to SAT>IP servers to X KB. 
+	- The default value is 0, corresponding to use the kernel default value
+	* eg: --satip-receive-buffer  350 - to set the socket buffer to 350KB
+	* eg: --satip-receive-buffer 1024 - to set the socket buffer to 1MB
+
 * -S --slave ADAPTER1,ADAPTER2-ADAPTER4[,..]:MASTER - specify slave adapters	
 	* Allows specifying bonded adapters (multiple adapters connected with a splitter to the same LNB)
 	* This feature is used by FBC receivers and AXE to specify the source input of the adapter
@@ -257,12 +272,13 @@ Help
 	* The format is: ADAPTER1:PIN,ADAPTER2-ADAPTER4
 			* eg : 0,2-3
 
-* -c --multiple-pmt adapter_list:maximum_number_of_channels_supported: Enable 2 PMTs inside of the same CAPMT to double the number of decrypted channels
-	* The format is: ADAPTER1:MAX_CHANNELS[-CAID1[-CAID2]...,ADAPTER2:MAX_CHANNELS[-CAID3[-CAID4]...]
-			* eg : 0:1-100
-The DDCI adapters 0 will support maximum of 1 CAPMT (2 channels) and will use CAID1. If CAID is not specified it will use CAMs CAIDs
+* -c --ca-channels adapter_list:maximum_number_of_channels_supported: Specify the number of channels supported by the CAM and override the CAIDs
+	* The format is: ADAPTER1:[*]MAX_CHANNELS[-CAID1[-CAID2]...,ADAPTER2:MAX_CHANNELS[-CAID3[-CAID4]...] 
+		 * before the MAX_CHANNELS enable 2 PMTs inside of the same CAPMT to double the number of decrypted channels
+			* eg : 0:*1-100
+The DDCI adapters 0 will support maximum of 1 CAPMT (2 channels because of *) and will use CAID1. If CAID is not specified it will use CAMs CAIDs
 Official CAMs support 1 or 2 channels, with this option this is extended to 2 or 4
-By default every CAM supports 4 channels
+By default every CAM supports 1 channels
 
 How to compile:
 ------

--- a/html/status.html
+++ b/html/status.html
@@ -581,7 +581,7 @@
 							}
 							// DVB-S/DVB-S2
 							case 5: {
-								params += "&src=" + state['ad_pos'][i] + "&pol=" + pol[state['ad_pol'][i]].replace('(', '').replace(')', '')
+								params += "&src=" + state['ad_pos'][i] + "&sr=" + state['ad_sr'][i] + "&pol=" + pol[state['ad_pol'][i]].replace('(', '').replace(')', '')
 								break
 							}
 							// DVB-C2

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -335,8 +335,8 @@ Help\n\
 * -b --buffer X:Y : set the app adapter buffer to X Bytes (default: %d) and set the kernel DVB buffer to Y Bytes (default: %d) - both multiple of 188\n\
 	* eg: -b 18800:18988\n\
 \n\
-* -B X : set the app socket write buffer to X KB. \n\
-	* eg: -B 10000 - to set the socket buffer to 10MB\n\
+* -B X : set the app socket write buffer to X MB. \n\
+	* eg: -B 10 - to set the socket buffer to 10MB (default value)\n\
 \n\
 * --client-send-buffer X : set the socket write buffer for client connections to X KB. \n\
 	- The default value is 0, corresponding to use the kernel default value\n\
@@ -684,7 +684,7 @@ void set_options(int argc, char *argv[]) {
     opts.lnb_high = (10600 * 1000UL);
     opts.lnb_circular = (10750 * 1000UL);
     opts.lnb_switch = (11700 * 1000UL);
-    opts.max_sbuf = 100;
+    opts.max_sbuf = 10;
     opts.pmt_scan = 1;
     opts.strength_multiplier = 1;
     opts.snr_multiplier = 1;
@@ -1179,7 +1179,10 @@ void set_options(int argc, char *argv[]) {
     opts.rtsp_host = (char *)_malloc(MAX_HOST);
     sprintf(opts.rtsp_host, "%s:%d", lip, opts.rtsp_port);
 
-    LOG("Listening configuration RTSP:%s HTTP:%s (bind address: %s)", opts.rtsp_host ? opts.rtsp_host : "(null)", opts.http_host ? opts.http_host : "(null)", opts.bind ? opts.bind : "(null)");
+    LOG("Listening configuration RTSP:%s HTTP:%s (bind address: %s)",
+        opts.rtsp_host ? opts.rtsp_host : "(null)",
+        opts.http_host ? opts.http_host : "(null)",
+        opts.bind ? opts.bind : "(null)");
 
     opts.datetime_compile = (char *)_malloc(64);
     sprintf(opts.datetime_compile, "%s | %s", __DATE__, __TIME__);
@@ -1805,7 +1808,8 @@ int ssdp_reply(sockets *s) {
         rdid = strcasestr((const char *)s->buf, "DEVICEID.SES.COM:");
         if (rdid && opts.device_id == map_int(strip(rdid + 17), NULL)) {
             ptr = 0;
-            strcatf(buf, ptr, device_id_conflict, opts.bind ? opts.bind : getlocalip(), opts.name_app,
+            strcatf(buf, ptr, device_id_conflict,
+                    opts.bind ? opts.bind : getlocalip(), opts.name_app,
                     version, opts.device_id);
             LOG("A new device joined the network with the same Device ID:  %s, "
                 "asking to change DEVICEID.SES.COM",

--- a/src/pmt.h
+++ b/src/pmt.h
@@ -140,7 +140,7 @@ typedef struct struct_pmt {
     char encrypted;
     int first_active_pid;
     int64_t grace_time, start_time;
-    uint16_t filter;
+    int filter;
     int clean_pos, clean_cc;
     uint8_t *clean;
     int pmt_len; // dynamic array

--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -565,14 +565,11 @@ int sockets_add(int sock, USockAddr *sa, int sid, int type, socket_action a,
     ss->id = i;
     ss->sock_err = 0;
     ss->overflow = 0;
-    ss->overflow_packets = 0;
-    ss->buf_alloc = ss->buf_used = 0;
     ss->iteration = 0;
-    ss->spos = ss->wpos = 0;
-    ss->wmax = opts.max_sbuf;
     ss->master = -1;
     ss->flush_enqued_data = 0;
-    ss->prio_pack.len = 0;
+    ss->prio_data_len = 0;
+
     ss->read = (read_action)sockets_read;
     ss->lock = NULL;
     if (ss->type == TYPE_UDP || ss->type == TYPE_RTCP)
@@ -613,10 +610,8 @@ int sockets_del(int sock) {
     so = ss->sock;
     ss->sock = -1; // avoid infinite loop
     LOG("sockets_del: sock %d -> handle %d, sid %d, overflow bytes %d, "
-        "allocated "
-        "%d, used %d, unsend packets %d",
-        sock, so, ss->sid, ss->overflow, ss->buf_alloc, ss->buf_used,
-        (ss->wmax > 0) ? ((ss->wpos - ss->spos) % ss->wmax) : 0);
+        "total buffered bytes %jd",
+        sock, so, ss->sid, ss->overflow, ss->buffered_bytes);
 
     if (so >= 0) {
         LOGM("sockets_del: closing socket handle %d", so);
@@ -635,16 +630,12 @@ int sockets_del(int sock) {
     ss->master = -1;
     if ((ss->flags & 1) && ss->buf)
         _free(ss->buf);
-    if (ss->pack) {
-        int i;
-        for (i = 0; i < ss->wmax; i++)
-            if (ss->pack[i].buf) {
-                _free(ss->pack[i].buf);
-                ss->pack[i].buf = NULL;
-            }
-        _free(ss->pack);
-        ss->pack = NULL;
+    if (ss->prio_data) {
+        _free(ss->prio_data);
+        ss->prio_data = NULL;
+        ss->prio_data_len = 0;
     }
+    free_fifo(&ss->fifo);
 
     LOG("sockets_del: sock %d Last open socket is at index %d current_handle "
         "%d",
@@ -710,7 +701,7 @@ void *select_and_execute(void *arg) {
                 pf[i].fd = s[i]->sock;
                 pf[i].events = s[i]->events;
 
-                if (s[i]->spos != s[i]->wpos)
+                if (fifo_used(&s[i]->fifo))
                     pf[i].events |= POLLOUT;
 
                 pf[i].revents = 0;
@@ -746,19 +737,17 @@ void *select_and_execute(void *arg) {
                     c_time = getTick();
                     ss->iteration++;
                     ss->revents = pf[i].revents;
+                    int buffered = fifo_used(&ss->fifo);
 
                     DEBUGM("event on socket index %d handle %d type %d "
-                           "spos %d "
-                           "wpos %d "
-                           "(poll fd: %d, events: %d, revents: %d)",
-                           i, ss->sock, ss->type, ss->spos, ss->wpos, pf[i].fd,
+                           "buffered %d (poll fd: %d, events: %d, revents: %d)",
+                           i, ss->sock, ss->type, buffered, pf[i].fd,
                            pf[i].events, pf[i].revents);
                     sockets_lock(ss);
 
-                    if ((pf[i].revents & POLLOUT) && (ss->spos != ss->wpos)) {
-                        LOGM(
-                            "start flush sock id %d, send pos %d, write pos %d",
-                            ss->id, ss->spos, ss->wpos);
+                    if ((pf[i].revents & POLLOUT) && buffered) {
+                        LOGM("start flush sock id %d, buffered %d", ss->id,
+                             buffered);
                         flush_socket(ss);
 
                         if ((pf[i].revents & (~POLLOUT)) == 0) {
@@ -905,7 +894,7 @@ void *select_and_execute(void *arg) {
                     continue;
                 if (((ss->timeout_ms > 0) &&
                      (lt - ss->rtime > ss->timeout_ms) &&
-                     (ss->spos == ss->wpos)) ||
+                     (fifo_used(&ss->fifo) == 0)) ||
                     (ss->force_close)) {
                     if (ss->timeout && !ss->force_close) {
                         int rv;
@@ -1073,29 +1062,16 @@ void free_all_streams();
 void free_all_adapters();
 void free_all_keys();
 
-void free_pack(SNPacket *p) {
-    if (!p)
-        return;
-    if (p->buf)
-        _free(p->buf);
-    p->size = 0;
-    p->buf = NULL;
-    p->len = 0;
-}
 void free_all() {
-    int i = 0, j;
+    int i = 0;
 
     for (i = MAX_SOCKS - 1; i > 0; i--) {
         if (!s[i])
             continue;
         if (s[i]->enabled)
             sockets_del(i);
-        if (s[i]->pack) {
-            for (j = 0; j < s[i]->wmax; j++)
-                free_pack(&s[i]->pack[j]);
-            _free(s[i]->pack);
-        }
-        free_pack(&s[i]->prio_pack);
+        free_fifo(&s[i]->fifo);
+        _free(s[i]->prio_data);
         if (s[i])
             _free(s[i]);
         s[i] = NULL;
@@ -1331,54 +1307,79 @@ int my_writev(sockets *s, struct iovec *iov, int iiov) {
     return rv;
 }
 
-int alloc_snpacket(SNPacket *p, int len) {
-    if (!p->buf || (p->size < len)) {
-        int newlen = (len < 1500) ? 1500 : len + 10;
-        void *mem = _realloc(p->buf, newlen);
-        if (mem) {
-            p->buf = mem;
-            p->size = newlen;
-            return 1;
-        } else {
-            LOG("%s: could not allocate %d bytes for socket buffer",
-                __FUNCTION__, newlen);
-            return -1;
-        }
-    }
-    return 0;
-}
-
 int socket_enque_highprio(sockets *s, struct iovec *iov, int iovcnt) {
     int len = 0, i, pos = 0;
     for (i = 0; i < iovcnt; i++)
         len += iov[i].iov_len;
 
-    pos = s->prio_pack.len;
+    pos = s->prio_data_len;
 
-    if (-1 == alloc_snpacket(&s->prio_pack, pos + len))
+    if (ensure_allocated((void **)&s->prio_data, 0, 1, pos + len, 1024))
         return 0;
 
     for (i = 0; i < iovcnt; i++) {
-        memcpy(s->prio_pack.buf + pos, iov[i].iov_base, iov[i].iov_len);
+        memcpy(s->prio_data + pos, iov[i].iov_base, iov[i].iov_len);
         pos += iov[i].iov_len;
     }
-    s->prio_pack.len = pos;
+    s->prio_data_len = pos;
     return 0;
 }
+
+// finds the next RTSP/TCP Header which starts with:
+//   -  0x24 0x00 [len len] 0x80 0x21 for TS data
+//   -  0x24 0x01 [len len] 0x80 0xC8
+int find_next_rtsp_header(SFIFO *fifo) {
+    uint64_t offset = fifo->read_index;
+    while (offset < fifo->write_index - 8) {
+        if ((((fifo_peek_32(fifo, offset) & 0xFFFF0000) == 0x24000000) &&
+             (fifo_peek_32(fifo, offset + 4) & 0xFFFF0000) == 0x80210000))
+            return offset - fifo->read_index;
+        if ((((fifo_peek_32(fifo, offset) & 0xFFFF0000) == 0x24010000) &&
+             (fifo_peek_32(fifo, offset + 4) & 0xFFFF0000) == 0x80C80000))
+            return offset - fifo->read_index;
+        offset++;
+    }
+    return -1;
+}
+
+// copies the data from a iov structure to the fifo, starting with offset
+// if offset is 0 the entire data is copied.
+int copy_iovec_to_fifo(SFIFO *fifo, int offset, struct iovec *iov, int iovcnt) {
+    int len = 0, i;
+    uint64_t available;
+    int size = opts.max_sbuf * 1048576;
+
+    if (create_fifo(fifo, size))
+        LOG_AND_RETURN(0, "Unable to allocate the FIFO with size %d", size);
+    available = fifo_available(fifo);
+
+    for (i = 0; i < iovcnt; i++)
+        len += iov[i].iov_len;
+    if (len - offset > available)
+        return 0;
+
+    for (i = 0; i < iovcnt; i++) {
+        if (offset < iov[i].iov_len) {
+            fifo_push(fifo, iov[i].iov_base + offset, iov[i].iov_len - offset);
+        }
+        offset = (offset > iov[i].iov_len) ? offset - iov[i].iov_len : 0;
+    }
+    return available - fifo_available(fifo);
+}
+
 int sockets_writev_prio(int sock_id, struct iovec *iov, int iovcnt,
                         int high_prio) {
-    int i, pos = 0, len;
-    unsigned char *tmpbuf = NULL;
-    struct iovec tmpiov[3];
+    int i, len = 0, offset = 0, rv = 0;
     sockets *s = get_sockets(sock_id);
     if (!s)
         return -1;
-    if (s->spos == s->wpos) {
-        int len = 0;
-        for (i = 0; i < iovcnt; i++)
-            len += iov[i].iov_len;
+    for (i = 0; i < iovcnt; i++)
+        len += iov[i].iov_len;
+    if (len == 0)
+        return 0;
 
-        int rv = my_writev(s, iov, iovcnt);
+    if (fifo_used(&s->fifo) == 0) {
+        rv = my_writev(s, iov, iovcnt);
         if (rv == len || rv == 0 || rv == -1) {
             s->flush_enqued_data = 0;
             return rv;
@@ -1387,112 +1388,49 @@ int sockets_writev_prio(int sock_id, struct iovec *iov, int iovcnt,
             rv = 0;
 
         if (rv >= 0) {
-            tmpbuf = _malloc(len);
-            if (!tmpbuf) {
-                s->overflow += len - rv;
-                dropped_bytes += len - rv;
-                LOG_AND_RETURN(0, "%s: Could not allocate %d bytes for tmpbuf",
-                               __FUNCTION__, len);
-            }
-            for (i = 0; i < iovcnt; i++) {
-                if (rv <= pos + iov[i].iov_len) // copy only the unsent data
-                    memcpy(tmpbuf + pos, iov[i].iov_base, iov[i].iov_len);
-                pos += iov[i].iov_len;
-            }
-            LOGM("incomplete write %d left %d from %d", rv, len - rv, len);
-            tmpiov[0].iov_base = tmpbuf + rv;
-            tmpiov[0].iov_len = len - rv;
-            iov = tmpiov;
-            iovcnt = 1;
-        }
-    }
-
-    if (!s->pack) {
-        s->pack = _malloc(s->wmax * sizeof(SNPacket));
-        if (!s->pack) {
-            s->overflow++;
-            if (tmpbuf)
-                _free(tmpbuf);
-            LOG_AND_RETURN(0, "%s: Could not allocate memory for s->pack %d",
-                           __FUNCTION__, s->wmax);
+            offset = rv;
         }
     }
 
     // high priority packets will be queued in high_prio and flushed after
     // the current packet example http_response, to avoid waiting all other
     // rtsp data to be dequeued first
-    if (high_prio && !s->flush_enqued_data && s->spos != s->wpos) {
-        int rv = socket_enque_highprio(s, iov, iovcnt);
-        if (tmpbuf)
-            _free(tmpbuf);
-        return rv;
+    if (high_prio && !s->flush_enqued_data && (fifo_used(&s->fifo) > 0)) {
+        return socket_enque_highprio(s, iov, iovcnt);
     }
     // if we need the user tuned to a new freq, drop all the data that is in
     // the buffer if both high_prio and flush_enqued_data are both set, no
     // need to add to pio_pack
     if (s->flush_enqued_data) {
-        LOG("sock %d dropping enqueued stream data from %d to %d", s->id,
-            (s->spos + 1) % s->wmax, s->wpos);
+        int off = find_next_rtsp_header(&s->fifo);
+        if (off >= 0) {
+            LOG("sock %d dropping %jd enqueued bytes (offset %d)", s->id,
+                s->fifo.write_index - (s->fifo.read_index + off), off);
+            s->fifo.write_index = s->fifo.read_index + off;
+        }
         s->flush_enqued_data = 0;
-        s->wpos = (s->spos + 1) % s->wmax;
     }
 
-    len = 0;
-    for (i = 0; i < iovcnt; i++)
-        len += iov[i].iov_len;
+    // buffer unwritten data to FIFO
+    int copied = copy_iovec_to_fifo(&s->fifo, offset, iov, iovcnt);
+    if (!copied) {
+        if ((s->overflow == 0) || (opts.log & DEFAULT_LOG))
+            LOG("Insufficient bandwidth: sock %d: overflow %d bytes, total "
+                "%.1f MB, len %d, offset %d, rv %d, available %d",
+                s->id, len - offset, s->overflow / 1048576.0, len, offset, rv,
+                fifo_available(&s->fifo));
+        s->overflow += len - offset;
+        dropped_bytes += len - offset;
 
-    // queue the packet otherwise
-    SNPacket *p = s->pack + s->wpos;
-
-    i = alloc_snpacket(p, len);
-    if (i > 0) {
-        s->buf_alloc++;
-    } else if (i < 0) {
-        LOG("overflow p is %p, buf %p", p, p ? p->buf : NULL);
-        s->overflow += len;
-        dropped_bytes += len;
-        if (tmpbuf)
-            _free(tmpbuf);
         return 0;
     }
-
-    s->buf_used++;
-    LOGL(((s->buf_used % 1000) == 0) ? 1 : DEFAULT_LOG,
-         "SOCK %d it %d: queueing %d bytes at %d (out of %d) send pos %d "
-         "[A:%d, "
-         "U:%d]",
-         s->id, s->iteration, len, s->wpos, s->wmax, s->spos, s->buf_alloc,
-         s->buf_used);
-
-    if (s->spos ==
-        ((s->wpos + 1) % s->wmax)) // the queue is full, start overwriting
-    {
-        s->overflow += len;
-        dropped_bytes += len;
-        s->overflow_packets++;
-        if ((s->overflow_packets < 100) || ((s->overflow_packets % 100) == 0) ||
-            (opts.log & DEFAULT_LOG))
-            LOG("Insufficient bandwidth: sock %d: overflow %.1f MB", s->id,
-                s->overflow / 1048576.0);
-
-        if (tmpbuf)
-            _free(tmpbuf);
-        return 0;
-    }
-
-    pos = 0;
-    for (i = 0; i < iovcnt; i++) {
-        memcpy(p->buf + pos, iov[i].iov_base, iov[i].iov_len);
-        pos += iov[i].iov_len;
-    }
-    p->len = pos;
-    buffered_bytes += pos;
-    s->wpos = (s->wpos + 1) % s->wmax;
-
-    if (tmpbuf)
-        _free(tmpbuf);
-
-    return 0;
+    if (copied + offset != len)
+        LOG("Unhandled sock %d data: copied %d offset %d len %d", s->id, copied, offset, len);
+    LOGM("got %d bytes, offset %d, rv %d, buffered %d bytes - used %d", len,
+        offset, rv, copied, fifo_used(&s->fifo));
+    s->buffered_bytes += copied;
+    buffered_bytes += copied;
+    return offset;
 }
 
 int sockets_write(int sock_id, void *buf, int len) {
@@ -1502,113 +1440,80 @@ int sockets_write(int sock_id, void *buf, int len) {
     return sockets_writev(sock_id, iov, 1);
 }
 
-int flush_socket_one_packet(sockets *s) {
+int flush_socket_all(sockets *s, int used) {
     struct iovec iov[2];
-    uint64_t ctime = getTick();
-    int r = 1, rv = 0;
-    SNPacket *p = NULL;
-
-    memset(iov, 0, sizeof(iov));
-    if (s->spos == s->wpos)
-        goto end;
-    if (s->pack)
-        p = s->pack + s->spos;
-    else
-        goto end;
-    if (p->buf) {
-        iov[0].iov_len = p->len;
-        iov[0].iov_base = p->buf;
-        rv = my_writev(s, iov, 1);
-        if ((rv > 0) && (rv != p->len)) {
-            LOG("incomplete write, buffered %d packets, wrote %d, bytes "
-                "left "
-                "%d",
-                (s->wpos - s->spos + s->wmax) % s->wmax, rv, p->len - rv);
-            memmove(p->buf, p->buf + rv, p->len - rv);
-            p->len -= rv;
-            return 1;
-        } else {
-            if (rv != p->len)
-                return 1;
-        }
-    }
-    LOG("SOCK %d: flushed %d out of %d (%d bytes) in %jd ms", s->id, s->spos,
-        s->wpos, p ? p->len : -1, getTick() - ctime);
-    if (!s->prio_pack.len) {
-        s->spos = (s->spos + 1) % s->wmax;
-    } else { // makes sure http response (prio_pack) is sent next
-        SNPacket tmp;
-        memcpy(&tmp, p, sizeof(tmp));
-        memcpy(p, &s->prio_pack, sizeof(tmp));
-        memcpy(&s->prio_pack, &tmp, sizeof(tmp));
-        s->prio_pack.len = 0;
-        LOG("SOCK %d moved priority packet in the queue at pos %d instead "
-            "of "
-            "%d",
-            s->id, s->spos, s->wpos);
-    }
-    r = 0;
-end:
-    if (s->force_close && s->spos == s->wpos) {
-        LOGM("SOCK %d: set timeout_ms to %d from wrwait", s->id, s->timeout_ms);
-        s->timeout_ms = 1;
-    }
-    return r;
-}
-
-int flush_socket_all(sockets *s) {
-    struct iovec iov[s->wmax + 1];
-    int spos, i = 0, rv = 0, np = 0, init_rv, len = 0;
+    int i = 0, rv = 0;
     uint64_t ctime = getTick();
 
-    if (s->spos == s->wpos)
+    if (used == 0)
         return 0;
 
-    memset(&iov, 0, sizeof(iov));
-    spos = s->spos;
-    while (spos != s->wpos) {
-        if (!s->pack[spos].buf) {
-            spos = (spos + 1) % s->wmax;
-            continue;
-        }
-        iov[i].iov_base = s->pack[spos].buf;
-        iov[i++].iov_len = s->pack[spos].len;
-        len += s->pack[spos].len;
-        spos = (spos + 1) % s->wmax;
+    iov[0].iov_len = fifo_peek(&s->fifo, &iov[0].iov_base, used, 0);
+    i = 1;
+    // the entire FIFO can be read using 2 pointers
+    if (iov[0].iov_len < used) {
+        iov[1].iov_len = fifo_peek(&s->fifo, &iov[1].iov_base,
+                                   used - iov[0].iov_len, iov[0].iov_len);
+        i++;
     }
-    if (i > 0)
-        init_rv = rv = my_writev(s, iov, i);
-    else {
-        s->spos = (s->spos + 1) % s->wmax;
-        return rv;
-    }
+    rv = my_writev(s, iov, i);
 
     if (rv <= 0)
         return rv;
+    fifo_skip_bytes(&s->fifo, rv);
 
-    while (s->spos != s->wpos) {
-        if (rv < s->pack[s->spos].len)
-            break;
-        rv -= s->pack[s->spos].len;
-        s->spos = (s->spos + 1) % s->wmax;
-        np++;
-    }
-    LOGM("SOCK %d: flushed %d (out of %d) bytes in %d packets (left %d) in %jd "
+    LOGM("SOCK %d: flushed %d (out of %d) bytes in %jd "
          "ms",
-         s->id, init_rv, len, np, i - np, getTick() - ctime);
-    if (rv == 0 || s->spos == s->wpos)
-        return 0;
-    SNPacket *p = s->pack + s->spos;
-    memmove(p->buf, p->buf + rv, p->len - rv);
-    p->len -= rv;
+         s->id, rv, used, getTick() - ctime);
 
-    return 0;
+    return rv;
+}
+
+int flush_socket_prio(sockets *s) {
+    struct iovec iov[2];
+    uint64_t ctime = getTick();
+    int rv = 0;
+    int left = find_next_rtsp_header(&s->fifo);
+    memset(iov, 0, sizeof(iov));
+    if (left > 0) {
+        if ((rv = flush_socket_all(s, left)) >= 0)
+            left -= rv;
+    }
+
+    if (left > 0)
+        LOG_AND_RETURN(left,
+                       "sock %d flushed incomplete packet before priority "
+                       "response: left %d, rv %d in %jd ms",
+                       s->id, left, rv, getTick() - ctime);
+
+    iov[0].iov_base = s->prio_data;
+    iov[0].iov_len = s->prio_data_len;
+    rv = my_writev(s, iov, 1);
+    LOG("sock %d, flushed %d bytes of priority data from %d", s->id, rv,
+        s->prio_data_len);
+    if (rv <= 0)
+        return 1;
+    if ((rv > 0) && (rv != s->prio_data_len)) {
+        LOG("sock %d incomplete priority data write %d left %d in %jd ms",
+            s->id, rv, s->prio_data_len - rv, getTick() - ctime);
+        memmove(s->prio_data, s->prio_data + rv, s->prio_data_len - rv);
+        s->prio_data_len -= rv;
+        return 1;
+    }
+    s->prio_data_len = 0;
+
+    if (s->force_close && (fifo_used(&s->fifo) == 0)) {
+        LOGM("SOCK %d: set timeout_ms to 1 from %d", s->id, s->timeout_ms);
+        s->timeout_ms = 1;
+    }
+    return rv;
 }
 
 int flush_socket(sockets *s) {
-    if (s->force_close || s->prio_pack.len)
-        return flush_socket_one_packet(s);
-    return flush_socket_all(s);
+    if (s->force_close || s->prio_data_len) {
+        return flush_socket_prio(s);
+    }
+    return flush_socket_all(s, fifo_used(&s->fifo));
 }
 
 void set_sockets_sid(int id, int sid) {

--- a/src/socketworks.h
+++ b/src/socketworks.h
@@ -2,17 +2,12 @@
 #define SOCKETWORKS_H
 #define MAX_SOCKS 1024
 #include "utils.h"
+#include "utils/fifo.h"
 #include <netinet/in.h>
 #include <sys/socket.h>
 
 typedef int (*socket_action)(void *s);
 typedef int (*read_action)(int, void *, size_t, void *, int *);
-
-typedef struct struct_spacket {
-    int len;
-    int size;
-    uint8_t *buf;
-} SNPacket;
 
 typedef union union_sockaddr {
     struct sockaddr sa;
@@ -49,11 +44,11 @@ typedef struct struct_sockets {
     pthread_t tid;
     SMutex *lock;
     int sock_err;
-    SNPacket *pack;
-    SNPacket prio_pack; // http_responses have higher priority
+    SFIFO fifo;
+    int prio_data_len;
+    uint8_t *prio_data; // http_responses have higher priority
     int flush_enqued_data;
-    int spos, wmax, wpos;
-    int overflow, buf_alloc, buf_used, overflow_packets;
+    int overflow;
     int64_t buffered_bytes;
     // if != -1 points to the master socket which holds the buffer and the
     // action function. Useful when the DVR buffer comes from different file
@@ -106,7 +101,6 @@ void set_socket_buffer(int sid, unsigned char *buf, int len);
 void sockets_timeout(int i, int t);
 void set_sockets_rtime(int i, int r);
 void free_all();
-void free_pack(SNPacket *p);
 void sockets_setread(int i, void *r);
 void sockets_setclose(int i, void *r);
 void set_socket_send_buffer(int sock, int len);
@@ -130,6 +124,7 @@ void set_socket_dscp(int id, int dscp, int prio);
 void sockets_set_opaque(int id, void *opaque, void *opaque2, void *opaque3);
 void sockets_force_close(int id);
 void sockets_set_master(int slave, int master);
+int copy_iovec_to_fifo(SFIFO *fifo, int offset, struct iovec *iov, int iovcnt);
 extern __thread char thread_name[];
 extern __thread pthread_t tid;
 extern __thread int select_timeout;

--- a/src/stream.c
+++ b/src/stream.c
@@ -947,6 +947,8 @@ int process_packets_for_stream(streams *sid, adapter *ad) {
         }
     }
 
+    //    if (iiov == 0)
+    //        return 0;
     if ((sid->type == STREAM_RTSP_UDP || sid->type == STREAM_RTSP_TCP))
         enqueue_rtp_header(sid, iov, iiov, last_rtp_header, rtp_buf + rtp_pos);
 
@@ -1330,7 +1332,7 @@ char *get_stream_protocol(int s_id, char *dest, int max_size) {
     else if (s->type == STREAM_RTSP_TCP)
         strlcatf(dest, max_size, len, "RTP/TCP");
     else
-        strlcatf(dest, max_size, len, "unkown");  // RTP/MCAST ?
+        strlcatf(dest, max_size, len, "unkown"); // RTP/MCAST ?
     return dest;
 }
 
@@ -1374,16 +1376,13 @@ int get_stream_overflow(int s_id) {
 }
 
 int get_stream_buffered_size(int s_id) {
-    int i, bytes = 0;
     streams *sid = get_sid_nw(s_id);
     if (!sid)
         return 0;
     sockets *s = get_sockets(sid->rsock_id);
-    if (!s || s->spos == s->wpos || !s->pack)
+    if (!s)
         return 0;
-    for (i = s->spos; i != s->wpos; i = (i + 1) % s->wmax)
-        bytes += s->pack[i].len;
-    return bytes;
+    return fifo_used(&s->fifo);
 }
 _symbols stream_sym[] = {
     {"st_enabled", VAR_AARRAY_INT8, st, 1, MAX_STREAMS,
@@ -1397,8 +1396,8 @@ _symbols stream_sym[] = {
      0},
     {"st_rport", VAR_FUNCTION_INT, (void *)&get_stream_rport, 0, MAX_STREAMS,
      0},
-    {"st_proto", VAR_FUNCTION_STRING, (void *)&get_stream_protocol, 0, MAX_STREAMS,
-     0},
+    {"st_proto", VAR_FUNCTION_STRING, (void *)&get_stream_protocol, 0,
+     MAX_STREAMS, 0},
     {"st_pids", VAR_FUNCTION_STRING, (void *)&get_stream_pids, 0, MAX_STREAMS,
      0},
     {"st_overflow", VAR_FUNCTION_INT, (void *)&get_stream_overflow, 0,

--- a/src/utils/alloc.h
+++ b/src/utils/alloc.h
@@ -15,7 +15,8 @@ void free_alloc();
 #define _malloc(a) malloc1(a, __FILE__, __LINE__, 1)
 #define _free(a) free1(a, __FILE__, __LINE__, 1)
 #define _realloc(a, b) realloc1(a, b, __FILE__, __LINE__, 1)
-#define ensure_allocated(a, b, c, d, e)                                        \
-    _ensure_allocated(a, b, c, d, e, __FILE__, __LINE__)
+#define ensure_allocated(p, struct_size, pointer_size, len, min_elements)      \
+    _ensure_allocated(p, struct_size, pointer_size, len, min_elements,         \
+                      __FILE__, __LINE__)
 
 #endif

--- a/src/utils/fifo.h
+++ b/src/utils/fifo.h
@@ -12,7 +12,6 @@
 // to a handle)
 
 typedef struct fifo {
-    char init;
     char *file;
     int line;
     uint64_t read_index;
@@ -28,6 +27,10 @@ static inline int fifo_available(SFIFO *f) {
 }
 
 static inline int fifo_used(SFIFO *f) { return f->write_index - f->read_index; }
+static inline void fifo_skip_bytes(SFIFO *f, uint32_t len) {
+    if(f->size > 0)
+        f->read_index += len;
+}
 
 int fifo_push_force(SFIFO *fifo, void *src, unsigned int len, int force);
 
@@ -39,6 +42,8 @@ uint32_t fifo_peek(SFIFO *fifo, void **dst, unsigned int len,
 int fifo_push_record(SFIFO *fifo, void *src, uint32_t len);
 
 uint32_t fifo_pop_record(SFIFO *fifo, void *dst, uint32_t len);
+uint32_t fifo_peek_32(SFIFO *fifo, uint64_t offset);
+uint32_t fifo_peek_record_size(SFIFO *fifo);
 
 #define create_fifo(f, x) _create_fifo(f, x, __FILE__, __LINE__)
 #define fifo_push(a, b, c) fifo_push_force(a, b, c, 0)

--- a/tests/test_socketworks.c
+++ b/tests/test_socketworks.c
@@ -25,6 +25,7 @@
 #include "minisatip.h"
 #include "socketworks.h"
 #include "utils.h"
+#include "utils/alloc.h"
 #include "utils/testing.h"
 #include <arpa/inet.h>
 #include <ctype.h>
@@ -64,67 +65,42 @@ int test_socket_enque_highprio() {
     socket_enque_highprio(ss, iov, 2);
     iov[0].iov_base = "test3";
     socket_enque_highprio(ss, iov, 1);
-    if (strncmp((char *)ss->prio_pack.buf, "test1test2test3",
-                ss->prio_pack.len))
+    if (strncmp((char *)ss->prio_data, "test1test2test3", ss->prio_data_len))
         LOG_AND_RETURN(1, "expected != the actual result: %s len %d",
-                       ss->prio_pack.buf, ss->prio_pack.len);
-    free_pack(&ss->prio_pack);
-    iov[0].iov_base = "test";
-    iov[0].iov_len = 4;
-    socket_enque_highprio(ss, iov, 1);
-    if (strncmp((char *)ss->prio_pack.buf, "test", ss->prio_pack.len))
-        LOG_AND_RETURN(1, "expected (%s) != the actual result: %s len %d",
-                       iov[0].iov_base, ss->prio_pack.buf, ss->prio_pack.len);
-    free_pack(&ss->prio_pack);
+                       ss->prio_data, ss->prio_data_len);
+    _free(ss->prio_data);
+    ss->prio_data_len = 0;
+    ss->prio_data = NULL;
     return 0;
 }
 
-int test_socket_writev_prio() {
+int test_socket_writev_flush_enqued() {
     struct iovec iov[2];
     char buf[100];
+    uint8_t start_rtsp_frame[] = {0x24, 0x0, 1, 2, 0x80, 0x21};
     int rv;
     memset(buf, 0, sizeof(buf));
     memset(&iov, 0, sizeof(iov));
     sockets *ss = s[id];
-    ss->wpos = 0;
-    ss->spos = 5; // trigger buffering
-    sockets_write(id, "0", 1);
-    ss->spos = 0;
-    sockets_write(id, "1", 1);
-    iov[0].iov_base = "p";
-    iov[0].iov_len = 1;
-    sockets_writev_prio(id, iov, 1, 1);
-    flush_socket(ss);
-    flush_socket(ss);
-    if (3 != (rv = read(read_fd, buf, sizeof(buf))))
-        LOG_AND_RETURN(2, "read unexpected number of bytes %d", rv);
-    if (strcmp(buf, "0p1"))
-        LOG_AND_RETURN(2, "unexpected result: 0p1 != %s", buf);
-    return 0;
-}
+    create_fifo(&ss->fifo, 100);
 
-int test_socket_writev_prio_flush() {
-    struct iovec iov[2];
-    char buf[100];
-    int rv;
-    memset(buf, 0, sizeof(buf));
-    memset(&iov, 0, sizeof(iov));
-    sockets *ss = s[id];
-    ss->wpos = 0;
-    ss->spos = 5; // trigger buffering
-    sockets_write(id, "0", 1);
-    ss->spos = 0;
+    // flush enqued data (everything after 0x24 is not written)
+    ss->fifo.write_index = 1;
+    ss->fifo.read_index = 0; // trigger buffering
+    char *data = ss->fifo.data;
+    data[0] = '0';
     sockets_write(id, "1", 1);
-    iov[0].iov_base = "p";
-    iov[0].iov_len = 1;
+    sockets_write(id, start_rtsp_frame, sizeof(start_rtsp_frame));
+    sockets_write(id, buf, sizeof(buf) / 2);
     ss->flush_enqued_data = 1;
-    sockets_writev_prio(id, iov, 1, 1);
     sockets_write(id, "2", 1);
     flush_socket(ss);
     if (3 != (rv = read(read_fd, buf, sizeof(buf))))
         LOG_AND_RETURN(2, "read unexpected number of bytes %d", rv);
-    if (strcmp(buf, "0p2"))
-        LOG_AND_RETURN(2, "unexpected result: 0p1 != %s", buf);
+    if (strncmp(buf, "012", 3))
+        LOG_AND_RETURN(2, "unexpected result: 012 != %s", buf);
+
+    free_fifo(&ss->fifo);
     return 0;
 }
 
@@ -148,33 +124,76 @@ ssize_t writev_test(int rsock, const struct iovec *iov, int iiov) {
 }
 
 int test_socket_buffering() {
-    struct iovec iov[2];
+    struct iovec iov[3];
     char buf[255];
+    uint8_t start_rtsp_frame[] = {0x24, 0x0, 1, 2, 0x80, 0x21};
     int i;
+    // account for 9 missing bytes at offset 50 (prio data + start_rtsp_frame)
     for (i = 0; i < sizeof(buf); i++)
-        buf[i] = i & 0xFF;
+        if (i < 50)
+            buf[i] = i;
+        else
+            buf[i] = i + 9;
 
     memset(&iov, 0, sizeof(iov));
     sockets *ss = s[id];
-    ss->wpos = 2;
-    ss->spos = 2;
+    create_fifo(&ss->fifo, 100);
+    ss->fifo.write_index = 50;
+    ss->fifo.read_index = 50;
     _writev = writev_test;
     // test writing flushing multiple packets at once
     to_write = 1;
     for (i = 0; i < 10; i++) {
+        if (i == 5)
+            sockets_write(id, start_rtsp_frame, sizeof(start_rtsp_frame));
         sockets_write(id, buf + i * 10, 10);
-        LOG("wrote packet %d: spos %d wpos %d", i, ss->spos, ss->wpos);
     }
+
+    ASSERT_EQUAL(ss->overflow, 10, "Expected overflow");
+    // prio data
+    iov[0].iov_base = "XYZ";
+    iov[0].iov_len = 3;
+    sockets_writev_prio(id, iov, 1, 1);
+    _hexdump("buffered data: ", ss->fifo.data, 100);
     // trigger partial write
     to_write = 47;
     flush_socket(ss);
+    to_write = 5;
     flush_socket(ss);
+    to_write = 5;
+    flush_socket(ss);
+    to_write = 50;
+    flush_socket(ss);
+    _hexdump("read data: ", test_buf, 95);
 
     for (i = 0; i < 90; i++) {
         char message[100];
-        sprintf(message, "Invalid value found in the buffer at position %d", i);
-        ASSERT(test_buf[i] == (i & 0xFF), message);
+        sprintf(message,
+                "Invalid value found in the buffer at position %d: %02X", i,
+                test_buf[i]);
+        if (i < 50 || i > 58)
+            ASSERT(test_buf[i] == i, message);
     }
+    ASSERT(memcmp(test_buf + 50, start_rtsp_frame, sizeof(start_rtsp_frame)),
+           "RTSP frame not found at expected position");
+
+    // test copy_iovec_to_fifo
+    iov[0].iov_base = buf;
+    iov[0].iov_len = 10;
+    iov[1].iov_base = buf + 10;
+    iov[1].iov_len = 10;
+    iov[2].iov_base = buf + 20;
+    iov[2].iov_len = 10;
+    ss->fifo.read_index = ss->fifo.write_index = 0;
+    copy_iovec_to_fifo(&ss->fifo, 0, iov, 3);
+    ASSERT(!memcmp(buf, ss->fifo.data, fifo_used(&ss->fifo)),
+           "copy_iovec_to_fifo failed with 0 offset");
+    ss->fifo.read_index = ss->fifo.write_index = 0;
+    copy_iovec_to_fifo(&ss->fifo, 19, iov, 3);
+    ASSERT(!memcmp(buf + 19, ss->fifo.data, fifo_used(&ss->fifo)),
+           "copy_iovec_to_fifo failed with custom offset offset");
+
+    free_fifo(&ss->fifo);
 
     return 0;
 }
@@ -183,7 +202,6 @@ int main() {
     opts.log = 1; // LOG_UTILS | LOG_SOCKET;
     strcpy(thread_name, "test_socketworks");
     init_alloc();
-    ;
     _writev = writev;
     int fd[2];
     if (pipe(fd) == -1) {
@@ -192,12 +210,10 @@ int main() {
     }
     read_fd = fd[0];
     id = sockets_add(fd[1], NULL, -1, TYPE_UDP, NULL, NULL, NULL);
-    s[id]->wmax = 10;
     TEST_FUNC(test_socket_enque_highprio(),
               "testing test_socket_enque_highprio");
-    TEST_FUNC(test_socket_writev_prio(), "testing socket_writev_prio");
-    TEST_FUNC(test_socket_writev_prio_flush(),
-              "testing socket_writev_prio with flushing the queue");
+    TEST_FUNC(test_socket_writev_flush_enqued(),
+              "testing socket_writev with flushing the queue");
     TEST_FUNC(test_socket_buffering(), "testing socket buffering and flushing");
     fflush(stdout);
     free_all();

--- a/tools/gen_readme
+++ b/tools/gen_readme
@@ -1,6 +1,4 @@
 #! /bin/bash
-rm src/minisatip.o
-gcc -c src/minisatip.c -DMINOR=\"67\"  -o src/minisatip.o
 make 
 cat readme_header > README.md
 ./minisatip -h | grep -v 'Built with' >> README.md


### PR DESCRIPTION
- Switches the socket buffering to use FIFO to simplify the code and reduce memory usage.
- Priority data functionality is preserved (RTSP responses send to the client has priority over regular stream data):
- * There is a special buffer holding priority data
- * When present, the current packet until the next RTSP header is flushed then the priority data, then the flushing of the TS stream continues
- Fixes the tests to include the rtsp header 