### PR TITLE
Don't manipulate PMT IDs in the filter even when clean_psi is not used

### DIFF
--- a/src/pmt.c
+++ b/src/pmt.c
@@ -1907,11 +1907,7 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
     pmt_add_active_pmt(ad, pmt->id);
 
     if (pmt->version == ver) {
-        // just for testing purposes
-        p = find_pid(pmt->adapter, pid);
-        if (p)
-            p->pmt = -pmt->id;
-
+        // Already processed
         return 0;
     } else
         // In case of PMT update, just stop the PMT before processing the


### PR DESCRIPTION
Been running this locally for some time, haven't at least noticed any side effects.