### PR TITLE
Save the last_log to be accessible in case of core dump

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -1095,7 +1095,7 @@ void mark_pid_deleted(int aid, int sid, int _pid, SPid *p) {
     if (sort) {
         for (j = 0; j < MAX_STREAMS_PER_PID - 1; j++)
             if (p->sid[j + 1] > p->sid[j]) {
-                unsigned char t = p->sid[j];
+                int16_t t = p->sid[j];
                 p->sid[j] = p->sid[j + 1];
                 p->sid[j + 1] = t;
             }

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -1899,7 +1899,9 @@ int main(int argc, char *argv[]) {
     int i;
     unsigned long log_it;
     main_tid = get_tid();
-    strcpy(thread_name, "main");
+    thread_index = 0;
+    thread_info[thread_index].tid = main_tid;
+    strcpy(thread_info[thread_index].thread_name, "main");
     init_alloc();
     set_options(argc, argv);
     if ((rv = init_utils(argv[0]))) {

--- a/src/opts.h
+++ b/src/opts.h
@@ -38,7 +38,6 @@ struct struct_opts {
     int force_scan;
     int send_all_ecm;
     int file_line;
-    char *last_log;
     int dvbapi_port;
     char dvbapi_host[100];
     int dvbapi_offset;

--- a/src/utils/logging/logging.c
+++ b/src/utils/logging/logging.c
@@ -25,27 +25,27 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
-#include <syslog.h>
 #include <sys/time.h>
+#include <syslog.h>
 
 pthread_mutex_t log_mutex;
-extern __thread char thread_name[];
+SThreadInfo thread_info[135];
+__thread int thread_index;
 
 void _log(const char *file, int line, const char *fmt, ...) {
     va_list arg;
     int len = 0, len1 = 0, both = 0;
     static int idx, times;
-    char stid[50];
+    char stid[102];
     static char output[2][2000]; // prints just the first 2000 bytes from
                                  // the message
 
     /* Check if the message should be logged */
-    opts.last_log = (char *)fmt;
-
     stid[0] = 0;
     if (!opts.no_threads) {
         pthread_mutex_lock(&log_mutex);
-        snprintf(stid, sizeof(stid) - 2, " %s", thread_name);
+        snprintf(stid, sizeof(stid) - 1, " %s",
+                 thread_info[thread_index].thread_name);
         stid[sizeof(stid) - 1] = 0;
     }
 

--- a/src/utils/logging/logging.h
+++ b/src/utils/logging/logging.h
@@ -6,12 +6,22 @@
 #include "opts.h"
 
 #include <stdint.h>
+#include <sys/types.h>
 
 void _log(const char *file, int line, const char *fmt, ...);
 void _dump_packets(char *message, unsigned char *b, int len, int packet_offset);
 void _hexdump(char *desc, void *addr, int len);
 char *get_current_timestamp_log();
 uint32_t crc_32(const uint8_t *data, int datalen);
+
+#define MAX_THREAD_INFO 135 // 128 + 7
+typedef struct {
+    pthread_t tid;
+    char thread_name[100];
+    char *last_log;
+} SThreadInfo;
+extern SThreadInfo thread_info[MAX_THREAD_INFO];
+extern __thread int thread_index;
 
 #define LOG_GENERAL 1
 #define LOG_HTTP (1 << 1)
@@ -34,6 +44,7 @@ uint32_t crc_32(const uint8_t *data, int datalen);
 
 #define LOGL(level, a, ...)                                                    \
     {                                                                          \
+        thread_info[thread_index].last_log = a;                                \
         if ((level)&opts.log)                                                  \
             _log(__FILE__, __LINE__, a, ##__VA_ARGS__);                        \
     }
@@ -44,13 +55,17 @@ uint32_t crc_32(const uint8_t *data, int datalen);
 
 #define DEBUGL(level, a, ...)                                                  \
     {                                                                          \
+        thread_info[thread_index].last_log = a;                                \
         if ((level)&opts.debug)                                                \
             _log(__FILE__, __LINE__, a, ##__VA_ARGS__);                        \
     }
 #define DEBUGM(a, ...) DEBUGL(DEFAULT_LOG, a, ##__VA_ARGS__)
 
 #define LOG0(a, ...)                                                           \
-    { _log(__FILE__, __LINE__, a, ##__VA_ARGS__); }
+    {                                                                          \
+        thread_info[thread_index].last_log = a;                                \
+        _log(__FILE__, __LINE__, a, ##__VA_ARGS__);                            \
+    }
 
 #define FAIL(a, ...)                                                           \
     {                                                                          \

--- a/tests/test_ca.c
+++ b/tests/test_ca.c
@@ -161,7 +161,7 @@ int main() {
     opts.debug = 255;
     opts.cache_dir = "/tmp";
 
-    strcpy(thread_name, "test_ca");
+    strcpy(thread_info[thread_index].thread_name, "test_ca");
     memset(&d, 0, sizeof(d));
     memset(d.capmt, -1, sizeof(d.capmt));
     d.enabled = 1;

--- a/tests/test_ddci.c
+++ b/tests/test_ddci.c
@@ -469,7 +469,7 @@ int main() {
     opts.log = 65535;
     opts.debug = 0;
     opts.cache_dir = "/tmp";
-    strcpy(thread_name, "test_ddci");
+    strcpy(thread_info[thread_index].thread_name, "test_ddci");
     init_alloc();
     TEST_FUNC(test_channels(), "testing test_channels");
     TEST_FUNC(test_add_del_pmt(), "testing adding and removing pmts");

--- a/tests/test_dvb.c
+++ b/tests/test_dvb.c
@@ -72,7 +72,7 @@ int test_detect_dvb_parameters_roll_off() {
 int main() {
   opts.log = 1;
   opts.debug = 255;
-  strcpy(thread_name, "test_dvb");
+  strcpy(thread_info[thread_index].thread_name, "test_dvb");
 
   TEST_FUNC(test_detect_dvb_parameters_general(), "test detect_dvb_parameters with general parameters");
   TEST_FUNC(test_detect_dvb_parameters_roll_off(), "test detect_dvb_parameters roll-off parsing");

--- a/tests/test_pmt.c
+++ b/tests/test_pmt.c
@@ -153,7 +153,7 @@ int test_wait_pusi() {
 int main() {
     opts.log = 255;
     opts.debug = 255;
-    strcpy(thread_name, "test_pmt");
+    strcpy(thread_info[thread_index].thread_name, "test_pmt");
     TEST_FUNC(test_wait_pusi(), "testing decrypt");
     TEST_FUNC(test_decrypt(), "testing decrypt");
     fflush(stdout);

--- a/tests/test_socketworks.c
+++ b/tests/test_socketworks.c
@@ -200,7 +200,7 @@ int test_socket_buffering() {
 
 int main() {
     opts.log = 1; // LOG_UTILS | LOG_SOCKET;
-    strcpy(thread_name, "test_socketworks");
+    strcpy(thread_info[thread_index].thread_name, "test_socketworks");
     init_alloc();
     _writev = writev;
     int fd[2];

--- a/tests/test_utils.c
+++ b/tests/test_utils.c
@@ -27,8 +27,6 @@
 #include <string.h>
 #include <sys/stat.h>
 
-extern __thread char thread_name[100];
-
 int test_mkdir_recursive() {
     const char *dir = "/tmp/minisatip/test";
     mkdir_recursive(dir);
@@ -85,7 +83,7 @@ int test_fifo() {
 
 int main() {
     opts.log = 255;
-    strcpy(thread_name, "test_utils");
+    strcpy(thread_info[thread_index].thread_name, "test_utils");
     TEST_FUNC(test_mkdir_recursive(), "testing directory creation");
     TEST_FUNC(test_fifo(), "testing fifo");
     return 0;

--- a/tests/utils/test_hash_table.c
+++ b/tests/utils/test_hash_table.c
@@ -24,8 +24,6 @@
 #include "opts.h"
 #include <string.h>
 
-extern __thread char thread_name[100];
-
 #define MAX_HASH 100
 #define KEY_FOR_INDEX(i) (i)
 
@@ -69,7 +67,7 @@ int test_hash_table() {
 
 int main() {
     opts.log = 255;
-    strcpy(thread_name, "test_hash_table");
+    strcpy(thread_info[thread_index].thread_name, "test_hash_table");
     TEST_FUNC(test_hash_table(), "testing hash table");
     return 0;
 }


### PR DESCRIPTION
In case of core dump the TLS (Thread Local Storage) is not accessible. If the stack is corrupted is very tricky to figure out where minisatip died.
This PR saves all the LOGs in a thread specific variable (last_log) which allows figuring out around where minisatip crashed.