### PR TITLE
Inject a virtual SDT instead of mapping PID 17 from the first PMT

### DIFF
--- a/src/ddci.c
+++ b/src/ddci.c
@@ -583,7 +583,7 @@ int ddci_create_sdt(ddci_device_t *d, uint8_t *sdt) {
     SPMT *pmt;
     for (i = 0; i < MAX_CHANNELS_ON_CI; i++) {
         if ((pmt = get_pmt(d->pmt[i].id))) {
-            LOG("Adding PMT %d to SDT, sid %d", d->pmt[i].id, pmt->sid);
+            LOGM("Adding PMT %d to SDT, sid %d", d->pmt[i].id, pmt->sid);
             ddci_mapping_table_t *m =
                 get_pid_mapping(d, pmt->adapter, pmt->pid);
             if (!m) {

--- a/src/ddci.c
+++ b/src/ddci.c
@@ -555,31 +555,6 @@ int ddci_create_pat(ddci_device_t *d, uint8_t *b) {
     return len;
 }
 
-void ddci_replace_pi(ddci_device_t *d, int adapter, unsigned char *es,
-                     int len) {
-
-    int es_len, capid;
-    int i;
-
-    for (i = 0; i < len; i += es_len) // reading program info
-    {
-        es_len = es[i + 1] + 2;
-        if (es[i] != 9)
-            continue;
-        capid = (es[i + 4] & 0x1F) * 256 + es[i + 5];
-        ddci_mapping_table_t *m = get_pid_mapping(d, adapter, capid);
-        int dpid = capid;
-
-        if (m)
-            dpid = m->ddci_pid;
-
-        es[i + 4] &= 0xE0; //~0x1F
-        es[i + 4] |= (dpid >> 8);
-        es[i + 5] = dpid & 0xFF;
-        LOGM("%s: CA pid %d -> pid %d", __FUNCTION__, capid, dpid)
-    }
-}
-
 uint16_t YMDtoMJD(int Y, int M, int D) {
     int L = (M < 3) ? 1 : 0;
     return 14956 + D + (int)((Y - L) * 365.25) +

--- a/src/ddci.h
+++ b/src/ddci.h
@@ -33,9 +33,9 @@ typedef struct ddci_device {
     int cat_processed;
     int capid[MAX_CA_PIDS];
     uint64_t read_index[MAX_ADAPTERS]; // read index per adapter
-    uint64_t last_pat, last_pmt;
+    uint64_t last_pat, last_sdt, last_pmt;
     int tid, ver;
-    char pat_cc;
+    char pat_cc, sdt_cc;
     char disable_cat;
     SHashTable mapping;
     SFIFO fifo;
@@ -76,6 +76,7 @@ int push_ts_to_adapter(ddci_device_t *d, adapter *ad, uint16_t *mapping);
 void set_pid_ts(unsigned char *b, int pid);
 int ddci_process_ts(adapter *ad, ddci_device_t *d);
 int ddci_create_pat(ddci_device_t *d, uint8_t *b);
+int ddci_create_sdt(ddci_device_t *d, uint8_t *b);
 int ddci_create_pmt(ddci_device_t *d, SPMT *pmt, uint8_t *new_pmt, int pmt_size,
                     ddci_pmt_t *dp);
 ddci_mapping_table_t *get_pid_mapping_allddci(int ad, int pid);

--- a/src/pmt.c
+++ b/src/pmt.c
@@ -1576,7 +1576,7 @@ int assemble_packet(SFilter *f, uint8_t *b) {
         len = assemble_normal(f, b);
 
     b = f->data;
-    if ((len > 0) && (f->flags & FILTER_CRC)) // check the crc for PAT and PMT
+    if ((len > 0) && (f->flags & FILTER_CRC)) // check the crc for tables
     {
         uint32_t current_crc;
         if (len < 4 || len > FILTER_PACKET_SIZE)


### PR DESCRIPTION
Should fix accidentally overwriting PID 18 (the virtual EIT) on the DDCI adapter with an SDT that has been mapped from PID 17 to PID 18.

Still not runtime tested, but the test cases pass now.