### PR TITLE
Refactor virtual EIT generation somewhat

### DIFF
--- a/src/ddci.c
+++ b/src/ddci.c
@@ -622,7 +622,7 @@ uint16_t YMDtoMJD(int Y, int M, int D) {
 }
 
 // Based on vdr implementation provided by Klaus Schmidinger
-int ddci_create_epg(ddci_device_t *d, int sid, uint8_t *eit, int version) {
+int ddci_create_eit(ddci_device_t *d, int sid, uint8_t *eit, int version) {
     uint8_t *PayloadStart;
     uint8_t *SectionStart;
     uint8_t *DescriptorsStart;
@@ -830,10 +830,10 @@ int ddci_add_psi(ddci_device_t *d, uint8_t *dst, int len) {
                 // ADD EPG as well
                 if (len - pos >= 188)
                     pos +=
-                        ddci_create_epg(d, pmt->sid, dst + pos, d->pmt[i].ver);
+                        ddci_create_eit(d, pmt->sid, dst + pos, d->pmt[i].ver);
             }
             if (len - pos >= 188)
-                pos += ddci_create_epg(d, MAKE_SID_FOR_CA(d->id, i), dst + pos,
+                pos += ddci_create_eit(d, MAKE_SID_FOR_CA(d->id, i), dst + pos,
                                        d->pmt[i].ver);
         }
         d->last_pmt = ctime;

--- a/src/ddci.c
+++ b/src/ddci.c
@@ -623,33 +623,27 @@ uint16_t YMDtoMJD(int Y, int M, int D) {
 
 // Based on vdr implementation provided by Klaus Schmidinger
 int ddci_create_eit(ddci_device_t *d, int sid, uint8_t *eit, int version) {
-    uint8_t *PayloadStart;
-    uint8_t *SectionStart;
-    uint8_t *DescriptorsStart;
-    uint8_t ver = (version & 0x0F);
-    static int counter[MAX_ADAPTERS];
-    memset(eit, 0xFF, 188);
+    // Make an event that starts one hour in the past
     struct tm tm_r;
     time_t t =
         time(NULL) - 3600; // let's have the event start one hour in the past
     struct tm *tm = localtime_r(&t, &tm_r);
     uint16_t MJD = YMDtoMJD(tm->tm_year, tm->tm_mon + 1, tm->tm_mday);
+    
     uint8_t *p = eit;
-    // TS header:
-    *p++ = 0x47;
-    *p++ = 0x40;
-    *p++ = 0x12;
-    *p++ = 0x10 | (counter[d->id]++ & 0x0F); // continuity counter
+
     *p++ = 0x00; // pointer field (payload unit start indicator is set)
     // payload:
-    PayloadStart = p;
+    uint8_t *PayloadStart = p;
     *p++ = 0x4E; // TID present/following event on this transponder
-    *p++ = 0xF0;
-    *p++ = 0x00; // section length
-    SectionStart = p;
-    *p++ = sid >> 8;
-    *p++ = sid & 0xFF;
-    *p++ = 0xC1 | (ver << 1);
+    // section_syntax_indicator, reserved_future_use, reserved, section_length
+    *p++ = 0xF0; // 11110000
+    *p++ = 0x00; // 00000000
+    uint8_t *SectionStart = p;
+    // service_id
+    copy16(p, 0, sid);
+    p += 2;
+    *p++ = 0xC1 | ((version & 0x0F) << 1);
     *p++ = 0x00;        // section number
     *p++ = 0x00;        // last section number
     *p++ = 0x00;        // transport stream id
@@ -660,17 +654,19 @@ int ddci_create_eit(ddci_device_t *d, int sid, uint8_t *eit, int version) {
     *p++ = 0x4E;        // last table id
     *p++ = 0x00;        // event id
     *p++ = 0x01;        // ...
-    *p++ = MJD >> 8;    // start time
-    *p++ = MJD & 0xFF;  // ...
+    copy16(p, 0, MJD);  // start time
+    p += 2;
     *p++ = tm->tm_hour; // ...
     *p++ = tm->tm_min;  // ...
     *p++ = tm->tm_sec;  // ...
     *p++ = 0x24;        // duration (one day, should cover everything)
     *p++ = 0x00;        // ...
     *p++ = 0x00;        // ...
-    *p++ = 0x90;        // running status, _free/CA mode
-    *p++ = 0x00;        // descriptors loop length
-    DescriptorsStart = p;
+    uint8_t r = 4 << 5; // running_status = 4
+    r ^= 1 << 4;        // free_CA_mode = 1
+    *p++ = r;
+    *p++ = 0x00;        // descriptors_length
+    uint8_t *DescriptorsStart = p;
     *p++ = 0x55; // parental descriptor tag
     *p++ = 0x04; // descriptor length
     *p++ = '9';  // country code "902" ("All countries") -> EN 300 468 / 6.2.28;
@@ -683,11 +679,10 @@ int ddci_create_eit(ddci_device_t *d, int sid, uint8_t *eit, int version) {
     *(DescriptorsStart - 1) = p - DescriptorsStart;
     // checksum
     int crc = crc_32(PayloadStart, p - PayloadStart);
-    *p++ = crc >> 24;
-    *p++ = crc >> 16;
-    *p++ = crc >> 8;
-    *p++ = crc;
-    return 188;
+    copy32(p, 0, crc);
+    p += 4;
+
+    return p - eit;
 }
 
 int safe_get_pid_mapping(ddci_device_t *d, int aid, int pid) {
@@ -827,14 +822,11 @@ int ddci_add_psi(ddci_device_t *d, uint8_t *dst, int len) {
                     LOG("%s: could not find PMT %d adapter %d and pid %d to "
                         "mapping table",
                         __FUNCTION__, d->pmt[i].id, pmt->adapter, pmt->pid);
-                // ADD EPG as well
-                if (len - pos >= 188)
-                    pos +=
-                        ddci_create_eit(d, pmt->sid, dst + pos, d->pmt[i].ver);
+
+                // Add an EIT table for each channel
+                psi_len = ddci_create_eit(d, pmt->sid, dst + pos, d->pmt[i].ver);
+                pos += buffer_to_ts(dst + pos, len - pos, psi, psi_len, &d->eit_cc, 18);
             }
-            if (len - pos >= 188)
-                pos += ddci_create_eit(d, MAKE_SID_FOR_CA(d->id, i), dst + pos,
-                                       d->pmt[i].ver);
         }
         d->last_pmt = ctime;
     }

--- a/src/ddci.h
+++ b/src/ddci.h
@@ -35,7 +35,7 @@ typedef struct ddci_device {
     uint64_t read_index[MAX_ADAPTERS]; // read index per adapter
     uint64_t last_pat, last_sdt, last_pmt;
     int tid, ver;
-    char pat_cc, sdt_cc;
+    char pat_cc, sdt_cc, eit_cc;
     char disable_cat;
     SHashTable mapping;
     SFIFO fifo;


### PR DESCRIPTION
* don't write a full TS packet, use `buffer_to_ts` like for our other tables
* move CC counter to the adapter
* don't add EIT for the non-existant SID returned by `MAKE_SID_FOR_CA()`, only add for the SIDs we actually have in the transport stream