### PR TITLE
Don't build AXE builds with PMT=0

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -31,7 +31,6 @@ jobs:
       run: |
        make clean
        ./configure --disable-dvbapi --enable-static --host=sh4-linux --disable-dvbaes --disable-dvbca --enable-axe
-       make PMT=0
        zip -9 -r /minisatip_axe.zip minisatip html
 
     - name: Build MIPS


### PR DESCRIPTION
Closes #1099

Note that this is for master, since the AXE binaries are only built for that branch