### PR TITLE
Fix bugs in "-o" parameter parsing, factor out and add tests

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -43,6 +43,7 @@ SOURCES=\
 	stream.c \
 	adapter.c \
 	httpc.c \
+	opts.c \
 	utils.c \
 	api/symbols.c \
 	api/variables.c \

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -970,29 +970,7 @@ void set_options(int argc, char *argv[]) {
                 app_name);
             exit(0);
 #else
-
-            char buf[100];
-            memset(buf, 0, sizeof(buf));
-            safe_strncpy(buf, optarg);
-            if (buf[0] == '~') {
-                opts.pids_all_no_dec = 1;
-                memmove(&buf[0], &buf[1], sizeof(buf) - 1);
-            }
-            char *sep2 = strchr(buf, ',');
-            if (sep2 != NULL) {
-                *sep2 = 0;
-                opts.dvbapi_offset = map_int(sep2 + 1, NULL);
-                _strncpy(buf, optarg, sizeof(optarg) - 1 - strlen(sep2));
-            }
-            char *sep1 = strchr(buf, ':');
-            if (sep1 != NULL) {
-                *sep1 = 0;
-                safe_strncpy(opts.dvbapi_host, buf);
-                opts.dvbapi_port = map_int(sep1 + 1, NULL);
-            } else {
-                safe_strncpy(opts.dvbapi_host, buf);
-                opts.dvbapi_port = 9000;
-            }
+            parse_dvbapi_opt(optarg, &opts);
 #endif
             break;
         }

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -970,10 +970,7 @@ void set_options(int argc, char *argv[]) {
                 app_name);
             exit(0);
 #else
-            if (sizeof(optarg) > 99) {
-                LOG("-o argument too long: %s", optarg);
-                exit(1);
-            }
+
             char buf[100];
             memset(buf, 0, sizeof(buf));
             safe_strncpy(buf, optarg);

--- a/src/opts.c
+++ b/src/opts.c
@@ -29,13 +29,13 @@ void parse_dvbapi_opt(char *optarg, struct_opts_t *optz) {
     safe_strncpy(buf, optarg);
     if (buf[0] == '~') {
         optz->pids_all_no_dec = 1;
-        memmove(&buf[0], &buf[1], sizeof(buf) - 1);
+        memmove(buf, buf + 1, strlen(buf));
     }
     char *sep2 = strchr(buf, ',');
     if (sep2 != NULL) {
         *sep2 = 0;
         optz->dvbapi_offset = map_int(sep2 + 1, NULL);
-        _strncpy(buf, optarg, sizeof(optarg) - 1 - strlen(sep2));
+        memmove(buf, buf, strlen(buf) - 1 - strlen(sep2));
     }
     char *sep1 = strchr(buf, ':');
     if (sep1 != NULL) {

--- a/src/opts.c
+++ b/src/opts.c
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2014-2023 Catalin Toda <catalinii@yahoo.com> et al
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+ * USA
+ *
+ */
+
+#include "opts.h"
+#include "utils.h"
+#include "utils/logging/logging.h"
+#include <string.h>
+
+void parse_dvbapi_opt(char *optarg, struct_opts_t *optz) {
+    char buf[100];
+    memset(buf, 0, sizeof(buf));
+    safe_strncpy(buf, optarg);
+    if (buf[0] == '~') {
+        optz->pids_all_no_dec = 1;
+        memmove(&buf[0], &buf[1], sizeof(buf) - 1);
+    }
+    char *sep2 = strchr(buf, ',');
+    if (sep2 != NULL) {
+        *sep2 = 0;
+        optz->dvbapi_offset = map_int(sep2 + 1, NULL);
+        _strncpy(buf, optarg, sizeof(optarg) - 1 - strlen(sep2));
+    }
+    char *sep1 = strchr(buf, ':');
+    if (sep1 != NULL) {
+        // Hostname and port
+        *sep1 = 0;
+        safe_strncpy(optz->dvbapi_host, buf);
+        optz->dvbapi_port = map_int(sep1 + 1, NULL);
+    } else {
+        // Socket file
+        safe_strncpy(optz->dvbapi_host, buf);
+        optz->dvbapi_port = 9000;
+    }
+
+    if (optz->dvbapi_host[0] == '/') {
+        LOG("Using DVBAPI socket at %s", optz->dvbapi_host);
+    } else {
+        LOG("Using DVBAPI server at %s:%d, offset %d", optz->dvbapi_host,
+            optz->dvbapi_port, optz->dvbapi_offset);
+    }
+
+    if (optz->pids_all_no_dec) {
+        LOG("Not filtering out encrypted packets from pids=all streams");
+    }
+}

--- a/src/opts.h
+++ b/src/opts.h
@@ -6,7 +6,7 @@
 #include <stdint.h>
 #include <time.h>
 
-struct struct_opts {
+typedef struct struct_opts {
     char *rrtp;
     char *name_app;
     char *command_line;
@@ -87,7 +87,10 @@ struct struct_opts {
     int axe_unicinp[4];
     int axe_power;
 #endif
-};
-extern struct struct_opts opts;
+} struct_opts_t;
+
+void parse_dvbapi_opt(char *optarg, struct_opts_t *optz);
+
+extern struct_opts_t opts;
 
 #endif

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -15,6 +15,7 @@ else
 endif
 
 SOURCES=\
+	test_opts.c \
 	test_ca.c \
 	test_pmt.c \
 	test_ddci.c \

--- a/tests/test_opts.c
+++ b/tests/test_opts.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2014-2023 Catalin Toda <catalinii@yahoo.com> et al
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+ * USA
+ *
+ */
+
+#include "opts.h"
+#include "utils/testing.h"
+#include <stdio.h>
+#include <string.h>
+
+void _reset_dvbapi_opts() {
+    opts.pids_all_no_dec = 0;
+    opts.dvbapi_offset = 0;
+    opts.dvbapi_port = 0;
+    memset(opts.dvbapi_host, 0, sizeof(opts.dvbapi_host));
+}
+
+void _parse_dvbapi_opt(char *optarg) {
+    LOG("Parsing \"%s\"", optarg);
+    _reset_dvbapi_opts();
+    parse_dvbapi_opt(optarg, &opts);
+}
+
+int test_parse_dvbapi_opt() {
+    // Socket
+    _parse_dvbapi_opt("/tmp/camd.socket");
+    ASSERT(opts.pids_all_no_dec == 0, "opts.pids_all_no_dec != 0");
+    ASSERT(opts.dvbapi_offset == 0, "opts.dvbapi_offset != 0");
+    ASSERT(opts.dvbapi_port == 9000, "opts.dvbapi_port != 9000");
+    ASSERT(strcmp(opts.dvbapi_host, "/tmp/camd.socket") == 0,
+           "opts.dvbapi_host != \"/tmp/camd.socket\"");
+
+    // Socket with offset or port doesn't make sense, so skip checking those
+
+    // Host
+    _parse_dvbapi_opt("192.168.1.100");
+    ASSERT(opts.pids_all_no_dec == 0, "opts.pids_all_no_dec != 0");
+    ASSERT(opts.dvbapi_offset == 0, "opts.dvbapi_offset != 0");
+    ASSERT(opts.dvbapi_port == 9000, "opts.dvbapi_port != 9000");
+    ASSERT(strcmp(opts.dvbapi_host, "192.168.1.100") == 0,
+           "opts.dvbapi_host != \"192.168.1.100\"");
+
+    // Host with pids_all_no_dec
+    _parse_dvbapi_opt("~192.168.1.100");
+    ASSERT(opts.pids_all_no_dec == 1, "opts.pids_all_no_dec != 1");
+    ASSERT(opts.dvbapi_offset == 0, "opts.dvbapi_offset != 0");
+    ASSERT(opts.dvbapi_port == 9000, "opts.dvbapi_port != 9000");
+    ASSERT(strcmp(opts.dvbapi_host, "192.168.1.100") == 0,
+           "opts.dvbapi_host != \"192.168.1.100\"");
+
+    // Host with port
+    _parse_dvbapi_opt("192.168.1.100:9001");
+    ASSERT(opts.pids_all_no_dec == 0, "opts.pids_all_no_dec != 0");
+    ASSERT(opts.dvbapi_offset == 0, "opts.dvbapi_offset != 0");
+    ASSERT(opts.dvbapi_port == 9001, "opts.dvbapi_port != 9001");
+    ASSERT(strcmp(opts.dvbapi_host, "192.168.1.100") == 0,
+           "opts.dvbapi_host != \"192.168.1.100\"");
+
+    // Host with port and offset
+    _parse_dvbapi_opt("192.168.1.100:9001,1");
+    ASSERT(opts.pids_all_no_dec == 0, "opts.pids_all_no_dec != 0");
+    ASSERT(opts.dvbapi_offset == 1, "opts.dvbapi_offset != 1");
+    ASSERT(opts.dvbapi_port == 9001, "opts.dvbapi_port != 9001");
+    ASSERT(strcmp(opts.dvbapi_host, "192.168.1.100") == 0,
+           "opts.dvbapi_host != \"192.168.1.100\"");
+
+    // Host with port and offset and pids_all_no_dec
+    _parse_dvbapi_opt("~192.168.1.100:9001,1");
+    ASSERT(opts.pids_all_no_dec == 1, "opts.pids_all_no_dec != 1");
+    ASSERT(opts.dvbapi_offset == 1, "opts.dvbapi_offset != 1");
+    ASSERT(opts.dvbapi_port == 9001, "opts.dvbapi_port != 9001");
+    ASSERT(strcmp(opts.dvbapi_host, "192.168.1.100") == 0,
+           "opts.dvbapi_host != \"192.168.1.100\"");
+
+    return 0;
+}
+
+int main() {
+    opts.log = 255;
+    strcpy(thread_info[thread_index].thread_name, "test_opts");
+    TEST_FUNC(test_parse_dvbapi_opt(), "parse_dvbapi_offset() failed");
+    return 0;
+}


### PR DESCRIPTION
This is against `next` but should be backported to `master` as well.

@uwe5 are you able to test this?

@catalinii I only factored out parsing of this particular parameter here, but IMO all but the most trivial parameters should get the same treatment so we can write tests and verify the parsing actually works. Especially options with multiple optional prefixes/suffixes etc. are really hard to verify just by looking at the code.

@lars18th feel free to test as well, you were the last one who touched this