### PR TITLE
Fix building with --enable-axe --disable-dvbca

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,3 +36,10 @@ jobs:
        make clean
        ./configure --enable-linuxdvb --enable-dvbca --enable-dvbcsa --enable-netcv --enable-satipc --enable-dvbapi --enable-axe
        make
+
+    - name: Build with --enable-axe, without libssl-dev
+      run: |
+       apt-get -y remove --purge libssl-dev
+       make clean
+       ./configure --enable-axe --enable-dvbapi --enable-dvbcsa --disable-dvbca --disable-dvbaes --disable-netcv
+       make

--- a/src/axe.c
+++ b/src/axe.c
@@ -19,7 +19,6 @@
  */
 
 #include "adapter.h"
-#include "ca.h"
 #include "dvb.h"
 #include "minisatip.h"
 #include "utils.h"


### PR DESCRIPTION
We must not include anything that depends on `<openssl>` since it's not available on AXE devices