### PR TITLE
Resolve warning in stream.c

### DIFF
--- a/src/stream.c
+++ b/src/stream.c
@@ -607,7 +607,7 @@ int enqueue_rtp_header(streams *sid, struct iovec *iov, int liov,
         len = 4;
     }
 
-    copy16(rtp_buf, len + 0, 0x8021);
+    copy16(rtp_buf, len + 0, (uint16_t)0x8021);
     copy16(rtp_buf, len + 2, sid->seq);
     copy32(rtp_buf, len + 4, timestamp);
     copy32(rtp_buf, len + 8, sid->ssrc);


### PR DESCRIPTION
Fixes:

stream.c:611:5: warning: implicit conversion from 'int' to 'char' changes value from 128 to -128 [-Wconstant-conversion]
    copy16(rtp_buf, len + 0, (uint16_t)0x8021);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/minisatip.h:34:27: note: expanded from macro 'copy16'
        a[i] = ((v) >> 8) & 0xFF;                                              \
             ~ ~~~~~~~~~~~^~~~~~
1 warning generated.