### PR TITLE
Add --bind-http (-U) parameter to set HTTP port address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Help
 	* 1 - use demuxX device 
 	* 2 - use dvrX device and additionally capture PSI data from demuxX device 
 	* 3 - use demuxX device and additionally capture PSI data from demuxX device 
-* -V --bind address: address for listeningg (RTSP + SSDP)
+* -V --bind address: address for listening (RTSP + SSDP)
 * -U --bind-http address: address for listening (HTTP)
 * -J --bind-dev device: device name for binding (all services)
         * beware that only works with 1 device. loopback may not work!

--- a/README.md
+++ b/README.md
@@ -238,7 +238,8 @@ Help
 	* 1 - use demuxX device 
 	* 2 - use dvrX device and additionally capture PSI data from demuxX device 
 	* 3 - use demuxX device and additionally capture PSI data from demuxX device 
-* -V --bind address: address for listening (all services)
+* -V --bind address: address for listeningg (RTSP + SSDP)
+* -U --bind-http address: address for listening (HTTP)
 * -J --bind-dev device: device name for binding (all services)
         * beware that only works with 1 device. loopback may not work!
 

--- a/src/opts.h
+++ b/src/opts.h
@@ -12,7 +12,8 @@ typedef struct struct_opts {
     char *command_line;
     char *http_host; // http-server host
     char *rtsp_host; // rtsp-server host
-    char *bind;      // bind address
+    char *bind;      // bind address (RTSP + SSDP)
+    char *bind_http; // bind address (HTTP)
     char *bind_dev;  // bind device
     char *datetime_compile;
     time_t start_time;


### PR DESCRIPTION
First of all, big thanks to @catalinii for minisatip and everyone else contributing fixes and features.

I have a very stable working setup on a Raspberry Pi CM4 with minisatip, a TBS6900, and TVHeadend and was glad the `-V` parameter allowed me to bind minisatip to localhost. Unfortunately, this currently also binds the HTTP port to localhost. Because I wanted to access the HTTP port for monitoring from my network and keep RTSP/SSDP at localhost, I introduced the `-U --bind-http address` parameter. With that modification I am happy with my setup and want to also share the code here, just in case it is considered helpful for everyone, or if someone wants to cherry-pick it.