### PR TITLE
AXE build changes, attempt to store build artifacts

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build AXE
       run: |
        make clean
-       ./configure --disable-netcv --disable-dvbapi --enable-static --host=sh4-linux --disable-dvbaes --disable-dvbca --enable-axe
+       ./configure --disable-netcv --disable-dvbapi --enable-static --host=sh4-linux --disable-dvbca --enable-axe
        make PMT=0
        zip -9 -r /minisatip_axe.zip minisatip html
 

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -41,6 +41,15 @@ jobs:
        make EXTRA_CFLAGS="-I/sysroot/mipsel/include -L/sysroot/mipsel/lib" EMBEDDED=1
        zip -9 -r /minisatip_mips.zip minisatip html
 
+    - name: Archive built binaries
+      uses: actions/upload-artifact@v4
+      with:
+        name: minisatip
+        path: |
+          /minisatip_x64.zip
+          /minisatip_arm.zip
+          /minisatip_axe.zip
+          /minisatip_mips.zip
 
     - name: Bump version and push tag/create release point
       uses: anothrNick/github-tag-action@1.35.0

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -30,8 +30,8 @@ jobs:
     - name: Build AXE
       run: |
        make clean
-       ./configure --disable-netcv --disable-dvbapi --enable-static --host=sh4-linux --disable-dvbca --enable-axe
-       make PMT=0
+       ./configure --enable-static --host=sh4-linux --disable-netcv --disable-dvbca --enable-axe --enable-dvbapi --enable-dvbcsa
+       make
        zip -9 -r /minisatip_axe.zip minisatip html
 
     - name: Build MIPS


### PR DESCRIPTION
Was looking for an easy way to test #1140 on my AXE devices, this should help with that. The idea is to be able to download the built binaries from any GitHub workflow run.