### PR TITLE
Release adapter if there are no listening clients.

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -309,6 +309,7 @@ int init_hw(int i) {
         ad->delsys(i, ad->fe, ad->sys);
     ad->master_sid = -1;
     ad->sid_cnt = 0;
+    ad->nosid_cnt = 0;
     ad->pid_err = ad->dec_err = 0;
     ad->new_gs = 0;
     ad->force_close = 0;

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -31,6 +31,7 @@ typedef struct ca_device ca_device_t;
 
 #define MAX_DELSYS 10
 #define MAX_PMT_FOR_ADAPTER 255
+#define MAX_NOSID 3000
 
 typedef struct struct_adapter adapter;
 struct struct_adapter {
@@ -54,6 +55,7 @@ struct struct_adapter {
     int ca_mask;
     int master_sid; // first SID, the one that controls the tuning
     int sid_cnt;    // number of streams
+    int nosid_cnt;
     int sock, fe_sock;
     int do_tune;
     int force_close;

--- a/src/stream.c
+++ b/src/stream.c
@@ -1090,6 +1090,19 @@ int read_dmx(sockets *s) {
         return 0;
     }
 
+    LOG("adapter %d sid_cnt %d nosid_cnt %d", ad->id, ad->sid_cnt, ad->nosid_cnt);
+    if (ad->sid_cnt < 1) {
+        ad->nosid_cnt++;
+        if (ad->nosid_cnt > MAX_NOSID){
+            ad->nosid_cnt = 0;
+            request_adapter_close(ad);
+        }
+        s->rlen = 0;
+        return 0;
+    }
+    else
+        ad->nosid_cnt = 0;
+
     threshold = ad->threshold;
 
     if (rtime - ad->rtime > threshold)


### PR DESCRIPTION
Hi,

I have Sundtek DVB-S/S2 USB device, which works reasonably well. It works most of the time, but is a bit unreliable and sometimes fails to tune correctly. I've been trying to debug where the problem is - it could be MythTV, minisatip, the drivers, device or my cables... Anyway, as part of my research I came across [this forum post](https://minisatip.org/forum/viewtopic.php?f=5&t=840&p=4368&hilit=sundtek&sid=9cb93658b17be3a90bdc2259c22973ab#p4368) which contains a patch to get minisatip to correctly release a tuner when no-one is listening, and I can't see it having been submitted. I think this might also relate to #586.

I'm aware that in the forum post there is a comment that this might be better done with a timer, but at least initially I wanted to submit the patch as-is, for completion and for attribution to the original poster, Rainer.

This patch seems to work well for me, and the devices do go offline when not in use, which previously they didn't. It also seems to improve the instability I see a bit, but doesn't fix it completely though. I suspect that's a Sundtek driver issue though.

Thanks,
Andrew
