### PR TITLE
Add support for service blacklisting for CAMs

### DIFF
--- a/src/ddci.c
+++ b/src/ddci.c
@@ -292,11 +292,9 @@ int find_ddci_for_pmt(Sddci_channel *c, SPMT *pmt) {
     int ddid = -100;
     int retry = 0;
 
-    // search always from the beginning when the PMT is started
-
-    // continue where we left off
-    for (c->pos = 0; c->pos < c->ddcis; c->pos++) {
-        ddid = c->ddci[c->pos].ddci;
+    int i = 0;
+    for (i = 0; i < c->ddcis; i++) {
+        ddid = c->ddci[i].ddci;
         ddci_device_t *d = get_ddci(ddid);
         if (!d) {
             LOG("DDID %d not enabled", ddid);

--- a/src/ddci.c
+++ b/src/ddci.c
@@ -1278,14 +1278,15 @@ void load_channels(SHashTable *ch) {
              opts.cache_dir, CONFIG_FILE_NAME);
 
     FILE *f = fopen(ddci_conf_path, "rt");
-    Sddci_channel c;
     char line[1000];
     int channels = 0;
-    int pos = 0;
     if (!f)
         return;
     while (fgets(line, sizeof(line), f)) {
+        int pos = 0;
         char buf[1000];
+        memset(buf, 0, sizeof(buf));
+        Sddci_channel c;
         memset(&c, 0, sizeof(c));
         char *x = strchr(line, '#');
         if (x)
@@ -1304,7 +1305,6 @@ void load_channels(SHashTable *ch) {
         int la = split(arg, cc, ARRAY_SIZE(arg), ',');
         int i = 0;
         channels++;
-        pos = 0;
         for (i = 0; i < la; i++) {
             int v = map_intd(arg[i], NULL, -1);
             if (v != -1) {

--- a/src/ddci.h
+++ b/src/ddci.h
@@ -62,7 +62,6 @@ typedef struct ddci_channel {
         uint8_t ddci;
     } ddci[MAX_ADAPTERS];
     int ddcis;
-    int pos;
     int sid;
     char name[50];
     char locked;

--- a/tests/test_ddci.c
+++ b/tests/test_ddci.c
@@ -85,22 +85,37 @@ void create_adapter(adapter *ad, int id) {
 int test_channels() {
     SHashTable h;
     int i;
-    Sddci_channel c, *t;
+    Sddci_channel c1, c2, *t;
     memset(&h, 0, sizeof(h));
     create_hash_table(&h, 10);
-    memset(&c, 0, sizeof(c));
-    c.sid = 200;
-    c.ddci[1].ddci = 1;
-    c.ddcis = 1;
-    setItem(&h, c.sid, &c, sizeof(c));
+
+    // Add one channel (SID 200) that can be decoded by DDCI 1
+    memset(&c1, 0, sizeof(c1));
+    c1.sid = 200;
+    c1.ddci[0].ddci = 1;
+    c1.ddcis = 1;
+    setItem(&h, c1.sid, &c1, sizeof(c1));
+
+    // Add a second channel (SID 300) that can be decoded by both DDCI 1 and 2
+    memset(&c2, 0, sizeof(c2));
+    c2.sid = 300;
+    c2.ddci[0].ddci = 1;
+    c2.ddci[1].ddci = 2;
+    c2.ddcis = 2;
+    setItem(&h, c2.sid, &c2, sizeof(c2));
+
+    // Save and reload the table
     save_channels(&h);
     free_hash(&h);
     create_hash_table(&h, 10);
     load_channels(&h);
-    ASSERT(getItem(&h, 200) != NULL, "Saved SID not found in table");
+
+    // Check the contents
+    ASSERT(getItem(&h, 200) != NULL, "Saved SID 200 not found in table");
+    ASSERT(getItem(&h, 300) != NULL, "Saved SID 300 not found in table");
     int ch = 0;
     FOREACH_ITEM(&h, t) { ch++; }
-    ASSERT(ch == 1, "Expected one channel after loading");
+    ASSERT(ch == 2, "Expected two channels after loading");
     free_hash(&h);
     return 0;
 }

--- a/tests/test_ddci.c
+++ b/tests/test_ddci.c
@@ -85,7 +85,7 @@ void create_adapter(adapter *ad, int id) {
 int test_channels() {
     SHashTable h;
     int i;
-    Sddci_channel c1, c2, *t;
+    Sddci_channel c1, c2, c3, *t;
     memset(&h, 0, sizeof(h));
     create_hash_table(&h, 10);
 
@@ -104,6 +104,12 @@ int test_channels() {
     c2.ddcis = 2;
     setItem(&h, c2.sid, &c2, sizeof(c2));
 
+    // Add a third channel (SID 400) that cannot be decoded by any adapter
+    memset(&c3, 0, sizeof(c3));
+    c3.sid = 400;
+    c3.ddcis = 0;
+    setItem(&h, c3.sid, &c3, sizeof(c3));
+
     // Save and reload the table
     save_channels(&h);
     free_hash(&h);
@@ -113,9 +119,10 @@ int test_channels() {
     // Check the contents
     ASSERT(getItem(&h, 200) != NULL, "Saved SID 200 not found in table");
     ASSERT(getItem(&h, 300) != NULL, "Saved SID 300 not found in table");
+    ASSERT(getItem(&h, 400) != NULL, "Saved SID 400 not found in table");
     int ch = 0;
     FOREACH_ITEM(&h, t) { ch++; }
-    ASSERT(ch == 2, "Expected two channels after loading");
+    ASSERT(ch == 3, "Expected two channels after loading");
     free_hash(&h);
     return 0;
 }


### PR DESCRIPTION
Brought up in https://github.com/catalinii/minisatip/issues/1091

Basically this allows the user to prevent a CAM from being used for a particular service, e.g. like this:

```
# ddci.conf
7000: # not assigned anywhere
```

