### PR TITLE
Support new elements, most importantly "Critical Security Update Version"

### DIFF
--- a/src/ca.c
+++ b/src/ca.c
@@ -979,6 +979,11 @@ static int data_initialize(ca_device_t *d) {
         LOG("can not set host_id elements");
     }
 
+    uint8_t csuv = 0x00;
+    if (!element_set(&d->private_data, 49, &csuv, 1)) {
+        LOG("can not set csuv elements");
+    }
+
     return 1;
 }
 /* content_control commands */

--- a/src/ca.c
+++ b/src/ca.c
@@ -81,9 +81,14 @@ char logfile[256];
 int extract_ci_cert = 0;
 int has_ci = 0;
 
+// See Annex A (normative): Parameters exchanged in APDUs
 uint32_t datatype_sizes[MAX_ELEMENTS] = {
-    0,   50,  0,  0, 0, 8,  8,  0, 0, 0, 0,  0, 32, 256, 256, 0, 0,
-    256, 256, 32, 8, 8, 32, 32, 0, 8, 2, 32, 1, 32, 1,   0,   32};
+    0,  0,   0,   0,  0, 8,   8,   0,  0, 0,  0, 0, // 0-11
+    32, 256, 256, 0,  0, 256, 256, 32,              // 12-19
+    8,  8,   32,  32, 0, 8,   2,   32, 1, 32,       // 20-29
+    1,  0,   32,  0,  1, 1,   0,   1,  1, 0,  1,    // 30-40
+    1,  1,   0,   0,  0, 0,   0,   0,  1, 1,  1,    // 41-51
+    4,  0,   1,   0};                               // 52-55
 
 int dvbca_id;
 ca_device_t *ca_devices[MAX_ADAPTERS];

--- a/src/ca.h
+++ b/src/ca.h
@@ -8,7 +8,7 @@
 #define MAX_SESSIONS 64
 #define PMT_INVALID -1
 #define PMT_ID_IS_VALID(x) (x > PMT_INVALID)
-#define MAX_ELEMENTS 33
+#define MAX_ELEMENTS 56
 #define MAX_PAIRS 10
 
 #define SIZE_INDICATOR 0x80


### PR DESCRIPTION
Should fix:

```
[30/12 20:01:53.761 AD2]: req element 49
[30/12 20:01:53.761 AD2]: element_get: invalid id
[30/12 20:01:53.761 AD2]: can not get element 49
[30/12 20:01:53.761 AD2]: cannot get element 49
[30/12 20:01:53.761 AD2]: cannot req data
```

@Delitants can you try your CAM again with this change?

Fixes #1029, fixes #1090, fixes #1134