### PR TITLE
Fix "_hexdump buffer size too small (114)" which has been spoiling hexdumps

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -599,7 +599,9 @@ int init_utils(char *arg0) {
 }
 
 void _hexdump(char *desc, void *addr, int len) {
-    int i, pos = 0, bl = (len * 6 < 100) ? 100 : len * 6;
+    // Each character needs roughly 5 bytes to print. Worst case scenario is 
+    // that one character ends up on a new line, requiring 74 bytes to print.
+    int i, pos = 0, bl = (len * 5) + 74;
     char buff[17];
     char buf[bl];
     unsigned char *pc = (unsigned char *)addr;

--- a/src/utils.h
+++ b/src/utils.h
@@ -54,11 +54,12 @@ void _strncpy(char *a, char *b, int len);
 
 #define strlcatf(buf, size, ptr, fmt...)                                       \
     do {                                                                       \
-        int __r = snprintf((buf) + ptr, (size)-ptr, fmt);                      \
+        int __r = snprintf((buf) + ptr, (size) - ptr, fmt);                    \
         ptr += __r;                                                            \
         if (ptr >= (size)) {                                                   \
-            LOG("%s buffer size too small (%d)", __FUNCTION__, size);          \
-            ptr = (size)-1;                                                    \
+            LOG("%s:%d buffer size too small (%d)", __FUNCTION__, __LINE__,    \
+                size);                                                         \
+            ptr = (size) - 1;                                                  \
         }                                                                      \
     } while (0)
 

--- a/tests/Makefile.in
+++ b/tests/Makefile.in
@@ -24,7 +24,8 @@ SOURCES=\
 	test_minisatip.c \
 	test_utils.c \
 	test_socketworks.c \
-	utils/test_hash_table.c
+	utils/test_hash_table.c \
+	utils/test_utils.c
 
 MAIN_SOURCES=$(shell find ../src -type f -iname '*.c')
 

--- a/tests/utils/test_utils.c
+++ b/tests/utils/test_utils.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2014-2024 Catalin Toda <catalinii@yahoo.com> et al
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307
+ * USA
+ *
+ */
+#define _GNU_SOURCE
+
+#include "opts.h"
+#include "utils.h"
+#include "utils/testing.h"
+#include <string.h>
+
+// This doesn't really test anything, visual inspection is required to verify
+// the results
+int test_hexdump() {
+    const char *data = "some string to \x11\x12\x13\x14 on two lines";
+
+    int i;
+    for (i = 1; i <= 32; i++) {
+        _hexdump(NULL, (void *)data, i);
+    }
+
+    return 0;
+}
+
+int main() {
+    opts.log = 255;
+    strcpy(thread_info[thread_index].thread_name, "test_hexdump");
+    TEST_FUNC(test_hexdump(), "test hexdump");
+    return 0;
+}


### PR DESCRIPTION
Fixes this:

```
[26/06 23:35:00.478 AD4]: _hexdump buffer size too small (114)
Message repeated 6 times
```

The problem was that the allocated length for the buffer was based solely on the length of the input string, not taking into account that a single character of input can require a whole line of hexdump output if it spills over to a new line.