### PR TITLE
Mark current directory as "safe" for git so revision number is parsed correctly

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -14,6 +14,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
+    - name: Configure working directory as git safe.directory
+      run: |
+        git config --global --add safe.directory /__w/minisatip/minisatip
     - name: Build x64
       run: |
        ./configure --enable-static CC="clang -static" --disable-netcv


### PR DESCRIPTION
Currently, official builds done by GitHub get "1.3.~" as version