### PR TITLE
Fix truncated command-line shown in the web interface

### DIFF
--- a/src/api/variables.h
+++ b/src/api/variables.h
@@ -44,6 +44,7 @@
 
 #define JSON_STATE_MAXLEN (256 * 1024)
 #define JSON_BANDWIDTH_MAXLEN 1024
+#define JSON_STRING_MAXLEN 1024
 
 typedef int (*get_data_int)(int p);
 typedef int64_t (*get_data_int64)(int p);
@@ -57,7 +58,7 @@ void *get_var_address(char *var, float *multiplier, int *type, void *storage,
                       int ls);
 
 int escape_json_string(char *dest, int dl, char *src, int sl);
-int get_json_state(char *buf, int len);
+int get_json_state(char *buf, int len, char *sbuf, int slen);
 int get_json_bandwidth(char *buf, int len);
 
 #endif

--- a/src/api/variables.h
+++ b/src/api/variables.h
@@ -42,6 +42,9 @@
 
 #define VAR_LENGTH 20
 
+#define JSON_STATE_MAXLEN (256 * 1024)
+#define JSON_BANDWIDTH_MAXLEN 1024
+
 typedef int (*get_data_int)(int p);
 typedef int64_t (*get_data_int64)(int p);
 typedef char *(*get_data_string)(int p, char *dest, int max_len);

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -1438,8 +1438,6 @@ int read_rtsp(sockets *s) {
         return 0;                                                              \
     }
 
-#define JSON_STATE_MAXLEN (256 * 1024)
-
 int read_http(sockets *s) {
     char *arg[50];
     char buf[2000]; // the XML should not be larger than 1400 as it will create
@@ -1602,13 +1600,14 @@ int read_http(sockets *s) {
     }
 
     if (strcmp(arg[1], "/bandwidth.json") == 0) {
-        char buf[1024];
-        int len = get_json_bandwidth(buf, sizeof(buf));
+        char *buf = _malloc(JSON_BANDWIDTH_MAXLEN);
+        int len = get_json_bandwidth(buf, JSON_BANDWIDTH_MAXLEN);
         http_response(s, 200,
                       "Content-Type: application/json\r\n"
                       "Connection: close\r\n"
                       "Access-Control-Allow-Origin: *",
                       buf, 0, len);
+        _free(buf);
         return 0;
     }
 

--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -1589,13 +1589,17 @@ int read_http(sockets *s) {
 
     if (strcmp(arg[1], "/state.json") == 0) {
         char *buf = _malloc(JSON_STATE_MAXLEN);
-        int len = get_json_state(buf, JSON_STATE_MAXLEN);
+        char *sbuf = _malloc(JSON_STRING_MAXLEN);
+        memset(sbuf, 0, JSON_STRING_MAXLEN);
+        int len =
+            get_json_state(buf, JSON_STATE_MAXLEN, sbuf, JSON_STRING_MAXLEN);
         http_response(s, 200,
                       "Content-Type: application/json\r\n"
                       "Connection: close\r\n"
                       "Access-Control-Allow-Origin: *",
                       buf, 0, len);
         _free(buf);
+        _free(sbuf);
         return 0;
     }
 


### PR DESCRIPTION
When building `state.json`, the maximum string length was limited to 200 bytes. This means that very long command-lines cannot be represented, leading to `escape_json_string:179 buffer size too small (199)`.

For example:

```
/usr/local/bin/minisatip-dvbs2-proxy -f -R /usr/local/share/minisatip-dvbs2-proxy/html/ -I minisatip-dvbs2-proxy -w 10.110.4.14:8080 -U 10.110.4.14 -V 10.110.4.14 -D 414 -R /usr/local/share/minisatip-dvbs2-proxy/html -z /var/cache/minisatip-dvbs2-proxy -s *dvbs2:10.110.4.11 -s *dvbs2:10.110.4.12 -s *dvbs2:10.110.4.11 -s *dvbs2:10.110.4.12 -s *dvbs2:10.110.4.11 -s *dvbs2:10.110.4.12 -s *dvbs2:10.110.4.11 -s *dvbs2:10.110.4.12 -A 0:0:0,0:1:0,0:2:0,0:3:0,0:4:0,0:5:0,1:6:1,1:7:1 -l general
```

With this change, the maximum length is increased to 1 KiB, and the memory is allocated on the heap instead.