### PR TITLE
Use strlen() instead of allocation size

### DIFF
--- a/src/api/variables.c
+++ b/src/api/variables.c
@@ -277,7 +277,8 @@ int get_json_state(char *buf, int len, char *sbuf, int slen) {
                     funs(off, sbuf, slen - 1);
                     if (off > 0)
                         strlcatf(buf, len, ptr, ",");
-                    ptr += escape_json_string(buf + ptr, len - ptr, sbuf, slen);
+                    ptr += escape_json_string(buf + ptr, len - ptr, sbuf,
+                                              strlen(sbuf));
                 }
                 strlcatf(buf, len, ptr, "]");
                 //				LOG("func_str -> %s", buf);


### PR DESCRIPTION
Fixes regression introduced in https://github.com/catalinii/minisatip/pull/1168. AFAICT the original code worked because we allocated the string using `char[]`, but now with dynamic allocation we need to use `strlen()` instead, otherwise we'll have to deal with NULL characters in the loop manually.