### PR TITLE
Fix target device_id when other device is detected

### DIFF
--- a/src/minisatip.c
+++ b/src/minisatip.c
@@ -2031,7 +2031,7 @@ int readBootID() {
         uuid4_generate(opts.uuid);
     }
 
-    if (opts.device_id < 1) {
+    if (opts.device_id < local_device_id) {
         opts.device_id = local_device_id;
     }
 


### PR DESCRIPTION
When the enforced/stored device_id is already used, use another one free.