### PR TITLE
Remove unrecognized option --disable-dvbaes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,5 +50,5 @@ jobs:
       run: |
        apt-get -y remove --purge libssl-dev
        make clean
-       ./configure --enable-axe --enable-dvbapi --enable-dvbcsa --disable-dvbca --disable-dvbaes --disable-netcv
+       ./configure --enable-axe --enable-dvbapi --enable-dvbcsa --disable-dvbca --disable-netcv
        make


### PR DESCRIPTION
Fixes "configure: WARNING: unrecognized options: --disable-dvbaes"

Addition as already fixed in b6d0e50b5a1f5e687407173c61fbecd50db883be
- Was previously in #1141