### PR TITLE
tables_destroy: call ca_close_ca without argument

### DIFF
--- a/src/tables.c
+++ b/src/tables.c
@@ -387,7 +387,7 @@ int tables_destroy() {
     int i;
     for (i = 0; i < nca; i++) {
         if (ca[i].enabled && ca[i].op->ca_close_ca)
-            ca[i].op->ca_close_ca(&ca[i]);
+            ca[i].op->ca_close_ca();
     }
     return 0;
 }


### PR DESCRIPTION
This matches function call and fixes build with gcc-15

    tables.c: In function 'tables_destroy':
    tables.c:390:13: error: too many arguments to function 'ca[i].op->ca_close_ca'
      390 |             ca[i].op->ca_close_ca(&ca[i]);
          |             ^~

- closes #1198 