### PR TITLE
Keep original thread name for main thread (#1208)

### DIFF
--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -702,15 +702,14 @@ void *select_and_execute(void *arg) {
         return NULL;
     }
 
+    tid = get_tid();
     memset(thread_info[thread_index].thread_name, 0,
            sizeof(thread_info[thread_index].thread_name));
     if (arg) {
         safe_strncpy(thread_info[thread_index].thread_name, (char *)arg);
+        pthread_setname_np(tid, thread_info[thread_index].thread_name);
     } else
         strcpy(thread_info[thread_index].thread_name, "main");
-
-    tid = get_tid();
-    pthread_setname_np(tid, thread_info[thread_index].thread_name);
 
     select_timeout = SELECT_TIMEOUT;
     thread_info[thread_index].tid = tid;


### PR DESCRIPTION
Fixes e.g. `killall` not matching the general process by (binary) name.