### PR TITLE
fixed NULL pointer deref + satip off-by-one

### DIFF
--- a/src/satipc.c
+++ b/src/satipc.c
@@ -1682,7 +1682,7 @@ void find_satip_adapter(adapter **a) {
         }
         if (strchr(host, '/')) {
             char *end = strchr(host, '/');
-            _strncpy(source_ip, host, end - host);
+            _strncpy(source_ip, host, end - host + 1);
             memmove(host, end + 1, sizeof(host) - 1);
         }
         port = map_int(sep2, NULL);

--- a/src/socketworks.c
+++ b/src/socketworks.c
@@ -1562,6 +1562,8 @@ int flush_socket_all(sockets *s) {
 
     if (s->spos == s->wpos)
         return 0;
+    if (!s->pack)
+	return 0;
 
     memset(&iov, 0, sizeof(iov));
     spos = s->spos;


### PR DESCRIPTION
1. fixed a problem where the s->pack is NULL most likely due to another thread already freeing the resource leading to a NULL pointer dereference
2. same fix for satip receivers with multiple source IPs.  