### PR TITLE
Fix 0% strength/SNR due to DVB API legacy fallback

### DIFF
--- a/src/dvb.c
+++ b/src/dvb.c
@@ -1853,8 +1853,9 @@ int get_signal_new(adapter *ad, int *status, uint32_t *ber, uint16_t *strength,
         strength_s = "dBm";
         init_strength = enum_cmdargs[0].u.st.stat[0].svalue; // dBm / 1000
         strengthd = get_strength_decibels(init_strength);
-    } else if (enum_cmdargs[0].u.st.stat[0].scale == 0)
-        err |= 1;
+    }
+    //  else if (enum_cmdargs[0].u.st.stat[0].scale == FE_SCALE_NOT_AVAILABLE)
+    //      err |= 1;
 
     if (enum_cmdargs[1].u.st.stat[0].scale == FE_SCALE_RELATIVE) {
         snr_s = "%";
@@ -1864,7 +1865,7 @@ int get_signal_new(adapter *ad, int *status, uint32_t *ber, uint16_t *strength,
         init_snr = enum_cmdargs[1].u.st.stat[0].svalue; // dB * 1000
         *db = (int)get_snr_decibels(init_snr, &snrd, ad->db_snr_map);
     }
-    //	else if (enum_cmdargs[1].u.st.stat[0].scale == 0)
+    //	else if (enum_cmdargs[1].u.st.stat[0].scale == FE_SCALE_NOT_AVAILABLE)
     //		err |= 2;
 
     *ber = enum_cmdargs[2].u.st.stat[0].uvalue & 0x7FFF;


### PR DESCRIPTION
If strength/SNR are not immediately available after tuning/locking, the scale `FE_SCALE_NOT_AVAILABLE` (= 0) is returned. Don't fall back any longer to legacy DVB API for further status requests, as they lead to 0% strength/SNR then, due to failing legacy calls.

Fixes #1211.