### PR TITLE
Specify -std=gnu99

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -16,7 +16,7 @@ AXE=@AXE@
 DDCI=0
 T2MI=0
 
-CFLAGS?=-Wall -Wno-switch -ggdb -fPIC -fno-common -Warray-bounds
+CFLAGS?=-std=gnu99 -Wall -Wno-switch -ggdb -fPIC -fno-common -Warray-bounds
 CFLAGS += -I../src
 CFLAGS += $(EXTRA_CFLAGS) @CFLAGS@
 LDFLAGS += @LDFLAGS@ -lpthread


### PR DESCRIPTION
Fixes this issue when building satip-axe:

```
utils/uuid.c: In function 'uuid4_generate':
utils/uuid.c:11:5: error: 'for' loop initial declarations are only allowed in C99 mode
     for (int i = 0; i < 36; ++i) {
     ^
utils/uuid.c:11:5: note: use option -std=c99 or -std=gnu99 to compile your code
```