### PR TITLE
Fix slave adapter assignments

### DIFF
--- a/src/adapter.c
+++ b/src/adapter.c
@@ -1887,7 +1887,7 @@ void set_slave_adapters(char *o) {
                 continue;
 
             if (master >= 0 && master < MAX_ADAPTERS) {
-                if (!a[master] && !is_adapter_disabled(master))
+                if (!a[master])
                     a[master] = adapter_alloc();
 
                 if (a[master] && a[master]->master_source < 0) {

--- a/src/adapter.c
+++ b/src/adapter.c
@@ -1890,9 +1890,7 @@ void set_slave_adapters(char *o) {
                 if (!a[master])
                     a[master] = adapter_alloc();
 
-                if (a[master] && a[master]->master_source < 0) {
-                    a[master]->master_source =
-                        -2; // force this adapter as master
+                if (a[master]) {
                     ad->master_source = master;
                     LOG("Setting master adapter %d for adapter %d",
                         ad->master_source, j);

--- a/tests/test_opts.c
+++ b/tests/test_opts.c
@@ -18,10 +18,13 @@
  *
  */
 
+#include "adapter.h"
 #include "opts.h"
 #include "utils/testing.h"
 #include <stdio.h>
 #include <string.h>
+
+extern adapter *a[MAX_ADAPTERS];
 
 void _reset_dvbapi_opts() {
     opts.pids_all_no_dec = 0;
@@ -90,9 +93,26 @@ int test_parse_dvbapi_opt() {
     return 0;
 }
 
+int test_set_slave_adapters() {
+    int i;
+    set_slave_adapters("0-1:0,2-3:2");
+
+    for (i = 0; i < 4; i++) {
+        LOG("adapter %d master %d", a[i]->id, a[i]->master_source);
+    }
+
+    ASSERT(a[0]->master_source == 0, "adapter 0 master != 0");
+    ASSERT(a[1]->master_source == 0, "adapter 1 master != 0");
+    ASSERT(a[2]->master_source == 2, "adapter 2 master != 2");
+    ASSERT(a[3]->master_source == 2, "adapter 3 master != 2");
+       
+    return 0;
+}
+
 int main() {
     opts.log = 255;
     strcpy(thread_info[thread_index].thread_name, "test_opts");
     TEST_FUNC(test_parse_dvbapi_opt(), "parse_dvbapi_offset() failed");
+    TEST_FUNC(test_set_slave_adapters(), "test_set_slave_adapters() failed");
     return 0;
 }


### PR DESCRIPTION
Might fix #1225 , fixes certain assignment configurations on AXE devices at least.

Without this patch, `0-1:0,2-3:2` results in the following, which is wrong:

> Setting master adapter 0 for adapter 0
> Setting master adapter 3 for adapter 2

With this patch, the output is correct:

> Setting master adapter 0 for adapter 0
> Setting master adapter 0 for adapter 1
> Setting master adapter 2 for adapter 2
> Setting master adapter 2 for adapter 3

Verified at runtime as well:
![2025-06-10_11-35](https://github.com/user-attachments/assets/6d024ebc-00e1-42af-861f-bc2d44f0e276)
