### PR TITLE
Major fixes for compilation on Fedora 42

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -174,7 +174,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],
 AS_IF([test $enable_bounds_check -eq 0],
   [CXXFLAGS="$ac_save_CFLAGS"])
 
-FM="$FM\nCCXXFLAGS\t\t$CFLAGS"
+FM="$FM\nCXXFLAGS\t\t$CFLAGS"
 
 
 AC_SUBST(LINUXDVB)

--- a/configure.ac
+++ b/configure.ac
@@ -95,6 +95,7 @@ AC_ARG_WITH([xml2],
   [xml2_dir=$with_xml2])
   
 CXXFLAGS="-I$xml2_dir"
+CFLAGS="-I$xml2_dir"
 
 cd src
 AC_CHECK_HEADERS([libnetceiver/netcv/headers.h],[NETCVCLIENT=1],[NETCVCLIENT=0])

--- a/src/netceiver.cpp
+++ b/src/netceiver.cpp
@@ -43,11 +43,11 @@ int m_logskipmask = 0;
 
 extern char *fe_pilot[];
 extern char *fe_rolloff[];
-extern char *fe_delsys[];
-extern char *fe_fec[];
-extern char *fe_modulation[];
-extern char *fe_tmode[];
-extern char *fe_gi[];
+extern const char *fe_delsys[];
+extern const char *fe_fec[];
+extern const char *fe_modulation[];
+extern const char *fe_tmode[];
+extern const char *fe_gi[];
 extern char *fe_hierarchy[];
 extern char *fe_pol[];
 
@@ -163,6 +163,7 @@ int netcv_commit(adapter *ad) {
         switch (tp->sys) {
         case SYS_DVBS:
         case SYS_DVBS2:
+	    {
             m_pos = 1800 + map_pos[tp->diseqc];
 
             memset(&m_sec, 0, sizeof(recv_sec_t));
@@ -214,6 +215,7 @@ int netcv_commit(adapter *ad) {
             // unreachable code
             //			m_fep.u.qpsk.fec_inner |= (tp->ro << 24);
             //			break;
+	    }
 
         case SYS_DVBC_ANNEX_A:
             m_pos = 0xfff; /* not sure, to be tested */


### PR DESCRIPTION
- Fixed: blocking issues
- Pending (can be done by others): compilation only works in permissive mode

```
LC_ALL=C CXXFLAGS="-fpermissive" CFLAGS="-fpermissive" make
```

Successful started afterwards (Netceiver is connected on dedicated network card):

```
minisatip -n eth1:3 -b 15640 –t -f -l netceiver
[27/07 16:04:58.420 main]: Listening configuration RTSP:***:554 (bind address: (null)), HTTP:***:8080 (bind address: (null))
[27/07 16:04:58.421 main]: Running mode: foreground
[27/07 16:04:58.421 main]: minisatip version v2.0.5~0f67bf7, compiled on Jul 27 2025 15:44:23, with s2api version: 050C
[27/07 16:04:58.421 main]: Built without dvbcsa
[27/07 16:04:58.421 main]: Built with CI
[27/07 16:04:58.421 main]: Built with dvbapi
[27/07 16:04:58.421 main]: Built with tables processing
[27/07 16:04:58.421 main]: Built with pmt processing
[27/07 16:04:58.421 main]: Built with satip client
[27/07 16:04:58.421 main]: Built with linux dvb client
[27/07 16:04:58.421 main]: Built with netceiver
[27/07 16:04:58.421 main]: Built without ddci
[27/07 16:04:58.421 main]: Command line: /home/vdrdev/src/minisatip/minisatip -n eth1:3 -b 15640 –t -f -l netceiver
[27/07 16:04:58.421 main]:  LOG  of the module enabled: general
[27/07 16:04:58.421 main]:  LOG  of the module enabled: netceiver
[27/07 16:04:58.421 main]: Initial values bootid 0, device_id 0, UUID  (reading new from /var/cache/minisatip/bootid)
[27/07 16:04:58.421 main]: Running with bootid 1, device_id 1, UUID 2933d8ad-5e37-177b-c82f-a9ca888a2bef
[27/07 16:04:58.421 main]: New TCP listening socket 3 at 0:0:0:0:554, family 2
[27/07 16:04:58.422 main]: New TCP listening socket 4 at 0:0:0:0:8080, family 2
[27/07 16:04:58.422 main]: New UDP socket 5 bound to 0.0.0.0:1900 
[27/07 16:04:58.422 main]: setting multicast for 239.255.255.250
[27/07 16:04:58.422 main]: New UDP socket 6 bound to 239.255.255.250:1900 (mcast:239.255.255.250)
[27/07 16:04:58.422 main]: sockets_add: handle 5 (type 0) returning socket sock 0 [:0] read: 0x406e30
[27/07 16:04:58.422 main]: sockets_add: handle 6 (type 0) returning socket sock 1 [:0] read: 0x406e30
[27/07 16:04:58.422 main]: sockets_add: handle 3 (type 2) returning socket sock 2 [:0] read: 0x409ad0
[27/07 16:04:58.422 main]: sockets_add: handle 4 (type 2) returning socket sock 3 [:0] read: 0x409ad0
[27/07 16:04:58.422 main]: sockets_add: handle -2 (type 0) returning socket sock 4 [:0] read: 0x406e30
[27/07 16:04:58.422 main]: set_socket_thread: thread 7f937500d6c0 for sockets 4
[27/07 16:04:58.422 main]: sockets_add: handle -2 (type 0) returning socket sock 5 [:0] read: 0x406e30
[27/07 16:04:58.422 signal]: set_socket_thread: thread 7f937500d6c0 for sockets 5
[27/07 16:04:58.422 signal]: Starting select_and_execute on thread ID 7f937500d6c0, thread_name signal
[27/07 16:04:58.422 signal]: sockets_add: handle -2 (type 0) returning socket sock 6 [:0] read: 0x406e30
[27/07 16:04:58.422 signal]: set_socket_thread: thread 7f937480c6c0 for sockets 6
[27/07 16:04:58.423 signal]: sockets_add: handle -2 (type 0) returning socket sock 7 [:0] read: 0x406e30
[27/07 16:04:58.423 CA_poll]: Starting select_and_execute on thread ID 7f937480c6c0, thread_name CA_poll
[27/07 16:04:58.423 signal]: starting init_all_hw 0
[27/07 16:05:03.582 signal]: REEL: Search for 3 Netceivers on eth1... ########################################
Found NetCeiver: fe80::2**:**ff:fe**:**** 
	Tuner: Philips TDA10023 DVB-C, Type 1
	Tuner: Philips TDA10023 DVB-C, Type 1
	Tuner: Philips TDA10023 DVB-C, Type 1

[27/07 16:05:03.583 signal]: netceiver: adding [AD0 DVB-C] [AD1 DVB-C] [AD2 DVB-C] 
[27/07 16:05:03.583 signal]: netceiver: creating DVR pipe for adapter 0  -> dvr: 11
[27/07 16:05:03.583 signal]: deleting pids on adapter 0, sid -1, pids=NULL
[27/07 16:05:03.583 signal]: sockets_add: handle 11 (type 5) returning socket sock 8 [:0] read: 0x406dc0
[27/07 16:05:03.584 signal]: set_socket_thread: thread 7f936dffb6c0 for sockets 8
[27/07 16:05:03.584 signal]: done opening adapter 0 delivery systems: dvbc undefined undefined undefined
[27/07 16:05:03.584 AD0]: Starting select_and_execute on thread ID 7f936dffb6c0, thread_name AD0
[27/07 16:05:03.584 signal]: FE 1 mapped to Adapter 0, sys dvbc
[27/07 16:05:03.585 signal]: FE 2 mapped to Adapter 1, sys dvbc
[27/07 16:05:03.585 signal]: FE 3 mapped to Adapter 2, sys dvbc
[27/07 16:05:03.585 signal]: netceiver: creating DVR pipe for adapter 1  -> dvr: 13
[27/07 16:05:03.585 signal]: deleting pids on adapter 1, sid -1, pids=NULL
[27/07 16:05:03.585 signal]: sockets_add: handle 13 (type 5) returning socket sock 9 [:0] read: 0x406dc0
[27/07 16:05:03.585 signal]: set_socket_thread: thread 7f936d7fa6c0 for sockets 9
[27/07 16:05:03.585 signal]: done opening adapter 1 delivery systems: dvbc undefined undefined undefined
[27/07 16:05:03.585 AD1]: Starting select_and_execute on thread ID 7f936d7fa6c0, thread_name AD1
[27/07 16:05:03.585 signal]: netceiver: creating DVR pipe for adapter 2  -> dvr: 15
[27/07 16:05:03.585 signal]: deleting pids on adapter 2, sid -1, pids=NULL
[27/07 16:05:03.586 signal]: sockets_add: handle 15 (type 5) returning socket sock 10 [:0] read: 0x406dc0
[27/07 16:05:03.586 signal]: set_socket_thread: thread 7f936cff96c0 for sockets 10
[27/07 16:05:03.586 signal]: done opening adapter 2 delivery systems: dvbc undefined undefined undefined
[27/07 16:05:03.586 signal]: done init_hw 1
[27/07 16:05:03.586 signal]: Initializing with 3 devices
[27/07 16:05:03.586 AD2]: Starting select_and_execute on thread ID 7f936cff96c0, thread_name AD2
[27/07 16:05:03.586 main]: Starting select_and_execute on thread ID 7f9375b1dac0, thread_name main
^C[27/07 16:05:10.705 AD1]: add_join_thread: pthread 7f936d7fa6c0
[27/07 16:05:10.705 AD0]: add_join_thread: pthread 7f936dffb6c0
[27/07 16:05:10.705 AD2]: add_join_thread: pthread 7f936cff96c0
[27/07 16:05:10.756 CA_poll]: add_join_thread: pthread 7f937480c6c0
[27/07 16:05:10.757 main]: add_join_thread: pthread 7f937500d6c0
[27/07 16:05:10.777 main]: The main loop ended, run_loop = 0
[27/07 16:05:10.777 main]: Destroying mutex 0x479500
[27/07 16:05:10.777 main]: Destroying mutex 0x478da0
[27/07 16:05:10.777 main]: destroy disabled mutex 0x479500
[27/07 16:05:10.777 main]: Closing...
[27/07 16:05:10.777 main]: closing DVR socket 15 pos 10 aid 2
[27/07 16:05:10.777 main]: closing adapter 2  -> fe:0 dvr:15, sock:10, fe_sock:-1
[27/07 16:05:10.777 main]: deleting pids on adapter 2, sid -1, pids=NULL
[27/07 16:05:10.778 main]: netceiver: receiver instance is NULL (id=2)
[27/07 16:05:10.778 main]: netceiver: delete receiver instance for adapter 2
RECEIVED SIGNAL 11 (1) - SP=0 IP=0
```