### PR TITLE
gcc++ fixes

### DIFF
--- a/src/dvb.cpp
+++ b/src/dvb.cpp
@@ -152,18 +152,18 @@ int detect_dvb_parameters(char *s, transponder *tp) {
     tp->freq = -1;
     tp->inversion = -1;
     tp->hprate = -1;
-    tp->tmode = -1;
-    tp->gi = -1;
+    tp->tmode = (fe_transmit_mode_t) -1;
+    tp->gi = (fe_guard_interval_t)(fe_guard_interval_t) -1;
     tp->bw = -1;
     tp->sm = -1;
     tp->t2id = -1;
     tp->fe = -1;
     tp->ro = -1;
-    tp->mtype = -1;
+    tp->mtype = (fe_modulation_t) -1;
     tp->plts = -1;
-    tp->fec = -1;
-    tp->sr = -1;
-    tp->pol = -1;
+    tp->fec = (fe_code_rate_t) -1;
+    tp->sr = (fe_sec_voltage_t) -1;
+    tp->pol = (fe_sec_voltage_t) -1;
     tp->diseqc = -1;
     tp->c2tft = -1;
     tp->ds = -1;
@@ -192,7 +192,7 @@ int detect_dvb_parameters(char *s, transponder *tp) {
         if (strncmp("freq=", arg[i], 5) == 0)
             tp->freq = map_float(arg[i] + 5, 1000);
         if (strncmp("pol=", arg[i], 4) == 0)
-            tp->pol = map_int(arg[i] + 4, (char **)fe_pol);
+            tp->pol = (fe_sec_voltage_t) map_int(arg[i] + 4, (char **)fe_pol);
         if (strncmp("sr=", arg[i], 3) == 0)
             tp->sr = map_int(arg[i] + 3, NULL) * 1000;
         if (strncmp("fe=", arg[i], 3) == 0)
@@ -202,15 +202,15 @@ int detect_dvb_parameters(char *s, transponder *tp) {
         if (strncmp("ro=", arg[i], 3) == 0)
             tp->ro = map_int(arg[i] + 3, (char **)fe_rolloff);
         if (strncmp("mtype=", arg[i], 6) == 0)
-            tp->mtype = map_int(arg[i] + 6, (char **)fe_modulation);
+            tp->mtype = (fe_modulation_t) map_int(arg[i] + 6, (char **)fe_modulation);
         if (strncmp("fec=", arg[i], 4) == 0)
-            tp->fec = map_int(arg[i] + 4, (char **)fe_fec);
+            tp->fec = (fe_code_rate_t) map_int(arg[i] + 4, (char **)fe_fec);
         if (strncmp("plts=", arg[i], 5) == 0)
             tp->plts = map_int(arg[i] + 5, (char **)fe_pilot);
         if (strncmp("gi=", arg[i], 3) == 0)
-            tp->gi = map_int(arg[i] + 3, (char **)fe_gi);
+            tp->gi = (fe_guard_interval_t) map_int(arg[i] + 3, (char **)fe_gi);
         if (strncmp("tmode=", arg[i], 6) == 0)
-            tp->tmode = map_int(arg[i] + 6, (char **)fe_tmode);
+            tp->tmode = (fe_transmit_mode_t) map_int(arg[i] + 6, (char **)fe_tmode);
         if (strncmp("bw=", arg[i], 3) == 0) {
             tp->bw = map_float(arg[i] + 3, 1000000);
             if (tp->bw < 0 ||

--- a/src/dvb.cpp
+++ b/src/dvb.cpp
@@ -162,8 +162,8 @@ int detect_dvb_parameters(char *s, transponder *tp) {
     tp->mtype = (fe_modulation_t) -1;
     tp->plts = -1;
     tp->fec = (fe_code_rate_t) -1;
-    tp->sr = (fe_sec_voltage_t) -1;
-    tp->pol = (fe_sec_voltage_t) -1;
+    tp->sr = -1;
+    tp->pol = -1;
     tp->diseqc = -1;
     tp->c2tft = -1;
     tp->ds = -1;
@@ -192,7 +192,7 @@ int detect_dvb_parameters(char *s, transponder *tp) {
         if (strncmp("freq=", arg[i], 5) == 0)
             tp->freq = map_float(arg[i] + 5, 1000);
         if (strncmp("pol=", arg[i], 4) == 0)
-            tp->pol = (fe_sec_voltage_t) map_int(arg[i] + 4, (char **)fe_pol);
+            tp->pol = map_int(arg[i] + 4, (char **)fe_pol);
         if (strncmp("sr=", arg[i], 3) == 0)
             tp->sr = map_int(arg[i] + 3, NULL) * 1000;
         if (strncmp("fe=", arg[i], 3) == 0)

--- a/src/dvb.cpp
+++ b/src/dvb.cpp
@@ -153,7 +153,7 @@ int detect_dvb_parameters(char *s, transponder *tp) {
     tp->inversion = -1;
     tp->hprate = -1;
     tp->tmode = (fe_transmit_mode_t) -1;
-    tp->gi = (fe_guard_interval_t)(fe_guard_interval_t) -1;
+    tp->gi = (fe_guard_interval_t) -1;
     tp->bw = -1;
     tp->sm = -1;
     tp->t2id = -1;

--- a/src/dvb.h
+++ b/src/dvb.h
@@ -327,7 +327,7 @@ typedef struct struct_transponder {
     int plts;
     fe_code_rate_t fec;
     int sr;
-    fe_sec_voltage_t pol;
+    int pol;
     int diseqc;
 
     struct diseqc diseqc_param;

--- a/src/dvb.h
+++ b/src/dvb.h
@@ -311,13 +311,13 @@ typedef struct struct_transponder {
     int sys;
     int freq;
     int inversion;
-    int mtype;
+    fe_modulation_t mtype;
     int fe;
 
     // DVB-T
     int hprate;
-    int tmode;
-    int gi;
+    fe_transmit_mode_t tmode;
+    fe_guard_interval_t gi;
     int bw;
     int sm;
     int t2id;
@@ -325,9 +325,9 @@ typedef struct struct_transponder {
     // DVB-S2
     int ro;
     int plts;
-    int fec;
+    fe_code_rate_t fec;
     int sr;
-    int pol;
+    fe_sec_voltage_t pol;
     int diseqc;
 
     struct diseqc diseqc_param;

--- a/src/minisatip.cpp
+++ b/src/minisatip.cpp
@@ -1011,7 +1011,7 @@ void set_options(int argc, char *argv[]) {
             }
 
             // default interface is vlan4 as it is used on the REEL
-            opts.netcv_if = "vlan4";
+            opts.netcv_if = (char*) "vlan4";
             opts.netcv_count = map_int(optarg, NULL);
 #endif
             break;

--- a/src/netceiver.cpp
+++ b/src/netceiver.cpp
@@ -129,7 +129,7 @@ int netcv_commit(adapter *ad) {
     int i;
 
     int m_pos = 0;
-    fe_type_t type = 0;
+    fe_type_t type = (fe_type_t) 0;
     recv_sec_t m_sec;
     struct dvb_frontend_parameters m_fep;
     dvb_pid_t m_pids[MAX_PIDS];
@@ -158,7 +158,7 @@ int netcv_commit(adapter *ad) {
 
         int map_pos[] = {0, 192, 130, 282,
                          -50}; // Default sat positions: 19.2E, 13E, 28.2E, 5W
-        int map_pol[] = {0, SEC_VOLTAGE_13, SEC_VOLTAGE_18, SEC_VOLTAGE_OFF};
+        fe_sec_voltage_t map_pol[] = {(fe_sec_voltage_t) 0, SEC_VOLTAGE_13, SEC_VOLTAGE_18, SEC_VOLTAGE_OFF};
 
         switch (tp->sys) {
         case SYS_DVBS:
@@ -181,11 +181,11 @@ int netcv_commit(adapter *ad) {
                 switch (tp->fec) // Handle FEC numbering exceptions
                 {
                 case FEC_3_5:
-                    m_fep.u.qpsk.fec_inner = 13;
+                    m_fep.u.qpsk.fec_inner = (fe_code_rate_t) 13;
                     break;
 
                 case FEC_9_10:
-                    m_fep.u.qpsk.fec_inner = 14;
+                    m_fep.u.qpsk.fec_inner = (fe_code_rate_t) 14;
                     break;
 
                 default:
@@ -194,13 +194,13 @@ int netcv_commit(adapter *ad) {
 
                 // Für DVB-S2 PSK8 oder QPSK, siehe vdr-mcli-plugin/device.c
                 if (tp->mtype)
-                    m_fep.u.qpsk.fec_inner |= (PSK8 << 16);
+                    m_fep.u.qpsk.fec_inner = (fe_code_rate_t) (m_fep.u.qpsk.fec_inner | (PSK8 << 16));
                 else
-                    m_fep.u.qpsk.fec_inner |= (QPSK_S2 << 16);
-                type = FE_DVBS2;
+                    m_fep.u.qpsk.fec_inner = (fe_code_rate_t) (m_fep.u.qpsk.fec_inner | (QPSK_S2 << 16));
+                type = (fe_type_t) FE_DVBS2;
             }
 
-            char *map_posc[] = {"", " @ 19.2E", " @ 13E", " @ 28.2E", " @ 5W"};
+            const char *map_posc[] = {"", " @ 19.2E", " @ 13E", " @ 28.2E", " @ 5W"};
             LOG("netceiver: adapter %d tuning to %d%s pol:%s sr:%d fec:%s "
                 "delsys:%s "
                 "mod:%s",
@@ -347,7 +347,7 @@ int netcv_tune(int aid, transponder *tp) {
 }
 
 fe_delivery_system_t netcv_delsys(int aid, int fd, fe_delivery_system_t *sys) {
-    return 0;
+    return SYS_UNDEFINED;
 }
 
 void find_netcv_adapter(adapter **a) {
@@ -435,7 +435,7 @@ void find_netcv_adapter(adapter **a) {
         if (!a[na])
             a[na] = adapter_alloc();
         if (!sn[na])
-            sn[na] = _malloc(sizeof(SNetceiver));
+            sn[na] = (SNetceiver*) _malloc(sizeof(SNetceiver));
 
         ad = a[na];
         ad->pa = 0;
@@ -463,7 +463,7 @@ void find_netcv_adapter(adapter **a) {
 
         /* register delivery system type */
         for (k = 0; k < 10; k++)
-            ad->sys[k] = 0;
+            ad->sys[k] = SYS_UNDEFINED;
         switch (map_type[i]) {
         case FE_DVBS2:
             ad->sys[0] = SYS_DVBS2;
@@ -507,7 +507,7 @@ void find_netcv_adapter(adapter **a) {
  */
 
 int handle_ts(unsigned char *buffer, size_t len, void *p) {
-    SNetceiver *nc = p;
+    SNetceiver *nc = (SNetceiver *) p;
     size_t lw;
 
     if (nc->lp == 0)
@@ -530,7 +530,7 @@ int handle_ts(unsigned char *buffer, size_t len, void *p) {
 
 /* Handle signal status information */
 int handle_ten(tra_t *ten, void *p) {
-    adapter *ad = p;
+    adapter *ad = (adapter *) p;
     recv_festatus_t *festat;
 
     if (ten) {

--- a/src/utils/alloc.cpp
+++ b/src/utils/alloc.cpp
@@ -87,6 +87,7 @@ void *realloc1(void *p, int a, const char *f, int l, int record) {
     int old_mem = 0;
     void *x = realloc(p, a);
     if (record) {
+	// TODO FIX: warning: pointer 'p' may be used after 'void* realloc(void*, size_t)' [-Wuse-after-free]
         old_mem = record_allocation(p, x, a, a, a, 1, 0, f, l);
     }
     LOGM("%s:%d realloc allocated %d bytes from %d: %p", f, l, a, old_mem, x);


### PR DESCRIPTION
- add several missing casts for compiling with gcc-c++ 15
- add TODO for a leftover warning, potential use-after-free