### PR TITLE
Partial revert of 670d80ba2798d018004d105260ef1ec3a281df43

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,9 +3,7 @@ name: Coverity Scan
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
-
+  # We can't run on pull request because the secret token is not available there
 
 jobs:
   build:


### PR DESCRIPTION
Can't run Coverity on pull requests because for whatever reason the secret token required is not injected into pull request workflows