### PR TITLE
WIP: Add support for descrambling data streams with constant code-words

### DIFF
--- a/src/ca.cpp
+++ b/src/ca.cpp
@@ -312,8 +312,7 @@ int CAPMT_add_PMT(uint8_t *capmt, int len, SPMT *pmt, int cmd_id,
                  pmt->id, pmt->adapter, pmt->stream_pid[i]->pid);
             continue;
         }
-        if (!pmt->stream_pid[i]->is_audio && !pmt->stream_pid[i]->is_video)
-            continue;
+
         capmt[pos++] = pmt->stream_pid[i]->type;
         copy16(capmt, pos, pmt->stream_pid[i]->pid);
         pos += 2;

--- a/src/dvbapi.cpp
+++ b/src/dvbapi.cpp
@@ -332,6 +332,9 @@ int dvbapi_reply(sockets *s) {
         case DVBAPI_ECM_INFO: {
             int pos1 = s->rlen - pos;
             SKey *k = get_key(b[4] - opts.dvbapi_offset);
+            if (!k) {
+                break;
+            }
             unsigned char cardsystem[255];
             unsigned char reader[255];
             unsigned char from[255];
@@ -343,16 +346,15 @@ int dvbapi_reply(sockets *s) {
 
             copy16r(sid, b, i);
 
-            if (k) {
-                msg[0] = k->cardsystem;
-                msg[1] = k->reader;
-                msg[2] = k->from;
-                msg[3] = k->protocol;
-                copy16r(k->caid, b, i + 2);
-                copy16r(k->info_pid, b, i + 4);
-                copy32r(k->prid, b, i + 6);
-                copy32r(k->ecmtime, b, i + 10);
-            }
+            msg[0] = k->cardsystem;
+            msg[1] = k->reader;
+            msg[2] = k->from;
+            msg[3] = k->protocol;
+            copy16r(k->caid, b, i + 2);
+            copy16r(k->info_pid, b, i + 4);
+            copy32r(k->prid, b, i + 6);
+            copy32r(k->ecmtime, b, i + 10);
+
             i += 14;
             while (msg[j] && i < pos1) {
                 len = b[i++];
@@ -364,7 +366,7 @@ int dvbapi_reply(sockets *s) {
                 i += len;
                 j++;
             }
-            if (i < pos1 && k)
+            if (i < pos1)
                 k->hops = b[i++];
             pos += i;
             LOG("dvbapi: ECM_INFO: key %d, SID = %04X, CAID = %04X (%s), PID = "
@@ -372,9 +374,8 @@ int dvbapi_reply(sockets *s) {
                 "(%04X), ProvID = %06X, ECM time = %d ms, reader = %s, from = "
                 "%s, "
                 "protocol = %s, hops = %d",
-                k ? k->id : -1, sid, k ? k->caid : 0, msg[0],
-                k ? k->info_pid : 0, k ? k->info_pid : 0, k ? k->prid : 0,
-                k ? k->ecmtime : -1, msg[1], msg[2], msg[3], k ? k->hops : 0);
+                k->id, sid, k->caid, msg[0], k->info_pid, k->info_pid, k->prid,
+                k->ecmtime, msg[1], msg[2], msg[3], k->hops);
             break;
         }
 

--- a/src/dvbapi.cpp
+++ b/src/dvbapi.cpp
@@ -316,10 +316,10 @@ int dvbapi_reply(sockets *s) {
                 memcpy(k->cw[parity], cw, k->key_len);
 
                 LOG("dvbapi: received DVBAPI_CA_SET_DESCR, key %d parity %d, "
-                    "index %d, "
+                    "index %d, algo %d, "
                     "CW %s: %02X %02X %02X %02X %02X %02X %02X %02X",
-                    k_id, parity, index, correct ? "OK" : "NOK", cw[0], cw[1],
-                    cw[2], cw[3], cw[4], cw[5], cw[6], cw[7]);
+                    k_id, parity, index, k->algo, correct ? "OK" : "NOK", cw[0],
+                    cw[1], cw[2], cw[3], cw[4], cw[5], cw[6], cw[7]);
 
                 send_cw(k->pmt_id, k->algo, parity, cw, NULL, 0, &k->icam_ecm);
             } else

--- a/src/dvbapi.cpp
+++ b/src/dvbapi.cpp
@@ -95,8 +95,6 @@ void dvbapi_close_socket() {
     dvbapi_is_enabled = 0;
 }
 
-void invalidate_adapter(int aid) { return; }
-
 int get_index_for_filter(SKey *k, int filter) {
     int i;
     for (i = 0; i < MAX_KEY_FILTERS; i++)
@@ -725,7 +723,6 @@ int keys_add(int i, int adapter, int pmt_id) {
     memset(k->filter_id, -1, sizeof(k->filter_id));
     memset(k->filter, -1, sizeof(k->filter));
     memset(k->demux, -1, sizeof(k->demux));
-    invalidate_adapter(adapter);
     __sync_add_and_fetch(&enabledKeys, 1);
     LOG("returning new key %d for adapter %d, pmt %d pid %d sid %04X", i,
         adapter, pmt->id, pmt->pid, k->sid);
@@ -856,14 +853,6 @@ void unregister_dvbapi() {
     LOG("unregistering dvbapi as the socket is closed");
     del_ca(&dvbapi);
     dvbapi_ca = -1;
-}
-
-void dvbapi_delete_keys_for_adapter(int aid) {
-    int i;
-    SKey *k;
-    for (i = 0; i < MAX_KEYS; i++)
-        if ((k = get_key(i)) && k->adapter == aid)
-            keys_del(i);
 }
 
 char *get_channel_for_key(int key, char *dest, int max_size) {

--- a/src/dvbapi.cpp
+++ b/src/dvbapi.cpp
@@ -384,9 +384,10 @@ int dvbapi_reply(sockets *s) {
             SKey *k;
             pos += 17;
             k_id = b[4] - opts.dvbapi_offset;
-            dvbapi_copy32r(algo, b, 5);
-            dvbapi_copy32r(mode, b, 9);
-            LOG("Key %d, Algo set to %d, Mode set to %d", k_id, algo, mode);
+            dvbapi_copy32r(algo, b, 9);
+            dvbapi_copy32r(mode, b, 13);
+            LOG("dvbapi: received DVBAPI_CA_SET_MODE, key %d, algo %d, mode %d",
+                k_id, algo, mode);
             k = get_key(k_id);
             if (!k)
                 break;

--- a/src/dvbapi.h
+++ b/src/dvbapi.h
@@ -90,7 +90,6 @@ int keys_del(int i);
 int dvbapi_process_pmt(unsigned char *b, adapter *ad);
 void dvbapi_pid_add(adapter *a, int pid, SPid *cp, int existing);
 void dvbapi_pid_del(adapter *a, int pid, SPid *cp);
-void dvbapi_delete_keys_for_adapter(int aid);
 void register_dvbapi();
 void unregister_dvbapi();
 void send_client_info(sockets *s);

--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -1538,6 +1538,9 @@ int assemble_packet(SFilter *f, uint8_t *b) {
     uint32_t crc;
 
     pid = PID_FROM_TS(b);
+    // ignore null packets
+    if (pid == 0x1fff)
+        return len;
     if (f->flags & FILTER_EMM)
         len = assemble_emm(f, b);
     else

--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -1312,7 +1312,6 @@ int pmt_add(int adapter, int sid, int pmt_pid) {
     pmt->state = PMT_STOPPED;
     pmt->cw = NULL;
     pmt->opaque = NULL;
-    pmt->first_active_pid = -1;
     pmt->ca_mask = pmt->disabled_ca_mask = 0;
     pmt->batch = NULL;
     memset(pmt->name, 0, sizeof(pmt->name));
@@ -1959,9 +1958,6 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
         if (!is_audio && !is_video)
             continue;
 
-        // is video stream
-        if (pmt->first_active_pid < 0 && is_video)
-            pmt->first_active_pid = spid;
         if (stream_pid_id >= 0)
             pmt_add_descriptors(pmt, stream_pid_id, pmt_b + i + 5, es_len);
 
@@ -1973,9 +1969,6 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
     // Add the PCR pid if it's independent
     if (pcr_pid > 0 && pcr_pid < 8191)
         pmt_add_stream_pid(pmt, pcr_pid, 0, 0, 0, 0);
-
-    if ((pmt->first_active_pid < 0) && pmt->stream_pid[0])
-        pmt->first_active_pid = pmt->stream_pid[0]->pid;
 
     SPMT *master = get_pmt(pmt->master_pmt);
     if (pmt->caids && master && master != pmt) {

--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -1029,11 +1029,9 @@ void start_active_pmts(adapter *ad) {
         int is_active = 0;
         int j, first = 0;
         int pmt_started = 0;
-        for (j = 0; j < pmt->stream_pids; j++)
-            // for all audio and video streams start the PMT containing them
-            if ((pmt->stream_pid[j]->is_audio ||
-                 pmt->stream_pid[j]->is_video) &&
-                pids[pmt->stream_pid[j]->pid] && pmt->id == pmt->master_pmt) {
+        for (j = 0; j < pmt->stream_pids; j++) {
+            // for all stream PIDs start the PMT containing them
+            if (pids[pmt->stream_pid[j]->pid] && pmt->id == pmt->master_pmt) {
                 is_active = 1;
 #ifndef DISABLE_TABLES
                 if (!first) {
@@ -1064,6 +1062,8 @@ void start_active_pmts(adapter *ad) {
 #endif
                 }
             }
+        }
+
         // non master PMTs should not be started
         if (pmt->state == PMT_RUNNING && !is_active) {
             LOG("Stopping started PMT %d: %s", pmt->id, pmt->name);
@@ -1954,9 +1954,6 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
                  es_len + i, pmt_len, es_len);
             break;
         }
-
-        if (!is_audio && !is_video)
-            continue;
 
         if (stream_pid_id >= 0)
             pmt_add_descriptors(pmt, stream_pid_id, pmt_b + i + 5, es_len);

--- a/src/pmt.h
+++ b/src/pmt.h
@@ -138,7 +138,6 @@ typedef struct struct_pmt {
     char state; // PMT state (PMT_STOPPED, PMT_STARTING, PMT_RUNNING,
                 // PMT_STOPPING)
     char encrypted;
-    int first_active_pid;
     int64_t grace_time, start_time;
     int filter;
     std::unordered_map<uint64_t, int> *global_start, *local_start;

--- a/src/pmt.h
+++ b/src/pmt.h
@@ -18,7 +18,8 @@
 
 #define MAX_PMT 25600
 #define MAX_CW 200
-#define MAX_CW_TIME 45000 // 45s
+#define DEFAULT_CW_TIME 45000   // 45s
+#define CONST_CW_TIME 315360000 // 10 years
 #define MAX_BATCH_SIZE 128
 
 #define FILTER_SIZE 16 // based on DMX_FILTER_SIZE
@@ -229,5 +230,6 @@ int pmt_add_stream_pid(SPMT *pmt, int pid, int type, int is_audio, int is_video,
                        int es_len);
 void pmt_add_caid(SPMT *pmt, uint16_t caid, uint16_t capid, uint8_t *data,
                   int len);
+int pmt_caid_is_const_cw(SPMT *pmt);
 void free_all_pmts();
 #endif


### PR DESCRIPTION
This set of changes enable successful reception of Abertis services on Hispasat 30W. Essentially each service contains just a PMT PID, a data PID and a CA PID. The data PID is BISS encrypted and contains an MPEG transport stream in its payload (basic encapsulation). Despite what the internet says, this doesn't seem to be T2-MI encapsulated, but instead uses a custom simpler encapsulation.

Once the data PID is decrypted, the output from minisatip can be piped through a simple de-encapsulator and then fed as an IPTV service to tvheadend.

Changes required:
* remove some "is video/audio" checks so we can successfully start a PMT that only contains a data PID. These particular PIDs use type 144 which is completely bogus (Blu-ray subtitling)
* since null packets are used as CA PID we need to discard them in `assemble_packet()`. The PID doens't contain anything required for descrambling, but I guess for technical reasons the service must have a CA PID.
* the stream parity never changes, so the initial constant code word we receive from DVBAPI will expire after some time. Work around this by detecting whether the PMT in question uses constant code-word scrambling and use a much longer life time.

@catalinii ready for review

Fixes https://github.com/catalinii/minisatip/issues/1223