### PR TITLE
WIP: Improve how PIDs are selected for descrambling

### DIFF
--- a/src/ca.cpp
+++ b/src/ca.cpp
@@ -312,8 +312,7 @@ int CAPMT_add_PMT(uint8_t *capmt, int len, SPMT *pmt, int cmd_id,
                  pmt->id, pmt->adapter, pmt->stream_pid[i]->pid);
             continue;
         }
-        if (!pmt->stream_pid[i]->is_audio && !pmt->stream_pid[i]->is_video)
-            continue;
+
         capmt[pos++] = pmt->stream_pid[i]->type;
         copy16(capmt, pos, pmt->stream_pid[i]->pid);
         pos += 2;

--- a/src/ca.cpp
+++ b/src/ca.cpp
@@ -307,9 +307,18 @@ int CAPMT_add_PMT(uint8_t *capmt, int len, SPMT *pmt, int cmd_id,
                   int added_only, int ca_id) {
     int i = 0, pos = 0;
     for (i = 0; i < pmt->stream_pids; i++) {
+        // Skip PIDs not actually subscribed to
         if (added_only && !find_pid(pmt->adapter, pmt->stream_pid[i]->pid)) {
-            LOGM("%s: skipping pmt %d (ad %d) pid %d from CAPMT", __FUNCTION__,
-                 pmt->id, pmt->adapter, pmt->stream_pid[i]->pid);
+            LOG("%s: omitting PMT %d (ad %d) pid %d from CAPMT (not "
+                "subscribed to)",
+                __FUNCTION__, pmt->id, pmt->adapter, pmt->stream_pid[i]->pid);
+            continue;
+        }
+
+        // Omit unscrambled PIDs
+        if (!pmt->stream_pid[i]->is_scrambled) {
+            LOG("%s: omitting PMT %d (ad %d) pid %d from CAPMT (not scrambled)",
+                __FUNCTION__, pmt->id, pmt->adapter, pmt->stream_pid[i]->pid);
             continue;
         }
 

--- a/src/ddci.cpp
+++ b/src/ddci.cpp
@@ -717,8 +717,8 @@ int safe_get_pid_mapping(ddci_device_t *d, int aid, int pid) {
 
 int ddci_create_pmt(ddci_device_t *d, SPMT *pmt, uint8_t *new_pmt, int pmt_size,
                     ddci_pmt_t *dp) {
-    int pid = pmt->pid, pi_len = 0, i;
-    uint8_t *b = new_pmt, *start_pmt, *start_pi_len;
+    int pid = pmt->pid, i;
+    uint8_t *b = new_pmt, *start_pmt;
     memset(new_pmt, 0, pmt_size);
 
     *b++ = 0;
@@ -734,29 +734,12 @@ int ddci_create_pmt(ddci_device_t *d, SPMT *pmt, uint8_t *new_pmt, int pmt_size,
     *b++ = 0xE0 | ((dp->pcr_pid >> 8) & 0xFF); // PCR PID
     *b++ = dp->pcr_pid & 0xFF;                 // PCR PID
 
-    start_pi_len = b;
-
     *b++ = 0; // PI LEN
     *b++ = 0;
 
     LOGM("%s: PMT %d AD %d, pid: %04X (%d), ver %d, sid %04X (%d) %s %s",
          __FUNCTION__, pmt->id, pmt->adapter, pid, pid, dp->ver, pmt->sid,
          pmt->sid, pmt->name[0] ? "channel:" : "", pmt->name);
-
-    // Add CA IDs and CA Pids
-    for (i = 0; i < pmt->caids; i++) {
-        int private_data_len = pmt->ca[i]->private_data_len;
-        *b++ = 0x09;
-        *b++ = 0x04 + private_data_len;
-        copy16(b, 0, pmt->ca[i]->id);
-        copy16(b, 2, safe_get_pid_mapping(d, pmt->adapter, pmt->ca[i]->pid));
-        memcpy(b + 4, pmt->ca[i]->private_data, private_data_len);
-        pi_len += 6 + private_data_len;
-        b += 4 + private_data_len;
-        LOGM("%s: pmt %d added caid %04X, pid %04X", __FUNCTION__, pmt->id,
-             pmt->ca[i]->id, pmt->ca[i]->pid);
-    }
-    copy16(start_pi_len, 0, pi_len);
 
     // Add Stream pids
     // Add CA IDs and CA Pids

--- a/src/dvbapi.cpp
+++ b/src/dvbapi.cpp
@@ -464,6 +464,12 @@ int dvbapi_send_pmt(SKey *k, int cmd_id) {
     copy16(buf, 10, len - 12);
     int i;
     for (i = 0; i < pmt->stream_pids; i++) {
+        if (!pmt->stream_pid[i]->is_scrambled) {
+            LOGM(
+                "%s: omitting PMT %d (ad %d) pid %d from CAPMT (not scrambled)",
+                __FUNCTION__, pmt->id, pmt->adapter, pmt->stream_pid[i]->pid);
+            continue;
+        }
         len += 5;
         int type = pmt->stream_pid[i]->type;
         int pid = pmt->stream_pid[i]->pid;

--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -1312,7 +1312,6 @@ int pmt_add(int adapter, int sid, int pmt_pid) {
     pmt->state = PMT_STOPPED;
     pmt->cw = NULL;
     pmt->opaque = NULL;
-    pmt->first_active_pid = -1;
     pmt->ca_mask = pmt->disabled_ca_mask = 0;
     pmt->batch = NULL;
     memset(pmt->name, 0, sizeof(pmt->name));
@@ -1959,9 +1958,6 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
         if (!is_audio && !is_video)
             continue;
 
-        // is video stream
-        if (pmt->first_active_pid < 0 && is_video)
-            pmt->first_active_pid = spid;
         if (stream_pid_id >= 0)
             pmt_add_descriptors(pmt, stream_pid_id, pmt_b + i + 5, es_len);
 
@@ -1973,9 +1969,6 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
     // Add the PCR pid if it's independent
     if (pcr_pid > 0 && pcr_pid < 8191)
         pmt_add_stream_pid(pmt, pcr_pid, 0, 0, 0, 0);
-
-    if ((pmt->first_active_pid < 0) && pmt->stream_pid[0])
-        pmt->first_active_pid = pmt->stream_pid[0]->pid;
 
     SPMT *master = get_pmt(pmt->master_pmt);
     if (pmt->caids && master && master != pmt) {

--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -1029,11 +1029,9 @@ void start_active_pmts(adapter *ad) {
         int is_active = 0;
         int j, first = 0;
         int pmt_started = 0;
-        for (j = 0; j < pmt->stream_pids; j++)
-            // for all audio and video streams start the PMT containing them
-            if ((pmt->stream_pid[j]->is_audio ||
-                 pmt->stream_pid[j]->is_video) &&
-                pids[pmt->stream_pid[j]->pid] && pmt->id == pmt->master_pmt) {
+        for (j = 0; j < pmt->stream_pids; j++) {
+            // for all stream PIDs start the PMT containing them
+            if (pids[pmt->stream_pid[j]->pid] && pmt->id == pmt->master_pmt) {
                 is_active = 1;
 #ifndef DISABLE_TABLES
                 if (!first) {
@@ -1064,6 +1062,8 @@ void start_active_pmts(adapter *ad) {
 #endif
                 }
             }
+        }
+
         // non master PMTs should not be started
         if (pmt->state == PMT_RUNNING && !is_active) {
             LOG("Stopping started PMT %d: %s", pmt->id, pmt->name);
@@ -1954,9 +1954,6 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
                  es_len + i, pmt_len, es_len);
             break;
         }
-
-        if (!is_audio && !is_video)
-            continue;
 
         if (stream_pid_id >= 0)
             pmt_add_descriptors(pmt, stream_pid_id, pmt_b + i + 5, es_len);

--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -1787,12 +1787,15 @@ void pmt_add_descriptors(SPMT *pmt, int stream_id, unsigned char *es, int len) {
         return;
     }
 
-    for (i = 0; i < len; i += es_len + 2) // reading program info
-    {
+    // Add each elementary stream descriptor
+    for (i = 0; i < len; i += es_len + 2) {
         es_len = es[i + 1];
-        if (es[i] != 9) {
-            pmt_add_descriptor(pmt, stream_id, es + i);
-        } else {
+
+        // Store all descriptors, we need to be able to fully reconstruct the
+        // stream descriptors in some cases
+        pmt_add_descriptor(pmt, stream_id, es + i);
+
+        if (es[i] == 0x09) { // CA descriptor
             caid = es[i + 2] * 256 + es[i + 3];
             capid = (es[i + 4] & 0x1F) * 256 + es[i + 5];
             pmt_add_caid(pmt, caid, capid, es + i + 6, es_len - 4);

--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -1799,6 +1799,9 @@ void pmt_add_descriptors(SPMT *pmt, int stream_id, unsigned char *es, int len) {
             caid = es[i + 2] * 256 + es[i + 3];
             capid = (es[i + 4] & 0x1F) * 256 + es[i + 5];
             pmt_add_caid(pmt, caid, capid, es + i + 6, es_len - 4);
+
+            // Mark the stream PID as scrambled
+            pmt->stream_pid[stream_id]->is_scrambled = true;
         }
     }
     return;

--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -1947,12 +1947,6 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
         } else
             LOG("Too many pids for pmt %d, discarding pid %d", pmt->id, spid);
 
-        LOG("PMT pid %d - stream pid %04X (%d), type %d%s, es_len %d, pos "
-            "%d, "
-            "caids %d",
-            pid, spid, spid, stype, isAC3 ? " [AC3]" : "", es_len, i,
-            pmt->caids);
-
         if ((es_len + i + 5 > pmt_len) || (es_len < 0)) {
             LOGM("pmt processing complete, es_len + i %d, len %d, es_len %d",
                  es_len + i, pmt_len, es_len);
@@ -1961,6 +1955,12 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
 
         if (stream_pid_id >= 0)
             pmt_add_descriptors(pmt, stream_pid_id, es, es_len);
+
+        LOG("PMT pid %d - stream pid %04X (%d), type %d%s, es_len %d, pos "
+            "%d, "
+            "caids %d",
+            pid, spid, spid, stype, isAC3 ? " [AC3]" : "", es_len, i,
+            pmt->caids);
 
         if (opmt != -1 && opmt != pmt->master_pmt) {
             pmt->master_pmt = opmt;

--- a/src/pmt.h
+++ b/src/pmt.h
@@ -102,6 +102,7 @@ typedef struct struct_stream_pid {
     int pid;
     char is_audio : 1;
     char is_video : 1;
+    bool is_scrambled;
     int desc_len;
     uint8_t desc[];
 } SStreamPid;

--- a/src/pmt.h
+++ b/src/pmt.h
@@ -138,7 +138,6 @@ typedef struct struct_pmt {
     char state; // PMT state (PMT_STOPPED, PMT_STARTING, PMT_RUNNING,
                 // PMT_STOPPING)
     char encrypted;
-    int first_active_pid;
     int64_t grace_time, start_time;
     int filter;
     std::unordered_map<uint64_t, int> *global_start, *local_start;

--- a/tests/test_ddci.cpp
+++ b/tests/test_ddci.cpp
@@ -552,8 +552,8 @@ int test_create_pmt() {
         LOG("Assemble packet failed");
         return 1;
     }
-    int new_pid = packet[30] * 256 + packet[31];
-    int new_capid = packet[21] * 256 + packet[22];
+    int new_pid = packet[18] * 256 + packet[19];
+    int new_capid = packet[9] * 256 + packet[10];
     new_pid &= 0x1FFF;
     new_capid &= 0x1FFF;
     if (new_pid != dpid)


### PR DESCRIPTION
Fixes two scenarios:

* a user wants to descramble a PID that is neither video nor audio. This wasn't possible because we skipped processing the PMT completely if it contained no video/audio stream PIDs
* simply removing the video/audio check would potentially cause CA PMT to balloon due to all DVBSUB and TELETEXT PIDs etc. potentially being added to it. This has been improved now with the addition of marking each stream PID as scrambled or not based on whether it has a CA descriptor (`0x09`). Due to a bug this particular descriptor was never stored in the stream PID, so when the PMT was reconstructed on a DDCI device the information was no longer there are filtering out scrambled PIDs would cause all PIDs to be left out.

Before:

```
[02/09 21:04:30.427 AD3]: new PMT 0 AD 3, pid: 05D3 (1491), filter 6, len 106, pi_len 0, ver 1, pcr 1535, sid 4330 (17200)  
[02/09 21:04:30.427 AD3]: PMT pid 1491 - stream pid 05FF (1535), type 27, es_len 11, pos 9, caids 0
[02/09 21:04:30.427 AD3]: PMT 0 PI pos 1 caid 0B00 => pid 1016 (4118), index 0
[02/09 21:04:30.427 AD3]: PMT pid 1491 - stream pid 0D25 (3365), type 3, es_len 20, pos 25, caids 1
[02/09 21:04:30.427 AD3]: PMT pid 1491 - stream pid 0FA9 (4009), type 3, es_len 20, pos 50, caids 1
[02/09 21:04:30.427 AD3]: PMT pid 1491 - stream pid 181F (6175), type 6, es_len 22, pos 75, caids 1
...
[02/09 21:04:30.552 AD0]: new PMT 4 AD 0, pid: 05D3 (1491), filter 9, len 72, pi_len 6, ver 1, pcr 1535, sid 4330 (17200)  
[02/09 21:04:30.552 AD0]: PMT 4 PI pos 1 caid 0B00 => pid 1016 (4118), index 0
[02/09 21:04:30.553 AD0]: PMT pid 1491 - stream pid 05FF (1535), type 27, es_len 5, pos 15, caids 1
[02/09 21:04:30.553 AD0]: PMT pid 1491 - stream pid 0D25 (3365), type 3, es_len 14, pos 25, caids 1
[02/09 21:04:30.553 AD0]: PMT pid 1491 - stream pid 0FA9 (4009), type 3, es_len 14, pos 44, caids 1
[02/09 21:04:30.553 AD0]: PMT pid 1491 - stream pid 181F (6175), type 6, es_len 0, pos 63, caids 1
```

After:

```
[02/09 21:20:16.221 AD3]: new PMT 0 AD 3, pid: 05D3 (1491), filter 6, len 106, pi_len 0, ver 1, pcr 1535, sid 4330 (17200)  
[02/09 21:20:16.221 AD3]: PMT 0 PI pos 1 caid 0B00 => pid 1016 (4118), index 0
[02/09 21:20:16.221 AD3]: PMT pid 1491 - stream pid 05FF (1535), type 27, es_len 11, pos 9, caids 1
[02/09 21:20:16.221 AD3]: PMT pid 1491 - stream pid 0D25 (3365), type 3, es_len 20, pos 25, caids 1
[02/09 21:20:16.221 AD3]: PMT pid 1491 - stream pid 0FA9 (4009), type 3, es_len 20, pos 50, caids 1
[02/09 21:20:16.221 AD3]: PMT pid 1491 - stream pid 181F (6175), type 6, es_len 22, pos 75, caids 1
...
[02/09 21:20:16.308 AD0]: new PMT 4 AD 0, pid: 05D3 (1491), filter 9, len 112, pi_len 6, ver 1, pcr 1535, sid 4330 (17200)  
[02/09 21:20:16.308 AD0]: PMT 4 PI pos 1 caid 0B00 => pid 1016 (4118), index 0
[02/09 21:20:16.308 AD0]: PMT pid 1491 - stream pid 05FF (1535), type 27, es_len 11, pos 15, caids 1
[02/09 21:20:16.308 AD0]: PMT pid 1491 - stream pid 0D25 (3365), type 3, es_len 20, pos 31, caids 1
[02/09 21:20:16.308 AD0]: PMT pid 1491 - stream pid 0FA9 (4009), type 3, es_len 20, pos 56, caids 1
[02/09 21:20:16.308 AD0]: PMT pid 1491 - stream pid 181F (6175), type 6, es_len 22, pos 81, caids 1
...
[02/09 21:20:16.308 AD0]: CAPMT_add_PMT: omitting PMT 4 (ad 0) pid 6175 from CAPMT (not scrambled)
```

Fixes https://github.com/catalinii/minisatip/pull/1304 incidentally