### PR TITLE
Fix deadlock when handling stream timeout

### DIFF
--- a/src/socketworks.cpp
+++ b/src/socketworks.cpp
@@ -889,10 +889,12 @@ void *select_and_execute(void *arg) {
                         int rv;
                         if (ss->sock == SOCK_TIMEOUT)
                             ss->rtime = getTick();
-                        std::lock_guard<SMutex> lock(ss->mutex);
+                        std::unique_lock<SMutex> lock(ss->mutex);
                         rv = ss->timeout(ss);
-                        if (rv)
+                        if (rv) {
+                            lock.unlock();
                             sockets_del(i);
+                        }
                     } else
                         sockets_del(i);
                 }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1178,7 +1178,7 @@ int stream_timeout(sockets *s) {
     s->rtime = ctime;
 
     if ((sid = get_sid(s->sid)) && sid->type != STREAM_HTTP) {
-        std::lock_guard<SMutex> lock(sid->mutex);
+        std::unique_lock<SMutex> lock(sid->mutex);
         rttime = sid->rtcp_wtime, rtime = sid->wtime;
 
         if (sid->do_play && ctime - rtime > 1000) {
@@ -1196,6 +1196,8 @@ int stream_timeout(sockets *s) {
             LOG("Stream timeout sid %d, closing (ctime %jd , sid->rtime %jd, "
                 "sid->timeout %d)",
                 sid->sid, ctime, sid->rtime, sid->timeout);
+
+            lock.unlock();
             close_stream(sid->sid); // do not lock before this
         }
     }


### PR DESCRIPTION
Hopefully fixes https://github.com/catalinii/minisatip/issues/1309

`close_stream()` acquires both `st_mutex` and each individual stream mutex, so we must release `sid->mutex` before calling it