### PR TITLE
Don't reject CWs with a failed check

### DIFF
--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -738,7 +738,7 @@ void update_cw(SPMT *pmt) {
                 break;
             }
             // if we can verify if the CW is return the latest CW
-            if (len)
+            if (len && cw) // but don't reject failed decrypt checks
                 continue;
 
             int change = 0;


### PR DESCRIPTION
When searching for a valid CW if you don't have any other alternative then accept any.

This makes sense when decoding with one CA system that can't be checked using the standard method: initial PUSI packet with a bitstream content of 0x0 0x0 0x1. Sometimes the check fails, but the CW is valid. Therefore, the check will be used now to distinguish between more than one CW. If you have several and one of them passes the check, that's the correct one. But don't assume that one that fails is invalid.

This fixes the decoding with some recent CA systems.