### PR TITLE
Remove unused PMT "grace time" concept

### DIFF
--- a/src/ddci.cpp
+++ b/src/ddci.cpp
@@ -332,9 +332,7 @@ int ddci_process_pmt(adapter *ad, SPMT *pmt) {
 
     if ((d = get_ddci(ad->id))) {
         LOG("Skip processing pmt for ddci adapter %d", ad->id);
-        // grace time for card decrypting lower than the default grace_time
-        pmt->grace_time = 20000;
-        pmt->start_time = getTick();
+
         SPMT *dpmt;
 
         // set the name of the PMT from the DDCI to the original pmt

--- a/src/pmt.h
+++ b/src/pmt.h
@@ -36,8 +36,6 @@
 #define PMT_STOPPING 3
 #define PMT_CACHED 4
 
-#define PMT_GRACE_TIME 2000
-
 #define CLM_MORE 0x00
 #define CLM_FIRST 0x01
 #define CLM_LAST 0x02
@@ -133,9 +131,7 @@ typedef struct struct_pmt {
     void *opaque;
     char state; // PMT state (PMT_STOPPED, PMT_STARTING, PMT_RUNNING,
                 // PMT_STOPPING)
-    char encrypted;
     int first_active_pid;
-    int64_t grace_time, start_time;
     int filter;
     std::unordered_map<uint64_t, int> *global_start, *local_start;
 } SPMT;

--- a/src/tables.cpp
+++ b/src/tables.cpp
@@ -276,26 +276,6 @@ int send_pmt_to_cas(adapter *ad, SPMT *pmt) {
     return rv;
 }
 
-void tables_update_encrypted_status(adapter *ad, SPMT *pmt) {
-    int i;
-    int status = pmt->encrypted;
-    if (!ad)
-        return;
-    LOGM("Updating status %d for pmt %d, ad mask %08X, pmt mask %08X", status,
-         pmt->id, ad->ca_mask, pmt->ca_mask);
-    for (i = 0; i < nca; i++)
-        if (ca[i].enabled && (ad->ca_mask & (1ULL << i)) &&
-            (pmt->ca_mask & (1ULL << i))) {
-            LOGM("Updating status %d pmt %d for ca %d and adapter %d", status,
-                 pmt->id, i, ad->id);
-            if (status == TABLES_CHANNEL_ENCRYPTED && ca[i].op->ca_encrypted)
-                ca[i].op->ca_encrypted(ad, pmt);
-            else if (status == TABLES_CHANNEL_DECRYPTED &&
-                     ca[i].op->ca_decrypted)
-                ca[i].op->ca_decrypted(ad, pmt);
-        }
-}
-
 void tables_add_pid(adapter *ad, SPMT *pmt, int pid) {
     uint64_t mask;
     for (int i = 0; i < nca; i++) {

--- a/src/tables.h
+++ b/src/tables.h
@@ -22,7 +22,7 @@ typedef int (*ca_close_action)();
 
 typedef struct struct_CA_op {
     ca_pid_action ca_add_pid, ca_del_pid;
-    ca_pmt_action ca_add_pmt, ca_del_pmt, ca_decrypted, ca_encrypted;
+    ca_pmt_action ca_add_pmt, ca_del_pmt;
     ca_device_action ca_init_dev, ca_close_dev, ca_ts;
     ca_close_action ca_close_ca;
 } SCA_op;
@@ -55,7 +55,6 @@ int close_pmt_for_cas(adapter *ad, SPMT *pmt);
 void tables_ca_ts(adapter *ad);
 int match_caid(SPMT *pmt, int caid, int mask);
 int match_ca_caid(int ica, int aid, int caid);
-void tables_update_encrypted_status(adapter *ad, SPMT *pmt);
 
 #endif
 


### PR DESCRIPTION
The tracking of start time and grace time has ultimately been done in order to call tables_update_encrypted_status(), which calls ca_encrypted() or ca_decrypted() if they're implemented by a registered CA - but nothing implements those functions so it's all dead code.