### PR TITLE
Store PMT descriptors in the PMT, not the first stream PID

### DIFF
--- a/src/pmt.h
+++ b/src/pmt.h
@@ -101,6 +101,8 @@ typedef struct descriptor {
         return this->type == other.type && this->len == other.len &&
                this->data == other.data;
     };
+
+    bool is_ca_descriptor() { return this->type == 0x09; }
 } descriptor_t;
 
 typedef struct struct_stream_pid {
@@ -127,6 +129,7 @@ typedef struct struct_pmt {
     int version;
     uint16_t caids;
     SPMTCA *ca[MAX_CAID];
+    std::vector<descriptor_t> descriptors;
     int stream_pids;
     SStreamPid *stream_pid[MAX_PMT_PIDS];
     int id;


### PR DESCRIPTION
Follow-up from https://github.com/catalinii/minisatip/pull/1339

PMTs can have descriptors defined in the program info, while stream PIDs have descriptors defined in their elementary stream info. Now we actually keep these separate so we know where they came from.

The long term goal is to not have to call `pmt_add_caid()` but instead just operate on the descriptors we parse. Trying to divide the work into manageable chunks, so I'm putting this up for review now.

The newly introduced methods are almost identical right now, but that will change in the future.