### PR TITLE
Update pmt.cpp

### DIFF
--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -740,7 +740,7 @@ void update_cw(SPMT *pmt) {
                 break;
             }
             // if we can verify if the CW is return the latest CW
-            if (len && cw) // but don't reject failed decrypt checks
+            if (len) // TEMP disabled: if (len && cw) // but don't reject failed decrypt checks
                 continue;
 
             int change = 0;


### PR DESCRIPTION
Disable "Don't reject CWs with a failed check" #1316

Temporally disable this fix until a rewrite will be done. 