### PR TITLE
Use a vector to store stream PIDs

### DIFF
--- a/src/ca.cpp
+++ b/src/ca.cpp
@@ -305,17 +305,17 @@ void disable_cws_for_all_pmts(ca_device_t *d) {
 
 int CAPMT_add_PMT(uint8_t *capmt, int len, SPMT *pmt, int cmd_id,
                   int added_only, int ca_id) {
-    int i = 0, pos = 0;
-    for (i = 0; i < pmt->stream_pids; i++) {
-        if (added_only && !find_pid(pmt->adapter, pmt->stream_pid[i]->pid)) {
+    int pos = 0;
+    for (const auto &stream_pid : pmt->stream_pids) {
+        if (added_only && !find_pid(pmt->adapter, stream_pid.pid)) {
             LOGM("%s: skipping pmt %d (ad %d) pid %d from CAPMT", __FUNCTION__,
-                 pmt->id, pmt->adapter, pmt->stream_pid[i]->pid);
+                 pmt->id, pmt->adapter, stream_pid.pid);
             continue;
         }
-        if (!pmt->stream_pid[i]->is_audio && !pmt->stream_pid[i]->is_video)
+        if (!stream_pid.is_audio && !stream_pid.is_video)
             continue;
-        capmt[pos++] = pmt->stream_pid[i]->type;
-        copy16(capmt, pos, pmt->stream_pid[i]->pid);
+        capmt[pos++] = stream_pid.type;
+        copy16(capmt, pos, stream_pid.pid);
         pos += 2;
         int pi_len_pos = pos, pi_len = 0;
         pos += 2;

--- a/src/dvbapi.cpp
+++ b/src/dvbapi.cpp
@@ -461,11 +461,11 @@ int dvbapi_send_pmt(SKey *k, int cmd_id) {
 
     // Pids associated with the PMT
     copy16(buf, 10, len - 12);
-    int i;
-    for (i = 0; i < pmt->stream_pids; i++) {
+
+    for (const auto &stream_pid : pmt->stream_pids) {
         len += 5;
-        int type = pmt->stream_pid[i]->type;
-        int pid = pmt->stream_pid[i]->pid;
+        int type = stream_pid.type;
+        int pid = stream_pid.pid;
         buf[len - 5] = type;
         copy16(buf, len - 4, pid);
         copy16(buf, len - 2, 0);

--- a/src/pmt.h
+++ b/src/pmt.h
@@ -7,7 +7,6 @@
 
 #define MAX_CAID 20
 #define MAX_ACTIVE_PIDS 20
-#define MAX_PMT_PIDS (2 * MAX_ACTIVE_PIDS)
 #define CA_ALGO_DVBCSA 0
 #define CA_ALGO_DES 1
 #define CA_ALGO_AES128_ECB 2
@@ -108,8 +107,8 @@ typedef struct descriptor {
 typedef struct struct_stream_pid {
     int type;
     int pid;
-    char is_audio : 1;
-    char is_video : 1;
+    bool is_audio;
+    bool is_video;
     std::vector<descriptor_t> descriptors;
 } SStreamPid;
 
@@ -130,8 +129,7 @@ typedef struct struct_pmt {
     uint16_t caids;
     SPMTCA *ca[MAX_CAID];
     std::vector<descriptor_t> descriptors;
-    int stream_pids;
-    SStreamPid *stream_pid[MAX_PMT_PIDS];
+    std::vector<SStreamPid> stream_pids;
     int id;
     int blen;
     int ca_mask, disabled_ca_mask;
@@ -231,8 +229,8 @@ int wait_pusi(adapter *ad, int len);
 int pmt_add_ca_descriptor(SPMT *pmt, uint8_t *buf, int sca_id);
 void free_filters();
 void stop_pmt(SPMT *pmt, adapter *ad);
-int pmt_add_stream_pid(SPMT *pmt, int pid, int type, int is_audio, int is_video,
-                       int es_len);
+int pmt_add_stream_pid(SPMT *pmt, int pid, int type, bool is_audio,
+                       bool is_video);
 void pmt_add_caid(SPMT *pmt, uint16_t caid, uint16_t capid, uint8_t *data,
                   int len);
 void free_all_pmts();

--- a/tests/test_ca.cpp
+++ b/tests/test_ca.cpp
@@ -86,22 +86,11 @@ int test_create_capmt() {
     add_pmt_to_capmt(&d, get_pmt(p1), 1);
     add_pmt_to_capmt(&d, get_pmt(p2), 1);
     SPMT *pmt = get_pmt(p1);
-    pmt->stream_pids = 2;
-    pmt->stream_pid[0] = (SStreamPid *)malloc(sizeof(SStreamPid));
-    pmt->stream_pid[0]->pid = 501;
-    pmt->stream_pid[0]->type = 2;
-    pmt->stream_pid[0]->pid = 502;
-    pmt->stream_pid[0]->type = 3;
-    pmt->stream_pid[1] = (SStreamPid *)malloc(sizeof(SStreamPid));
-
+    pmt_add_stream_pid(pmt, 501, 2, false, true);
+    pmt_add_stream_pid(pmt, 502, 3, true, false);
     pmt = get_pmt(p2);
-    pmt->stream_pids = 2;
-    pmt->stream_pid[0] = (SStreamPid *)malloc(sizeof(SStreamPid));
-    pmt->stream_pid[0]->pid = 601;
-    pmt->stream_pid[0]->type = 2;
-    pmt->stream_pid[0]->pid = 602;
-    pmt->stream_pid[0]->type = 3;
-    pmt->stream_pid[1] = (SStreamPid *)malloc(sizeof(SStreamPid));
+    pmt_add_stream_pid(pmt, 601, 2, false, true);
+    pmt_add_stream_pid(pmt, 602, 3, true, false);
 
     int len = create_capmt(d.capmt, 1, clean, sizeof(clean), 0, 0);
     if (len <= 0)

--- a/tests/test_ddci.cpp
+++ b/tests/test_ddci.cpp
@@ -67,8 +67,8 @@ SPMT *create_pmt(int ad, int sid, int pid1, int pid2, int caid1, int caid2) {
     int pmt_id = pmt_add(ad, sid, 1000);
     SPMT *pmt = get_pmt(pmt_id);
     pmt->pid = pmt_id * 1000;
-    pmt_add_stream_pid(pmt, pid1, 2, 0, 1, 0);
-    pmt_add_stream_pid(pmt, pid2, 6, 1, 0, 0);
+    pmt_add_stream_pid(pmt, pid1, 2, false, true);
+    pmt_add_stream_pid(pmt, pid2, 6, true, false);
     pmt_add_caid(pmt, caid1, caid1, NULL, 0);
     pmt_add_caid(pmt, caid2, caid2, NULL, 0);
     return pmt;
@@ -183,7 +183,7 @@ int test_add_del_pmt() {
     c->locked = 1;
     c->ddci[c->ddcis++].ddci = 1;
 
-    pmt_add_stream_pid(pmt2, 0xFF, 2, 0, 1, 0);
+    pmt_add_stream_pid(pmt2, 0xFF, 2, false, true);
     pmt_add_caid(pmt2, 0x502, 0xFE, NULL, 0);
 
     ASSERT(ddci_process_pmt(&ad, pmt2) == TABLES_RESULT_OK,
@@ -500,7 +500,7 @@ int test_create_pmt() {
     // gets added to the PMT correctly
     uint8_t descriptor_data[] = {0x09, 0x04, 0x0B, 0x00, 0x05, 0x73};
     descriptor_t ca_descriptor = create_descriptor(descriptor_data);
-    pmt->stream_pid[1]->descriptors.push_back(ca_descriptor);
+    pmt->stream_pids[1].descriptors.push_back(ca_descriptor);
 
     psi_len = ddci_create_pmt(&d, pmt, psi, sizeof(psi), &dp);
     cc = 1;
@@ -548,7 +548,7 @@ int test_create_pmt() {
     process_pmt(0, psi + 1, psi_len, new_pmt);
     filters[0] = NULL;
     ASSERT_EQUAL(
-        pmt->stream_pids, new_pmt->stream_pids,
+        pmt->stream_pids.size(), new_pmt->stream_pids.size(),
         "Number of streampids does not matches between generated PMT and "
         "read PMT");
     ASSERT_EQUAL(pmt->caids, new_pmt->caids,


### PR DESCRIPTION
Also changes `is_audio`/`is_video` to booleans.

The `test_create_capmt()` test case was broken, it overwrote `pmt->stream_pids[0]->type/pid` twice. The test should be expanded to actually test more stuff, mainly the structure of the CA PMT itself. Now it just calls `create_capmt()` and verifies that it returned a length, but the structure itself is untested. Especially going forward if/when we want to treat program-level CA descriptors and stream-level CA descriptors separately we need to have tests for this.