### PR TITLE
Rework the stream locking to include also the sockets

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -10,8 +10,6 @@
 #include <sys/uio.h>
 
 typedef std::recursive_mutex SMutex;
-#define mutex_lock(x) (x)->lock()
-#define mutex_unlock(x) (x)->unlock()
 
 int split(char **rv, char *s, int lrv, char sep);
 int map_int(char *s, char **v);


### PR DESCRIPTION
In adapter thread, process dmx did not lock sockets which would cause the rsock_id to be polled at the same time in the main thread.
This locks also the rsock for the streams that are being locked and it also reduces the time the lock is held (excluding the stream processing).
Before 2.0.27 both flushing and buffering were locking the stream lock so it was ok.

https://github.com/catalinii/minisatip/blame/37b0ba34eadcd4d50118968dc299c5f78c4f2d1c/src/socketworks.cpp#L1388 was being hit while 1 thread (ADx was pushing data) and the main thread was flushing data at the same time.