### PR TITLE
Use dedicated log module "ddci" for DDCI

### DIFF
--- a/src/ddci.cpp
+++ b/src/ddci.cpp
@@ -51,7 +51,7 @@
 #include "utils/ticks.h"
 #include <linux/dvb/ca.h>
 
-#define DEFAULT_LOG LOG_DVBCA
+#define DEFAULT_LOG LOG_DDCI
 #define CONFIG_FILE_NAME "ddci.conf"
 
 extern int dvbca_id;

--- a/src/utils.h
+++ b/src/utils.h
@@ -83,10 +83,11 @@ typedef ssize_t (*mywritev)(int fd, const struct iovec *io, int len);
 #endif
 
 #ifdef UTILS_C
-const char *loglevels[] = {
-    "general", "http",   "socketworks", "stream", "adapter",   "satipc",
-    "pmt",     "tables", "dvbapi",      "lock",   "netceiver", "ca",
-    "socket",  "utils",  "dmx",         "ssdp",   "dvb",       NULL};
+const char *loglevels[] = {"general", "http",   "socketworks", "stream",
+                           "adapter", "satipc", "pmt",         "tables",
+                           "dvbapi",  "lock",   "netceiver",   "ca",
+                           "socket",  "utils",  "dmx",         "ssdp",
+                           "dvb",     "ddci",   NULL};
 mywritev _writev = writev;
 #else
 extern char *loglevels[];

--- a/src/utils/logging/logging.h
+++ b/src/utils/logging/logging.h
@@ -40,6 +40,7 @@ extern __thread int thread_index;
 #define LOG_DMX (1 << 15)
 #define LOG_SSDP (1 << 16)
 #define LOG_DVB (1 << 17)
+#define LOG_DDCI (1 << 18)
 
 #define LOGL(level, a, ...)                                                    \
     {                                                                          \


### PR DESCRIPTION
Makes it possible to run with "-v ca" to debug CAM issues without getting overwhelmed by DDCI-related messages