### PR TITLE
Increase MAX_CA_PMT, cap value supplied by user

### DIFF
--- a/src/ca.cpp
+++ b/src/ca.cpp
@@ -3105,7 +3105,11 @@ void set_ca_channels(char *o) {
             multiple_pmt = 1;
         }
 
+        // Can't go over MAX_CA_PMT
         int max_ca_pmt = atoi(sep + 1);
+        if (max_ca_pmt > MAX_CA_PMT) {
+            max_ca_pmt = MAX_CA_PMT;
+        }
 
         ddci = map_intd(arg[i], NULL, -1);
         if (!ca_devices[ddci])

--- a/src/ca.h
+++ b/src/ca.h
@@ -3,7 +3,9 @@
 #include "adapter.h"
 #include "aes.h"
 #include "pmt.h"
-#define MAX_CA_PMT 4
+// Absolute maximum, used for array sizes. User sets the actual maximum value
+// using "-c"
+#define MAX_CA_PMT 8
 // Default number of CA PMTs to use
 #define DEFAULT_CA_PMT 1
 #define MAX_SESSIONS 64


### PR DESCRIPTION
This also fixes wrong default when no `-c` parameter is used.

Fixes https://github.com/catalinii/minisatip/issues/1355