### PR TITLE
Switch stream pids to std::string

### DIFF
--- a/src/adapter.h
+++ b/src/adapter.h
@@ -34,6 +34,37 @@ typedef struct ca_device ca_device_t;
 #define MAX_DELSYS 10
 #define MAX_PMT_FOR_ADAPTER 255
 
+#define MAX_STREAMS_PER_PID 16
+#define MAX_PIDS 128
+#define PID_STATE_INACTIVE 0
+#define PID_STATE_ACTIVE 1
+#define PID_STATE_NEW 2
+#define PID_STATE_DELETED 3
+
+typedef struct struct_pid {
+    int16_t pid;         // pid for this demux - not used
+    int fd;              // fd for this demux
+    int cc_err, cc_err2; // counter errors
+    int16_t sid[MAX_STREAMS_PER_PID];
+    char flags; // 0 - disabled , 1 enabled, 2 - will be enabled next tune when
+                // tune is called, 3 disable when tune is called
+    uint32_t packets, packets2; // how many packets for this pid arrived, used
+                                // to sort the pids
+    int dec_err;                // decrypt errors, continuity counters
+    uint8_t is_decrypted;       // Set when first decrypted
+    int16_t pmt, filter;
+    int16_t cc, cc1, cc2;
+    int sock; // sock_id
+#ifdef CRC_TS
+    uint32_t crc;
+    int count;
+#endif
+    struct_pid() : flags(0) {
+        for (auto &x : sid)
+            x = -1;
+    }
+} SPid;
+
 typedef struct struct_adapter adapter;
 struct struct_adapter {
     char enabled;

--- a/src/dvb.h
+++ b/src/dvb.h
@@ -1,6 +1,5 @@
 #ifndef DVB_H
 #define DVB_H
-
 #ifdef __APPLE__
 #include <sys/types.h>
 #else
@@ -9,7 +8,6 @@
 #endif
 
 #ifdef DISABLE_LINUXDVB
-// #include <linux/types.h>
 #include <stdint.h>
 #include <time.h>
 #define DVBAPIVERSION 0x0500
@@ -260,14 +258,7 @@ typedef enum dvb_snr_table {
 #define DTV_STREAM_ID 42
 #endif
 
-#define MAX_PIDS 128
-#define PID_STATE_INACTIVE 0
-#define PID_STATE_ACTIVE 1
-#define PID_STATE_NEW 2
-#define PID_STATE_DELETED 3
-
 #define MAX_DVBAPI_SYSTEMS 22
-#define MAX_STREAMS_PER_PID 16
 
 #define USE_DVR 0   // Always use DVR device for the stream
 #define USE_DEMUX 1 // Always use the DEMUX device for the stream
@@ -345,31 +336,6 @@ typedef struct struct_transponder {
 
     char *apids, *pids, *dpids, *x_pmt;
 } transponder;
-
-typedef struct struct_pid {
-    int16_t pid;         // pid for this demux - not used
-    int fd;              // fd for this demux
-    int cc_err, cc_err2; // counter errors
-    // stream id - one more to set it -1
-    int16_t sid[MAX_STREAMS_PER_PID];
-    char flags; // 0 - disabled , 1 enabled, 2 - will be enabled next tune when
-                // tune is called, 3 disable when tune is called
-    uint32_t packets, packets2; // how many packets for this pid arrived, used
-                                // to sort the pids
-    int dec_err;                // decrypt errors, continuity counters
-    uint8_t is_decrypted;       // Set when first decrypted
-    int16_t pmt, filter;
-    int16_t cc, cc1, cc2;
-    int sock; // sock_id
-#ifdef CRC_TS
-    uint32_t crc;
-    int count;
-#endif
-    struct_pid() : flags(0) {
-        for (auto &x : sid)
-            x = -1;
-    }
-} SPid;
 
 #ifndef DISABLE_LINUXDVB
 // int tune_it(int fd_frontend, unsigned int freq, unsigned int srate, char pol,

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -145,21 +145,21 @@ void set_stream_parameters(int s_id, transponder *t) {
     if (!sid || !sid->enabled)
         return;
     if (t->apids && t->apids[0] >= '0' && t->apids[0] <= '9') {
-        _strncpy(sid->apids, t->apids, LEN_PIDS);
-        t->apids = sid->apids;
+        sid->apids = t->apids;
+        t->apids = (char *)sid->apids.c_str();
     }
     if (t->dpids && t->dpids[0] >= '0' && t->dpids[0] <= '9') {
-        _strncpy(sid->dpids, t->dpids, LEN_PIDS);
-        t->dpids = sid->dpids;
+        sid->dpids = t->dpids;
+        t->dpids = (char *)sid->dpids.c_str();
     }
     if (t->pids && t->pids[0] >= '0' && t->pids[0] <= '9') {
-        _strncpy(sid->pids, t->pids, LEN_PIDS);
-        t->pids = sid->pids;
+        sid->pids = t->pids;
+        t->pids = (char *)sid->pids.c_str();
     }
 
     if (t->x_pmt && t->x_pmt[0] >= '0' && t->x_pmt[0] <= '9') {
-        _strncpy(sid->x_pmt, t->x_pmt, LEN_PIDS);
-        t->x_pmt = sid->x_pmt;
+        sid->x_pmt = t->x_pmt;
+        t->x_pmt = (char *)sid->x_pmt.c_str();
     }
 
     if (!t->apids)

--- a/src/stream.h
+++ b/src/stream.h
@@ -3,6 +3,7 @@
 
 #include "dvb.h"
 #include "socketworks.h"
+#include <string>
 #include <sys/socket.h>
 
 // MAX_STREAMS, DDCI_SID should fit in adapter->sid
@@ -21,8 +22,6 @@
 #define UDP_MAX_PACK 7   // maximum udp rtp packets to buffer
 #define TCP_MAX_PACK 42  // maximum tcp packets for a RTP header
 #define TCP_MAX_IOV 1008 // TCP_MAX_PACK * X < 1024
-
-#define LEN_PIDS (MAX_PIDS * 5 + 1)
 
 typedef struct struct_streams {
     char enabled;
@@ -45,8 +44,7 @@ typedef struct struct_streams {
     int do_play;
     int start_streaming;
     transponder tp;
-    char apids[LEN_PIDS + 1], dpids[LEN_PIDS + 1], pids[LEN_PIDS + 1],
-        x_pmt[LEN_PIDS + 1];
+    std::string apids, dpids, pids, x_pmt;
     uint32_t sp, sb;
     int timeout;
     char useragent[40];


### PR DESCRIPTION
Dynamically allocates the memory for apids, dpids, pids and x_pmt instead of statically sized based on the number of pids.
Also moves struct_pid to adapter.h where it belongs
