### PR TITLE
Fix inverted condition that caused stream PIDs to be missing from DDCI PMT

### DIFF
--- a/src/ddci.cpp
+++ b/src/ddci.cpp
@@ -743,7 +743,7 @@ int ddci_create_pmt(ddci_device_t *d, SPMT *pmt, uint8_t *new_pmt, int pmt_size,
             if (!p) {
                 p = find_pid(pmt->adapter, 8192); // all pids are requested
             }
-            if (p && !p->sid.empty()) {
+            if (p && p->sid.empty()) {
                 LOGM("%s: adapter %d pid %d not requested by the client",
                      __FUNCTION__, pmt->adapter, stream_pid.pid);
                 continue;


### PR DESCRIPTION
Broke in https://github.com/catalinii/minisatip/pull/1361