### PR TITLE
Don't attempt to filter out PIDs from DDCI PMTs

### DIFF
--- a/src/ca.cpp
+++ b/src/ca.cpp
@@ -271,12 +271,6 @@ int get_max_pmt_for_ca(int i) {
     return MAX_CA_PMT;
 }
 
-int get_ca_multiple_pmt(int i) {
-    if (i >= 0 && i < MAX_ADAPTERS && ca_devices[i] && ca_devices[i]->enabled)
-        return ca_devices[i]->multiple_pmt;
-    return 0;
-}
-
 void send_cw_to_all_pmts(ca_device_t *d, int parity) {
     int i;
     for (i = 0; i < d->max_ca_pmt; i++) {

--- a/src/ca.h
+++ b/src/ca.h
@@ -226,7 +226,6 @@ void set_ca_adapter_pin(char *o);
 void set_ca_adapter_force_ci(char *o);
 char *get_ca_pin(int i);
 void set_ca_channels(char *o);
-int get_ca_multiple_pmt(int i);
 int get_max_pmt_for_ca(int i);
 void get_authdata_filename(char *dest, size_t len, unsigned int slot,
                            char *ci_name);

--- a/src/ddci.cpp
+++ b/src/ddci.cpp
@@ -735,21 +735,7 @@ int ddci_create_pmt(ddci_device_t *d, SPMT *pmt, uint8_t *new_pmt, int pmt_size,
     copy16(start_pi_len, 0, pi_len);
 
     // Add Stream pids
-    // Add CA IDs and CA Pids
     for (const auto &stream_pid : pmt->stream_pids) {
-        if (get_ca_multiple_pmt(d->id)) {
-            // Do not map any pids that are not requested by the client
-            SPid *p = find_pid(pmt->adapter, stream_pid.pid);
-            if (!p) {
-                p = find_pid(pmt->adapter, 8192); // all pids are requested
-            }
-            if (p && p->sid.empty()) {
-                LOGM("%s: adapter %d pid %d not requested by the client",
-                     __FUNCTION__, pmt->adapter, stream_pid.pid);
-                continue;
-            }
-        }
-
         // Stream type + PID
         *b = stream_pid.type;
         copy16(b, 1, safe_get_pid_mapping(d, pmt->adapter, stream_pid.pid));


### PR DESCRIPTION
In normal operation, the whole mux is sent to the CAM, and all CAMs can handle that just fine, even though a mux can have upwards of 100 PIDs. When this filtering logic was added the main concern was that the CA PMT would balloon in size, however, that filtering happens elsewhere independent of this.

@catalinii continuation of https://github.com/catalinii/minisatip/pull/1365