### PR TITLE
dvbapi: add descramble watchdog and extend CW lifetime

### DIFF
--- a/src/dvbapi.cpp
+++ b/src/dvbapi.cpp
@@ -56,6 +56,8 @@ int dvbapi_sock = -1;
 int sock;
 int dvbapi_is_enabled = 0;
 int enabledKeys = 0;
+
+int dvbapi_enabled() { return dvbapi_is_enabled; }
 int network_mode = 1;
 int dvbapi_protocol_version = DVBAPI_PROTOCOL_VERSION;
 int dvbapi_ca = -1;
@@ -318,7 +320,10 @@ int dvbapi_reply(sockets *s) {
                     k_id, parity, index, k->algo, correct ? "OK" : "NOK", cw[0],
                     cw[1], cw[2], cw[3], cw[4], cw[5], cw[6], cw[7]);
 
-                send_cw(k->pmt_id, k->algo, parity, cw, NULL, 0, &k->icam_ecm);
+                // Some systems may keep the same parity for >45s; keep CWs longer to
+                // avoid short freezes on parity switch when the "other" parity CW
+                // expired on our side.
+                send_cw(k->pmt_id, k->algo, parity, cw, NULL, 180, &k->icam_ecm);
             } else
                 LOG("dvbapi: invalid DVBAPI_CA_SET_DESCR, key %d parity %d, k "
                     "%p, "

--- a/src/dvbapi.h
+++ b/src/dvbapi.h
@@ -95,6 +95,7 @@ int decrypt_stream(adapter *ad, void *arg);
 int keys_add(int i, int adapter, int pmt_id);
 int keys_del(int i);
 int dvbapi_process_pmt(unsigned char *b, adapter *ad);
+int dvbapi_send_pmt(SKey *k, int cmd_id);
 void dvbapi_pid_add(adapter *a, int pid, SPid *cp, int existing);
 void dvbapi_pid_del(adapter *a, int pid, SPid *cp);
 void register_dvbapi();

--- a/src/pmt.h
+++ b/src/pmt.h
@@ -144,6 +144,11 @@ typedef struct struct_pmt {
     SPMT_batch *batch;
     int8_t parity, update_cw;
     uint64_t last_update_cw;
+    int64_t last_descramble_ok;
+    int64_t last_scrambled;
+    int64_t descramble_fail_start;
+    int64_t last_descramble_restart;
+    uint8_t descramble_watchdog_resend_pmt;
     int16_t master_pmt; //  the pmt that contains the same pids as this PMT
     SCW *cw;
     SPid *p;


### PR DESCRIPTION
This PR targets an intermittent DVBAPI descramble stall observed with OSCam: scrambled TS continues but successful decrypt stops until a zap/reconnect.

Changes:
- Extend DVBAPI CW lifetime to 180s (avoid parity-switch freezes when parity is unchanged > default CW timeout).
- Add PMT-level descramble watchdog: track last scrambled vs last decrypt-ok; on stall clear CWs + resend CAPMT once; hard fallback restarts PMT state with cooldown.
- Expose dvbapi_send_pmt() and implement dvbapi_enabled() for the watchdog.

Files: src/dvbapi.cpp, src/dvbapi.h, src/pmt.cpp, src/pmt.h.

Happy to adjust thresholds/logging/style if you prefer different defaults.