### PR TITLE
Fix: Force stream close on SRT send failure and handle forced timeout…

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1303,37 +1303,38 @@ int stream_timeout(sockets *s) {
     ctime = getTick();
     s->rtime = ctime;
 
-    if ((sid = get_sid(s->sid))) {
-        std::unique_lock<SMutex> lock(sid->mutex);
-        if (sid->timeout == 1) {
-            LOG("Stream forced close requested for sid %d", sid->sid);
-            lock.unlock();
-            close_stream(sid->sid);
-            return 0;
+    if (!(sid = get_sid(s->sid)))
+        return 0;
+
+    std::unique_lock<SMutex> lock(sid->mutex);
+    if (sid->timeout == 1) {
+        LOG("Stream forced close requested for sid %d", sid->sid);
+        lock.unlock();
+        close_stream(sid->sid);
+        return 0;
+    }
+
+    if (sid->type != STREAM_HTTP && sid->type != STREAM_RTSP_SRT) {
+        rttime = sid->rtcp_wtime, rtime = sid->wtime;
+
+        if (sid->do_play && ctime - rtime > 1000) {
+            LOG("no data sent for more than 1s sid: %d for %s:%d", sid->sid,
+                get_stream_rhost(sid->sid, ra, sizeof(ra)),
+                get_stream_rport(sid->sid));
+            enqueue_rtp_header(sid, iov, 1, 0, rtp_buf);
+            flush_stream(sid, iov, 1, ctime);
         }
+        if (sid->do_play && ctime - rttime >= 200)
+            send_rtcp(sid->sid, ctime);
+        // check stream timeout, and allow 10s more to respond
+        if (sid->timeout > 0 && (ctime - sid->rtime > sid->timeout + 10000)) {
+            LOG("Stream timeout sid %d, closing (ctime %jd , sid->rtime "
+                "%jd, "
+                "sid->timeout %d)",
+                sid->sid, ctime, sid->rtime, sid->timeout);
 
-        if (sid->type != STREAM_HTTP && sid->type != STREAM_RTSP_SRT) {
-            rttime = sid->rtcp_wtime, rtime = sid->wtime;
-
-            if (sid->do_play && ctime - rtime > 1000) {
-                LOG("no data sent for more than 1s sid: %d for %s:%d", sid->sid,
-                    get_stream_rhost(sid->sid, ra, sizeof(ra)),
-                    get_stream_rport(sid->sid));
-                enqueue_rtp_header(sid, iov, 1, 0, rtp_buf);
-                flush_stream(sid, iov, 1, ctime);
-            }
-            if (sid->do_play && ctime - rttime >= 200)
-                send_rtcp(sid->sid, ctime);
-            // check stream timeout, and allow 10s more to respond
-            if (sid->timeout > 0 && (ctime - sid->rtime > sid->timeout + 10000)) {
-                LOG("Stream timeout sid %d, closing (ctime %jd , sid->rtime "
-                    "%jd, "
-                    "sid->timeout %d)",
-                    sid->sid, ctime, sid->rtime, sid->timeout);
-
-                lock.unlock();
-                close_stream(sid->sid); // do not lock before this
-            }
+            lock.unlock();
+            close_stream(sid->sid); // do not lock before this
         }
     }
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -788,6 +788,7 @@ int flush_stream(streams *sid, struct iovec *iov, int iiov, int64_t ctime) {
                 } else {
                     LOG("SRT send failed for sid %d: %s", sid->sid,
                         srt_getlasterror_str());
+                    sid->timeout = 1;
                     goto srt_done;
                 }
             }
@@ -1302,30 +1303,37 @@ int stream_timeout(sockets *s) {
     ctime = getTick();
     s->rtime = ctime;
 
-    if ((sid = get_sid(s->sid)) && sid->type != STREAM_HTTP &&
-        sid->type != STREAM_RTSP_SRT) {
+    if ((sid = get_sid(s->sid))) {
         std::unique_lock<SMutex> lock(sid->mutex);
-        rttime = sid->rtcp_wtime, rtime = sid->wtime;
-
-        if (sid->do_play && ctime - rtime > 1000) {
-            LOG("no data sent for more than 1s sid: %d for %s:%d", sid->sid,
-                get_stream_rhost(sid->sid, ra, sizeof(ra)),
-                get_stream_rport(sid->sid));
-            enqueue_rtp_header(sid, iov, 1, 0, rtp_buf);
-            flush_stream(sid, iov, 1, ctime);
-        }
-        if (sid->do_play && ctime - rttime >= 200)
-            send_rtcp(sid->sid, ctime);
-        // check stream timeout, and allow 10s more to respond
-        if ((sid->timeout > 0 && (ctime - sid->rtime > sid->timeout + 10000)) ||
-            (sid->timeout == 1)) {
-            LOG("Stream timeout sid %d, closing (ctime %jd , sid->rtime "
-                "%jd, "
-                "sid->timeout %d)",
-                sid->sid, ctime, sid->rtime, sid->timeout);
-
+        if (sid->timeout == 1) {
+            LOG("Stream forced close requested for sid %d", sid->sid);
             lock.unlock();
-            close_stream(sid->sid); // do not lock before this
+            close_stream(sid->sid);
+            return 0;
+        }
+
+        if (sid->type != STREAM_HTTP && sid->type != STREAM_RTSP_SRT) {
+            rttime = sid->rtcp_wtime, rtime = sid->wtime;
+
+            if (sid->do_play && ctime - rtime > 1000) {
+                LOG("no data sent for more than 1s sid: %d for %s:%d", sid->sid,
+                    get_stream_rhost(sid->sid, ra, sizeof(ra)),
+                    get_stream_rport(sid->sid));
+                enqueue_rtp_header(sid, iov, 1, 0, rtp_buf);
+                flush_stream(sid, iov, 1, ctime);
+            }
+            if (sid->do_play && ctime - rttime >= 200)
+                send_rtcp(sid->sid, ctime);
+            // check stream timeout, and allow 10s more to respond
+            if (sid->timeout > 0 && (ctime - sid->rtime > sid->timeout + 10000)) {
+                LOG("Stream timeout sid %d, closing (ctime %jd , sid->rtime "
+                    "%jd, "
+                    "sid->timeout %d)",
+                    sid->sid, ctime, sid->rtime, sid->timeout);
+
+                lock.unlock();
+                close_stream(sid->sid); // do not lock before this
+            }
         }
     }
 


### PR DESCRIPTION
### Problem

When an SRT send fails, `srt_send` in `flush_stream` returns an error, which is logged as `"SRT send failed for sid %d: %s"`. However, the stream is not torn down because the return value is ignored by callers, and the stream stays open in an unusable or dangling state.

Calling `close_stream` directly inside `flush_stream` is not safe due to lock-ordering rules:
- `flush_stream` is executed inside the data/DMX processing thread, which already holds `sid->mutex` (stream mutex) and `ad->mutex` (adapter mutex).
- `close_stream` acquires `st_mutex` before acquiring `st[i]->mutex` (which is `sid->mutex`).
- This lock-order inversion (`st_mutex` -> `sid->mutex` vs. `sid->mutex` -> `st_mutex`) can result in a dead-lock with other threads (e.g. RTSP control thread) that are tearing down streams.

### Solution

This PR implements a safe, deferred, asynchronous stream shutdown mechanism:
1. **Deferred Close Trigger**: When `srt_send` fails, the stream is marked for closure by setting `sid->timeout = 1` inside `flush_stream`.
2. **Safe Handshake/Timer Check**: Updates the periodic `stream_timeout()` timer callback (which runs every 200 ms in the sockets thread) to monitor `sid->timeout == 1` across all stream types (including `STREAM_RTSP_SRT` and `STREAM_HTTP`).
3. **Guard Clause Refactor**: Refactored `stream_timeout()` to use an early-return guard clause (`if (!(sid = get_sid(s->sid))) return 0;`) to avoid unnecessary nesting and improve readability.
4. **Deadlock Prevention**: When `stream_timeout` detects the forced close request, it temporarily unlocks `sid->mutex` before calling `close_stream()`, maintaining the correct, deadlock-free locking hierarchy.

### Verification

- Successfully verified that the codebase compiles cleanly with `CMake`.
- Verified that all unit tests (`test_opts`, `test_utils`, `test_adapter`, `test_pmt`) compile and run successfully.
