### PR TITLE
ca: replace deprecated X509_NAME_get_text_by_NID() with OpenSSL 4.0-compatible API

### DIFF
--- a/src/ca.cpp
+++ b/src/ca.cpp
@@ -1194,9 +1194,12 @@ static int element_set_certificate(struct cc_ctrl_data *cc_data,
 
 static int element_set_hostid_from_certificate(struct cc_ctrl_data *cc_data,
                                                unsigned int id, X509 *cert) {
+    const ASN1_STRING *data;
     const X509_NAME *subject;
     int nid_cn = OBJ_txt2nid("CN");
-    char hostid[20];
+    int idx;
+    int len;
+    char hostid[20] = {};
     uint8_t bin_hostid[8];
 
     if ((id != 5) && (id != 6)) {
@@ -1205,7 +1208,18 @@ static int element_set_hostid_from_certificate(struct cc_ctrl_data *cc_data,
     }
 
     subject = X509_get_subject_name(cert);
-    X509_NAME_get_text_by_NID(subject, nid_cn, hostid, sizeof(hostid));
+    idx = X509_NAME_get_index_by_NID(subject, nid_cn, -1);
+    if (idx >= 0) {
+        data = X509_NAME_ENTRY_get_data(X509_NAME_get_entry(subject, idx));
+        len = ASN1_STRING_length(data);
+        if (len > (int)sizeof(hostid) - 1)
+            len = sizeof(hostid) - 1;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+        memcpy(hostid, ASN1_STRING_data(data), len);
+#else
+        memcpy(hostid, ASN1_STRING_get0_data(data), len);
+#endif
+    }
 
     if (strlen(hostid) != 16) {
         LOG("malformed hostid");


### PR DESCRIPTION
X509_NAME_get_text_by_NID() was deprecated in OpenSSL 4.0. Replace it with X509_NAME_get_index_by_NID(), X509_NAME_get_entry(), X509_NAME_ENTRY_get_data(), and ASN1_STRING_get0_data(), which avoid the known deficiency of the deprecated function silently truncating strings containing embedded NUL bytes.

ASN1_STRING_get0_data() was introduced in OpenSSL 1.1.0 as the const-correct replacement for ASN1_STRING_data(). Add a preprocessor guard for compatibility with OpenSSL < 1.1.0.

Also zero-initialise the hostid buffer so that if the CN entry is not found, strlen(hostid) returns 0 and the existing malformed hostid check fires cleanly rather than reading uninitialised memory.

fixes:
```
src/ca.cpp: In function 'int element_set_hostid_from_certificate(cc_ctrl_data*, unsigned int, X509*)':
src/ca.cpp:1208:30: warning: 'int X509_NAME_get_text_by_NID(const X509_NAME*, int, char*, int)' is deprecated: Since OpenSSL 4.0 [-Wdeprecated-declarations]
 1208 |     X509_NAME_get_text_by_NID(subject, nid_cn, hostid, sizeof(hostid));
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/openssl/pem.h:23,
                 from src/ca.cpp:39:
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/openssl/x509.h:1041:27: note: declared here
 1041 | OSSL_DEPRECATEDIN_4_0 int X509_NAME_get_text_by_NID(const X509_NAME *name,
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~
``` 