### PR TITLE
Fix dynamic-stack-buffer-overflow in test_decrypt_packet

### DIFF
--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -655,7 +655,7 @@ void cw_decrypt_stream(SCW *cw, SPMT_batch *batch, int len) {
 
 // Return 0 if the packet was decrypted successfully, 1 otherwise
 int test_decrypt_packet(SCW *cw, SPMT_batch *start, int len) {
-    uint8_t data[len * 188 + 10];
+    uint8_t data[len * 188 + 256];
     int i = 0;
     uint32_t pos = 0;
     LOGM("Testing len %d, CW: %s", len, cw_to_string(cw, (char *)data));


### PR DESCRIPTION
Increase data buffer padding from +10 to +256 bytes to prevent OpenSSL's ossl_cipher_trailingdata from reading past the end of the VLA when processing the last packet with a large adaptation field (adapt_len >= 183). The 16-byte trailing read overran the previous 10-byte padding by up to 6 bytes.