### PR TITLE
Fix heap-use-after-free during shutdown caused by worker threads outl…

### DIFF
--- a/src/minisatip.cpp
+++ b/src/minisatip.cpp
@@ -1950,7 +1950,7 @@ int main(int argc, char *argv[]) {
 
     write_pid_file();
     select_and_execute(NULL);
-    join_all_threads();
+    join_thread();
     unlink(pid_file);
 #ifndef DISABLE_PMT
     pmt_destroy();

--- a/src/minisatip.cpp
+++ b/src/minisatip.cpp
@@ -1950,6 +1950,7 @@ int main(int argc, char *argv[]) {
 
     write_pid_file();
     select_and_execute(NULL);
+    join_all_threads();
     unlink(pid_file);
 #ifndef DISABLE_PMT
     pmt_destroy();

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -1269,7 +1269,7 @@ int calculate_bw(sockets *s) {
         buffered_bytes = 0;
         dropped_bytes = 0;
     }
-    join_thread();
+    join_exited_threads();
     return 0;
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -552,6 +552,23 @@ void join_thread() {
     join_pos = 0;
 }
 
+void join_all_threads() {
+    int i, running = 0;
+
+    do {
+        running = 0;
+        for (i = 0; i < MAX_THREAD_INFO; i++)
+            if (thread_info[i].enabled) {
+                running = 1;
+                break;
+            }
+        if (running)
+            sleep_msec(10);
+    } while (running);
+
+    join_thread();
+}
+
 int init_utils(char *arg0) {
     set_signal_handler(arg0);
     return 0;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -555,6 +555,14 @@ void join_exited_threads() {
 void join_thread() {
     int i, running = 0;
 
+    // A worker thread only registers itself via add_join_thread() at the very
+    // end of its select_and_execute() loop, right before it clears
+    // thread_info[].enabled. join_exited_threads() below can only join threads
+    // that are already in join_th[], so wait until every worker has cleared its
+    // enabled flag (guaranteeing it has already registered) before joining.
+    // Without this wait, main() would return while worker threads are still
+    // running and using global statics (e.g. the EnumMap tables in dvb.cpp),
+    // which are destroyed when main() returns - causing a heap-use-after-free.
     do {
         running = 0;
         for (i = 0; i < MAX_THREAD_INFO; i++)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -539,7 +539,7 @@ void add_join_thread(pthread_t t) {
     LOG("%s: pthread %lx", __FUNCTION__, t);
 }
 
-void join_thread() {
+void join_exited_threads() {
     int i, rv;
     std::lock_guard<SMutex> lock(join_lock);
     //	LOG("starting %s", __FUNCTION__);
@@ -552,7 +552,7 @@ void join_thread() {
     join_pos = 0;
 }
 
-void join_all_threads() {
+void join_thread() {
     int i, running = 0;
 
     do {
@@ -566,7 +566,7 @@ void join_all_threads() {
             sleep_msec(10);
     } while (running);
 
-    join_thread();
+    join_exited_threads();
 }
 
 int init_utils(char *arg0) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -97,6 +97,7 @@ void set_thread_prio(pthread_t tid, int prio);
 int find_new_id(void **arr, int count);
 void join_thread();
 void add_join_thread(pthread_t t);
+void join_all_threads();
 int init_utils(char *arg0);
 void _hexdump(const char *desc, void *addr, int len);
 uint32_t crc_32(const uint8_t *data, int datalen);

--- a/src/utils.h
+++ b/src/utils.h
@@ -97,7 +97,7 @@ void set_thread_prio(pthread_t tid, int prio);
 int find_new_id(void **arr, int count);
 void join_thread();
 void add_join_thread(pthread_t t);
-void join_all_threads();
+void join_exited_threads();
 int init_utils(char *arg0);
 void _hexdump(const char *desc, void *addr, int len);
 uint32_t crc_32(const uint8_t *data, int datalen);


### PR DESCRIPTION
…iving main

When SIGINT/SIGTERM is received, run_loop is set to 0 and main returns immediately while worker threads (ADx, signal, CA_poll) may still be running. After main() returns, the C++ runtime destroys the global static objects, such as the EnumMap-based fe_fec_map in dvb.cpp. A worker thread still executing select_and_execute() can then call EnumMap::reverse_lookup() on the freed vector, causing a heap-use-after-free (observed via describe_adapter/send_rtcp).

Make main() wait for all worker threads to exit and join them before cleaning up and returning. join_all_threads() polls thread_info[].enabled until every worker has cleared its flag (which happens after it has called add_join_thread()), then joins all registered threads.