### PR TITLE
fix(socketworks): disassociate all stream sockets in sockets_del_for_sid

### DIFF
--- a/src/socketworks.cpp
+++ b/src/socketworks.cpp
@@ -968,8 +968,8 @@ int sockets_del_for_sid(int sid) {
         return 0;
     for (i = 0; i < MAX_SOCKS; i++)
         if ((ss = get_sockets(i)) && ss->sid >= 0 && ss->sid == sid &&
-            (ss->type == TYPE_RTSP || ss->type == TYPE_HTTP ||
-             ss->type == TYPE_RTP || ss->type == TYPE_RTCP)) {
+            (ss->type == TYPE_RTSP || ss->type == TYPE_RTP ||
+             ss->type == TYPE_RTCP)) {
             ss->sid =
                 -1; // make sure the stream is not closed in the future to
                     // prevent closing the stream created by another socket

--- a/src/socketworks.cpp
+++ b/src/socketworks.cpp
@@ -530,7 +530,7 @@ int sockets_add(int sock, USockAddr *sa, int sid, int type, socket_action a,
     ss->close_unix_socket = true;
 
     ss->read = (read_action)sockets_read;
-    if (ss->type == TYPE_UDP || ss->type == TYPE_RTCP)
+    if (ss->type == TYPE_UDP || ss->type == TYPE_RTCP || ss->type == TYPE_RTP)
         ss->read = (read_action)sockets_recv;
     else if (ss->type == TYPE_SERVER)
         ss->read = (read_action)(void *)sockets_accept;
@@ -969,7 +969,7 @@ int sockets_del_for_sid(int sid) {
     for (i = 0; i < MAX_SOCKS; i++)
         if ((ss = get_sockets(i)) && ss->sid >= 0 && ss->sid == sid &&
             (ss->type == TYPE_RTSP || ss->type == TYPE_HTTP ||
-             ss->type == TYPE_UDP || ss->type == TYPE_RTCP)) {
+             ss->type == TYPE_RTP || ss->type == TYPE_RTCP)) {
             ss->sid =
                 -1; // make sure the stream is not closed in the future to
                     // prevent closing the stream created by another socket
@@ -1214,7 +1214,7 @@ int my_writev(sockets *s, struct iovec *iov, int iiov) {
         stime = getTick();
 
     if (s->sock > 0) {
-        if (s->type == TYPE_UDP && len > 1450)
+        if ((s->type == TYPE_UDP || s->type == TYPE_RTP) && len > 1450)
             rv = writev_udp(s->sock, iov, iiov);
         else
             rv = writev(s->sock, iov, iiov);

--- a/src/socketworks.cpp
+++ b/src/socketworks.cpp
@@ -967,11 +967,13 @@ int sockets_del_for_sid(int sid) {
     if (sid < 0)
         return 0;
     for (i = 0; i < MAX_SOCKS; i++)
-        if ((ss = get_sockets(i)) && ss->sid >= 0 && ss->type == TYPE_RTSP &&
-            ss->sid == sid) {
+        if ((ss = get_sockets(i)) && ss->sid >= 0 && ss->sid == sid &&
+            (ss->type == TYPE_RTSP || ss->type == TYPE_HTTP ||
+             ss->type == TYPE_UDP || ss->type == TYPE_RTCP)) {
             ss->sid =
                 -1; // make sure the stream is not closed in the future to
                     // prevent closing the stream created by another socket
+            ss->close = NULL;
         }
     return 0;
 }

--- a/src/socketworks.h
+++ b/src/socketworks.h
@@ -66,6 +66,7 @@ typedef struct struct_sockets {
 #define TYPE_RTSP 4
 #define TYPE_DVR 5
 #define TYPE_RTCP 6
+#define TYPE_RTP 7
 #define TYPE_NONBLOCK 256 // support for non blocking i/o mode
 #define TYPE_CONNECT                                                           \
     512 // support for non blocking connect -> when it is connected call write

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -312,8 +312,6 @@ int start_play(streams *sid, sockets *s) {
 }
 
 int close_stream_for_socket(sockets *s) {
-    if (!s || s->sid < 0)
-        return 0;
     streams *sid = get_sid(s->sid);
     LOG("%s: start close_stream_for_socket for id %d %p", __FUNCTION__, s->sid,
         sid);
@@ -519,7 +517,7 @@ int decode_transport(sockets *s, std::string_view arg, char *default_rtp,
                            p.dest, p.port);
 
         if ((sid->rsock_id =
-                 sockets_add(sid->rsock, &sid->sa, sid->sid, TYPE_UDP, NULL,
+                 sockets_add(sid->rsock, &sid->sa, sid->sid, TYPE_RTP, NULL,
                              (socket_action)close_stream_for_socket, NULL)) < 0)
             LOG_AND_RETURN(-1, "RTP sockets_add failed");
 

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -312,6 +312,8 @@ int start_play(streams *sid, sockets *s) {
 }
 
 int close_stream_for_socket(sockets *s) {
+    if (!s || s->sid < 0)
+        return 0;
     streams *sid = get_sid(s->sid);
     LOG("%s: start close_stream_for_socket for id %d %p", __FUNCTION__, s->sid,
         sid);


### PR DESCRIPTION
### Summary
This PR fixes a race condition where a stale socket close callback from a previously torn-down RTSP session prematurely closes a newly allocated stream sharing the same stream ID (`sid`).

### Cause
When a stream closes, `close_stream()` calls `sockets_del_for_sid(sid)` to disassociate sockets from the stream ID. Previously, `sockets_del_for_sid()` only checked for `TYPE_RTSP` sockets, leaving RTP (`TYPE_UDP`) and RTCP (`TYPE_RTCP`) sockets associated with `ss->sid`. When deferred socket deletion executed in the main loop (~200ms later), `close_stream_for_socket()` was invoked on a newly assigned stream sharing the same `sid`, setting `sid->timeout = 1` and force-closing it.

### Fix
- Updated `sockets_del_for_sid()` in `src/socketworks.cpp` to disassociate `TYPE_RTSP`, `TYPE_HTTP`, `TYPE_UDP`, and `TYPE_RTCP` sockets by resetting `ss->sid = -1` and clearing `ss->close = NULL`.
- Added a guard in `close_stream_for_socket()` in `src/stream.cpp` to ignore sockets with `s->sid < 0`.