### PR TITLE
fix(csa): declare the weak dvbcsa_bs_key_set_ecm with C linkage

### DIFF
--- a/src/csa.cpp
+++ b/src/csa.cpp
@@ -53,8 +53,14 @@ extern "C" {
 
 #define DEFAULT_LOG LOG_DVBCA
 
-void dvbcsa_bs_key_set_ecm(unsigned char ecm, const dvbcsa_cw_t cw,
-                           struct dvbcsa_bs_key_s *key) __attribute__((weak));
+// libdvbcsa is a C library, so this has to be declared with C linkage. An
+// ICAM patched libdvbcsa declares it in dvbcsa.h and the extern "C" there
+// applies, but building against a stock libdvbcsa leaves this declaration
+// on its own, and a C++ mangled weak reference never binds to the C symbol
+// even when an ICAM capable libdvbcsa.so is loaded at run time.
+extern "C" void dvbcsa_bs_key_set_ecm(unsigned char ecm, const dvbcsa_cw_t cw,
+                                      struct dvbcsa_bs_key_s *key)
+    __attribute__((weak));
 void dvbcsa_create_key(SCW *cw) { cw->key = dvbcsa_bs_key_alloc(); }
 
 void dvbcsa_delete_key(SCW *cw) { dvbcsa_key_free((dvbcsa_key_s *)cw->key); }


### PR DESCRIPTION
## Problem

`src/csa.cpp` declares the weak probe used to detect an iCAM capable libdvbcsa:

```c
void dvbcsa_bs_key_set_ecm(unsigned char ecm, const dvbcsa_cw_t cw,
                           struct dvbcsa_bs_key_s *key) __attribute__((weak));
```

This is a C++ translation unit and the declaration is outside any `extern "C"`
block of its own. Whether the emitted weak reference is the C symbol or the
mangled `_Z21dvbcsa_bs_key_set_ecmhPKhP15dvbcsa_bs_key_s` therefore depends
entirely on whether the `dvbcsa.h` that got included happened to declare the
function inside its `extern "C" { }`:

* Against an **iCAM patched** libdvbcsa the header declares it, the `extern "C"`
  there applies, and the reference is the plain C symbol. Works.
* Against a **stock** libdvbcsa the header does not declare it. The declaration
  in `csa.cpp` stands on its own as a C++ declaration and the binary carries a
  mangled weak reference that can never bind to libdvbcsa's C symbol — not at
  link time, not at load time, not even when an iCAM capable `libdvbcsa.so` is
  present.

The failure is silent at build time. At run time `init_algo_csa()` takes the
`else` branch, `CA_ALGO_DVBCSA_ICAM` is never registered, and minisatip reports
that it needs a libdvbcsa with iCAM support even on a system where that support
*is* installed, then descrambles with the plain key schedule.

This is how distributions hit it: the build host has stock libdvbcsa headers
(Fedora, Debian, …), the user later installs an iCAM capable `libdvbcsa.so`, and
there is no way to make iCAM work short of rebuilding minisatip against patched
headers.

### Demonstration

The same weak declaration compiled twice — once with the symbol declared inside
`extern "C"` (patched header present), once without (stock header):

```console
$ g++ -c -DHAVE_ICAM_HEADER wk.cpp -o wk1.o && nm -C wk1.o | grep set_ecm
                 w dvbcsa_bs_key_set_ecm

$ g++ -c wk.cpp -o wk2.o && nm wk2.o | grep set_ecm
                 w _Z21dvbcsa_bs_key_set_ecmhPKhP15dvbcsa_bs_key_s
```

The second is the reference an ordinary distribution build emits.

## Fix

Declare the prototype `extern "C"` so the symbol name no longer depends on which
headers were present at build time. One declaration changed, no behaviour change
for builds that were already working.

## Testing

`cmake -DDVBCSA=ON -DDVBCA=ON` build on Fedora 44, gcc 15, against a libdvbcsa
whose header *does* declare `dvbcsa_bs_key_set_ecm` (i.e. the case that already
worked) — builds clean and the reference stays unmangled:

```console
$ nm minisatip | grep set_ecm
                 w dvbcsa_bs_key_set_ecm
```

A build-time assertion would be cheap and would have caught the original
breakage, if you want one:

```console
nm -D minisatip | grep -q ' w dvbcsa_bs_key_set_ecm$'
```
