### PR TITLE
fix(dvbapi): read the iCAM mode only if the section is long enough

### DIFF
--- a/src/dvbapi.cpp
+++ b/src/dvbapi.cpp
@@ -654,7 +654,7 @@ int send_ecm(int filter_id, unsigned char *b, int len, void *opaque) {
     len = ((b[1] & 0xF) << 8) + b[2];
     len += 3;
     k->last_ecm = getTick();
-    if (b[2] - b[4] == 4) {
+    if (len > 0x15 && b[2] - b[4] == 4) {
         k->icam_ecm = b[0x15];
         k->is_icam = k->icam_ecm ? 1 : 0;
     } else {


### PR DESCRIPTION
Refactored after @Jalle19's reviews: the length clamp is gone — he is right that
it could never do anything — and so is the comment. What is left is one line.

## Problem

`send_ecm()` takes the iCAM mode from a fixed offset:

```c
if (b[2] - b[4] == 4) {
    k->icam_ecm = b[0x15];
```

without checking that the section reaches 0x16 bytes.

`len` at that point is the section length, and the filter layer guarantees that
`b .. b+len-1` lies inside `f->data`, so testing `len` is enough to make both
reads legal.

Two callers, two effects:

* **ECM filter.** `b` is `f->data`, so a short section reads leftovers from the
  previous section in the same filter. The key schedule is then selected from
  stale bytes. In-bounds, wrong value.
* **EMM filter** (`send_ecm()` is registered with `FILTER_ADD_REMOVE | isEMM`).
  `b` is `f->data + i` for a sub-section inside the buffer. A three byte
  sub-section at the end of a full buffer puts `i` at 3997, so `b[0x15]` is
  `f->data[4018]`, while `f->data` is 4002 bytes and `sizeof(SFilter)` is 4096 —
  the last two bytes of that read are past the allocation, the sixteen before it
  are the `flags` and `next_filter` members.

## Fix

```c
-    if (b[2] - b[4] == 4) {
+    if (len > 0x15 && b[2] - b[4] == 4) {
```

One line. `b[4]` is covered by the same guard through short-circuit evaluation.

A well formed ECM is unaffected: on a live VideoGuard feed all 36 captured
sections were far longer than 0x16 and take the same branch as before.

## Testing

Fedora 44, gcc 16, `cmake -DDVBCSA=ON -DDVBCA=ON -DBUILD_TESTING=ON`.

* `ctest` 13/13, with `TEST_SANITIZERS=ON` (default) and `OFF`.
* Live: OSCam over dvbapi, Digital Devices DVB-S2, Sky Germany / VideoGuard, iCAM
  active. Descrambling unchanged — a 3 minute recording of an encrypted service,
  0 encrypted packets, `ad_decerr 0`, `ad_ccerr 0`.

## Not in this PR

The derivation of the iCAM mode itself, and the disagreement between `b[0x15]` and
OSCam's `get_ecm_mode()`. No evidence it costs anyone a packet; I keep the
measurements if it ever becomes interesting.
