### PR TITLE
build(tests): make the test sanitizers optional via TEST_SANITIZERS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ option(CXX23 "Enable C++23 features (stacktrace)" ${CXX23_DEFAULT})
 option(DEBUG "Enable debug/sanitizer build" OFF)
 option(SRT "Enable SRT support" ${SRT_DEFAULT})
 option(BUILD_TESTING "Build tests" OFF)
+option(TEST_SANITIZERS "Build tests with AddressSanitizer/LeakSanitizer" ON)
 
 # Platform detection
 if(APPLE)
@@ -314,11 +315,13 @@ if(BUILD_TESTING)
     if(NOT DVBCSA_LIBRARY)
         target_compile_definitions(test_main_lib PRIVATE DISABLE_DVBCSA)
     endif()
-    target_compile_options(test_main_lib PRIVATE
-        -fsanitize=address
-        -fno-omit-frame-pointer
-        -fsanitize=leak
-    )
+    target_compile_options(test_main_lib PRIVATE -fno-omit-frame-pointer)
+    if(TEST_SANITIZERS)
+        target_compile_options(test_main_lib PRIVATE
+            -fsanitize=address
+            -fsanitize=leak
+        )
+    endif()
 
     foreach(TEST_SOURCE ${TEST_SOURCES})
         get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
@@ -338,15 +341,17 @@ if(BUILD_TESTING)
         if(NOT DVBCSA_LIBRARY)
             target_compile_definitions(${TEST_NAME} PRIVATE DISABLE_DVBCSA)
         endif()
-        target_compile_options(${TEST_NAME} PRIVATE
-            -fsanitize=address
-            -fno-omit-frame-pointer
-            -fsanitize=leak
-        )
-        target_link_options(${TEST_NAME} PRIVATE
-            -fsanitize=address
-            -fsanitize=leak
-        )
+        target_compile_options(${TEST_NAME} PRIVATE -fno-omit-frame-pointer)
+        if(TEST_SANITIZERS)
+            target_compile_options(${TEST_NAME} PRIVATE
+                -fsanitize=address
+                -fsanitize=leak
+            )
+            target_link_options(${TEST_NAME} PRIVATE
+                -fsanitize=address
+                -fsanitize=leak
+            )
+        endif()
         target_link_libraries(${TEST_NAME} PRIVATE ${TEST_LIBS})
         add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
     endforeach()


### PR DESCRIPTION
## Problem

The test targets in `CMakeLists.txt` hardcode `-fsanitize=address` and
`-fsanitize=leak` on both `test_main_lib` and every individual test. That is the
right default for development and CI, but it makes the test suite unbuildable
wherever the sanitizer runtime is not usable:

* distribution builds that run the tests in a package build root without
  `libasan` installed
* cross builds and musl toolchains where the ASan runtime is missing
* hardened build environments where ASan conflicts with the flags the build
  system injects

Today the only way out is to leave `BUILD_TESTING=OFF` and not run the tests at
all, which is exactly what a packager would like to avoid.

## Change

Add a `TEST_SANITIZERS` option, **defaulting to `ON`** so nothing changes for
existing builds, and guard the sanitizer compile and link options with it:

```console
cmake -DBUILD_TESTING=ON -DTEST_SANITIZERS=OFF ..
```

`-fno-omit-frame-pointer` stays unconditional — it is useful for test backtraces
on its own and costs nothing.

## Testing

Fedora 44, gcc 15, both configurations built and the suite run:

```console
$ cmake -DBUILD_TESTING=ON -DTEST_SANITIZERS=ON  .. && make -j8   # builds
$ cmake -DBUILD_TESTING=ON -DTEST_SANITIZERS=OFF .. && make -j8   # builds
```

The option demonstrably reaches the binaries:

```console
$ ldd build-ON/test_adapter  | grep -c asan
1
$ ldd build-OFF/test_adapter | grep -c asan
0
```

`ctest` results are identical in both configurations (one pre-existing
`test_utils` / `test_mkdir_recursive` failure in my environment, present on
unmodified master too and unrelated to this change).
