### PR TITLE
fix(adapter): resize the adapter buffers when -b is parsed

### DIFF
--- a/src/adapter.cpp
+++ b/src/adapter.cpp
@@ -119,6 +119,29 @@ adapter *adapter_alloc() {
     return ad;
 }
 
+// Adapters allocated by an option that came before -b still carry the
+// previous buffer size.
+void adapter_resize_buffers() {
+    int i;
+    for (i = 0; i < MAX_ADAPTERS; i++) {
+        adapter *ad = a[i];
+        unsigned char *nb;
+        if (!ad || !ad->buf || ad->lbuf == opts.adapter_buffer)
+            continue;
+        nb = (unsigned char *)realloc(ad->buf, opts.adapter_buffer + 10);
+        if (!nb) {
+            LOG("could not resize the buffer of adapter %d from %d to %d "
+                "bytes",
+                i, ad->lbuf, opts.adapter_buffer);
+            continue;
+        }
+        LOG("adapter %d: buffer resized from %d to %d bytes", i, ad->lbuf,
+            opts.adapter_buffer);
+        ad->buf = nb;
+        ad->lbuf = opts.adapter_buffer;
+    }
+}
+
 void find_adapters() {
     static int init_find_adapter;
     if (init_find_adapter == 1)
@@ -212,8 +235,8 @@ void adapter_set_dvr(adapter *ad) {
         sockets_add(ad->dvr, NULL, ad->id, TYPE_DVR, (socket_action)read_dmx,
                     (socket_action)close_adapter_for_socket,
                     (socket_action)adapter_timeout);
-    memset(ad->buf, 0, opts.adapter_buffer + 1);
-    set_socket_buffer(ad->sock, (unsigned char *)ad->buf, opts.adapter_buffer);
+    memset(ad->buf, 0, ad->lbuf + 1);
+    set_socket_buffer(ad->sock, (unsigned char *)ad->buf, ad->lbuf);
     if (ad->adapter_timeout > 0)
         sockets_timeout(ad->sock, ad->adapter_timeout);
     if (opts.th_priority > 0)
@@ -286,7 +309,7 @@ int init_hw(int i) {
                        "buffer was not initialized",
                        ad->id);
     }
-    memset(ad->buf, 0, opts.adapter_buffer + 1);
+    memset(ad->buf, 0, ad->lbuf + 1);
     ad->tp.clear();
     mark_pids_deleted(i, PID_STREAM_ID_UNDEFINED, NULL);
     update_pids(i);

--- a/src/adapter.h
+++ b/src/adapter.h
@@ -169,6 +169,7 @@ int init_hw(int i);
 int init_all_hw();
 int getAdaptersCount();
 adapter *adapter_alloc();
+void adapter_resize_buffers();
 int close_adapter(int na);
 int get_free_adapter(transponder *tp);
 int set_adapter_for_stream(int sid, int aid);

--- a/src/minisatip.cpp
+++ b/src/minisatip.cpp
@@ -802,6 +802,7 @@ void set_options(int argc, char *argv[]) {
                 opts.adapter_buffer = MAX_UDP_PACKET_SIZE;
             if (opts.dvr_buffer == 0)
                 opts.dvr_buffer = DVR_BUFFER;
+            adapter_resize_buffers();
 
             break;
         }


### PR DESCRIPTION
Updated after @Jalle19's and @lars18th's review: the resize is now called from the
`-b` handler instead of from `main()`, and the three places that worked on
`ad->buf` through the global option use `ad->lbuf`.

## Problem

Options such as `--delsys`, `--diseqc`, `--lnb`, `--unicable` or `--slave`
allocate an adapter while the command line is still being parsed. That adapter
gets the buffer size that was current at that moment:

```c
ad->lbuf = opts.adapter_buffer;
ad->buf = malloc(ad->lbuf + 10);
```

A `-b` that comes *after* it only raises `opts.adapter_buffer`. The adapter keeps
the smaller allocation, while the code that works on it uses the global option:

```c
memset(ad->buf, 0, opts.adapter_buffer + 1);               // adapter_set_dvr()
set_socket_buffer(ad->sock, ad->buf, opts.adapter_buffer); //      "
memset(ad->buf, 0, opts.adapter_buffer + 1);               // init_hw()
```

The second one is worse than the memsets: `set_socket_buffer()` stores the length
in `ss->lbuf`, and the DVR read path uses that as its limit
(`pos_len = master->lbuf - master->rlen`), so the reads themselves write past the
allocation.

```
minisatip --delsys 0:dvbs2 -b 1000000:1000000
```

segfaults at startup, or under ASan reports a heap-buffer-overflow WRITE in
`init_hw()`.

## Fix

Resize the adapters that already exist in the `-b` handler; the ones allocated
after it get the size from `adapter_alloc()` as before.

With that in place `ad->lbuf` is the buffer length in every case, so the three
sites above now use it and there is one source of truth for the size of `ad->buf`.

## Testing

Fedora 44, gcc 16, ASan build, `ctest` 13/13.

| command line | result |
|---|---|
| `--delsys 0:dvbs2 -b 1000000:1000000` | `adapter 0: buffer resized from 376000 to 999972 bytes` |
| `--delsys 0:dvbs2 -b 10000:10000` | `adapter 0: buffer resized from 376000 to 9964 bytes` |
| `-b 1000000:1000000 --delsys 0:dvbs2` | no resize — allocated at the right size |
| `--delsys 0:dvbs2` | no resize |

Live: OSCam over dvbapi, Digital Devices DVB-S2, VDR over SAT>IP — unchanged.
