### PR TITLE
feat(pmt): add --clean-psi to strip CA descriptors from descrambled PMTs

### DIFF
--- a/src/adapter.h
+++ b/src/adapter.h
@@ -121,6 +121,8 @@ struct struct_adapter {
     int active_demux_pids;
     int is_t2mi;
     uint64_t tune_time;
+    // --clean-psi packets to substitute in this buffer
+    int clean_psi_packets = 0;
     pthread_t thread;
     char thread_name[5];
     char null_packets;

--- a/src/minisatip.cpp
+++ b/src/minisatip.cpp
@@ -139,6 +139,7 @@ int rtsp, http, si, si1, ssdp1;
 #define SATIPC_RECV_BUFFER_OPT (LONG_OPT_ONLY_START + 3)
 #define CLIENT_SEND_BUFFER_OPT (LONG_OPT_ONLY_START + 4)
 #define HW_DESCRAMBLER_OPT (LONG_OPT_ONLY_START + 5)
+#define CLEAN_PSI_OPT (LONG_OPT_ONLY_START + 6)
 
 static const struct option long_options[] = {
     {"adapters", required_argument, NULL, ADAPTERS_OPT},
@@ -149,6 +150,7 @@ static const struct option long_options[] = {
     {"bind-http", required_argument, NULL, BIND_HTTP_OPT},
     {"bind-dev", required_argument, NULL, BIND_DEV_OPT},
     {"cache-dir", required_argument, NULL, CACHE_DIR_OPT},
+    {"clean-psi", optional_argument, NULL, CLEAN_PSI_OPT},
     {"send-all-ecm", no_argument, NULL, SENDALLECM_OPT},
     {"client-send-buffer", required_argument, NULL, CLIENT_SEND_BUFFER_OPT},
     {"delsys", required_argument, NULL, DELSYS_OPT},
@@ -545,6 +547,10 @@ Help\n\
 \t* Provides more reliable decrypting for channels included in multiple providers\n\
 \n\
 * --hw-descrambler: Enable hardware descrambler (Enigma2 CA ioctl). Disabled by default\n\
+\n\
+* --clean-psi[=seconds]: Rebuild the PMT of descrambled services without their CA descriptors\n\
+\t* Clients then see a free to air service, once it really is in the clear\n\
+\t* The PMT is withheld up to [seconds] (default 3) until that is known, 0 never withholds it\n\
 \n"
 #ifndef DISABLE_DVBCA
         "\
@@ -635,6 +641,8 @@ void set_options(int argc, char *argv[]) {
     memset(opts.dvbapi_host, 0, sizeof(opts.dvbapi_host));
     opts.drop_encrypted = 1;
     opts.pids_all_no_dec = 0;
+    opts.clean_psi = 0;
+    opts.clean_psi_grace = CLEAN_PSI_GRACE;
     opts.rtsp_port = 554;
     opts.use_ipv4_only = 1;
     opts.document_root = "html";
@@ -1063,6 +1071,20 @@ void set_options(int argc, char *argv[]) {
         case DISABLE_PMT_SCAN:
             opts.pmt_scan = 1 - opts.pmt_scan;
             break;
+
+        case CLEAN_PSI_OPT: {
+            char *e = NULL;
+            long v = optarg ? strtol(optarg, &e, 10) : CLEAN_PSI_GRACE / 1000;
+            if (optarg && (e == optarg || *e || v < 0 || v > 3600)) {
+                LOG0("--clean-psi: '%s' is not 0..3600 seconds, option "
+                     "disabled",
+                     optarg);
+                break;
+            }
+            opts.clean_psi = 1;
+            opts.clean_psi_grace = (int)v * 1000;
+            break;
+        }
 
 #ifndef DISABLE_DVBCA
         case CA_PIN_OPT:

--- a/src/opts.h
+++ b/src/opts.h
@@ -43,6 +43,8 @@ typedef struct struct_opts {
     int dvbapi_offset;
     int drop_encrypted;
     int pids_all_no_dec;
+    int clean_psi;
+    int clean_psi_grace;
     int rtsp_port;
     uint8_t netcv_count;
     char *netcv_if;

--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -740,6 +740,9 @@ void update_cw(SPMT *pmt) {
             if (len && !test_decrypt_packet(cws[i], start, len)) {
                 LOGM("correct CW found (len %d): %s", len,
                      cw_to_string(cws[i], buf));
+                // The only proof that this service really is descrambled, and
+                // what --clean-psi waits for.
+                pmt->ever_decrypted = 1;
                 cw = cws[i];
                 break;
             }
@@ -1249,6 +1252,9 @@ int pmt_process_stream(adapter *ad) {
         if (p && (p->filter != -1)) {
             process_filters(ad, b, p);
         }
+        // before pmt_decrypt_stream() clears the flags of what we descramble
+        if (opts.clean_psi && p && p->pmt >= 0)
+            pmt_clean_count_clear(ad, b, p);
         if (opts.emulate_pids_all && pid == 0) {
             p = find_pid(ad->id, 8192);
             if (p)
@@ -1273,6 +1279,353 @@ int pmt_process_stream(adapter *ad) {
     adapter_commit(ad);
 
     return 0;
+}
+
+// --clean-psi. What a client is given is decided in two steps: once per buffer
+// for the adapter, in pmt_clean_prepare(), and once per client in
+// process_packets_for_stream(). The adapter buffer is shared, so a rewrite in
+// place would force the same PMT on every client of the transponder.
+
+// Nothing is known about this service yet, so the rewrite starts at the next
+// section start rather than in the middle of one.
+void pmt_clean_reset(SPMT *pmt) {
+    pmt->ever_decrypted = 0;
+    pmt->arrives_clear = 0;
+    pmt->clear_run = 0;
+    pmt->clean_off = -1;
+}
+
+// Append the descriptors in b[0..n) that are not CA descriptors. False if one
+// runs past n.
+static bool copy_no_ca(std::vector<uint8_t> &out, const uint8_t *b, int n) {
+    for (int i = 0; i < n; i += 2 + b[i + 1]) {
+        if (i + 2 > n || i + 2 + b[i + 1] > n)
+            return false;
+        if (b[i] != 0x09)
+            out.insert(out.end(), b + i, b + i + 2 + b[i + 1]);
+    }
+    return true;
+}
+
+// Keep the section as broadcast, minus its CA descriptors. Every stream and
+// every other descriptor stays as the broadcaster sent it, in its order; only
+// the lengths, the version and the CRC change. pmt->clean stays empty for a
+// service without CA descriptors, and for anything but a single current
+// section, which is then passed on as it is.
+void pmt_clean_build(SPMT *pmt, uint8_t *b, int len) {
+    std::vector<uint8_t> &out = pmt->clean;
+    int slen, pi_len, es_len, i, at, n;
+    uint8_t crc[4];
+
+    out.clear();
+    if (len < 16)
+        return;
+    slen = 3 + (((b[1] & 0x0F) << 8) | b[2]);
+    pi_len = ((b[10] & 0x0F) << 8) | b[11];
+    if (slen > len || slen < 16 || !(b[5] & 0x01) || b[6] || b[7] ||
+        12 + pi_len > slen - 4)
+        return;
+    memcpy(pmt->clean_hdr, b, sizeof(pmt->clean_hdr));
+
+    out.assign(b, b + 12);
+    if (!copy_no_ca(out, b + 12, pi_len)) {
+        out.clear();
+        return;
+    }
+    n = out.size() - 12;
+    out[10] = (b[10] & 0xF0) | (n >> 8);
+    out[11] = n & 0xFF;
+
+    for (i = 12 + pi_len; i + 5 <= slen - 4; i += 5 + es_len) {
+        es_len = ((b[i + 3] & 0x0F) << 8) | b[i + 4];
+        at = out.size();
+        out.insert(out.end(), b + i, b + i + 5);
+        if (i + 5 + es_len > slen - 4 ||
+            !copy_no_ca(out, b + i + 5, es_len)) {
+            out.clear();
+            return;
+        }
+        n = out.size() - at - 5;
+        out[at + 3] = (b[i + 3] & 0xF0) | (n >> 8);
+        out[at + 4] = n & 0xFF;
+    }
+    // Bytes left over that are no stream, or no CA descriptor to drop
+    if (i != slen - 4 || (int)out.size() == slen - 4) {
+        out.clear();
+        return;
+    }
+
+    // The content differs from the broadcast, so the version has to as well
+    out[5] = (b[5] & 0xC1) | ((((b[5] >> 1) + 1) & 0x1F) << 1);
+    n = out.size() + 4 - 3;
+    out[1] = (b[1] & 0xF0) | (n >> 8);
+    out[2] = n & 0xFF;
+    copy32(crc, 0, crc_32(out.data(), out.size()));
+    out.insert(out.end(), crc, crc + 4);
+}
+
+// A service can reach us already descrambled and still carry the CA
+// descriptors of the broadcast: from another SAT>IP server or tuner that
+// descrambled without touching the PMT, from a CAM, or from a hardware
+// descrambler. No control word is validated here then, so the only evidence is
+// the stream itself.
+//
+// Only the stream carrying the PCR is read, which is the video of the service
+// and what a broadcaster scrambles if it scrambles anything. A service that
+// leaves its teletext in the clear - RTL does - would otherwise be read as
+// descrambled by a client that asked for that pid and nothing else.
+//
+// Transport scrambling covers the payload and not the adaptation field, so a
+// scrambled service still sends the odd PCR only packet in the clear. Only
+// packets that carry payload are counted, and one that arrives scrambled ends
+// the run. Our own descrambling is counted before pmt_decrypt_stream() clears
+// its flags, so a service we descramble can never be mistaken for one that
+// arrived in the clear.
+void pmt_clean_count_clear(adapter *ad, uint8_t *b, SPid *p) {
+    SPMT *pmt, *master;
+
+    if (!(b[3] & 0x10)) // no payload, clear whatever the service is
+        return;
+    if (!(pmt = get_pmt(p->pmt)))
+        return;
+    if (p->pid != pmt->pcr_pid)
+        return;
+    if ((master = get_pmt(pmt->master_pmt)))
+        pmt = master;
+    if (pmt->arrives_clear)
+        return;
+
+    if (b[3] & 0xC0) {
+        pmt->clear_run = 0;
+        return;
+    }
+    if (++pmt->clear_run < CLEAN_PSI_CLEAR_PACKETS)
+        return;
+    pmt->arrives_clear = 1;
+    LOG("adapter %d delivers pmt %d pid %d sid %d descrambled, the CA "
+        "descriptors of its PMT are stale",
+        ad->id, pmt->id, pmt->pid, pmt->sid);
+}
+
+// What a client gets on a PMT pid: the section as broadcast, nothing while the
+// service is still undecided, or the section without CA descriptors.
+enum clean_action { CLEAN_PASS = 0, CLEAN_HOLD, CLEAN_WRITE };
+
+typedef struct clean_pmt {
+    SPMT *pmt;
+    int pid;
+    enum clean_action action;
+} SCleanPMT;
+
+// A packet of the adapter buffer that is not handed on as it is. Built in
+// buffer order, so a client walks it with its own cursor instead of searching.
+typedef struct clean_packet {
+    int idx;      // packet number in ad->buf
+    uint8_t hold; // withhold it, rather than send pkt in its place
+    uint8_t pkt[DVB_FRAME];
+} SCleanPacket;
+
+static std::vector<SCleanPacket> clean_list[MAX_ADAPTERS];
+
+static SCleanPMT *clean_find(SCleanPMT *cp, int n, int pid) {
+    for (int i = 0; i < n; i++)
+        if (cp[i].pid == pid)
+            return cp + i;
+    return NULL;
+}
+
+// Offset of the payload, DVB_FRAME if the packet has none.
+static int ts_payload(uint8_t *b) {
+    int p = 4;
+    if (!(b[3] & 0x10))
+        return DVB_FRAME;
+    if (b[3] & 0x20)
+        p += 1 + b[4];
+    return p < DVB_FRAME ? p : DVB_FRAME;
+}
+
+// Does this packet begin a PMT section?
+static int starts_pmt(uint8_t *b) {
+    int p = ts_payload(b);
+    if (!(b[1] & 0x40) || p >= DVB_FRAME - 1)
+        return 0;
+    p += b[p] + 1; // pointer field
+    return p < DVB_FRAME && b[p] == 0x02;
+}
+
+// Gated on the service really being in the clear, or an unreachable card
+// server would announce an encrypted one as free to air: a control word that
+// decrypted here, or a stream that already arrives unscrambled.
+static enum clean_action pmt_clean_action(SPMT *pmt) {
+    SPMT *master = get_pmt(pmt->master_pmt);
+    if (!master)
+        master = pmt;
+    if (pmt->version < 0)
+        return CLEAN_HOLD; // not parsed yet
+    if (pmt->clean.empty())
+        return CLEAN_PASS; // free to air, or not a section we rewrite
+    if (pmt->state != PMT_CACHED &&
+        (master->ever_decrypted || master->arrives_clear))
+        return CLEAN_WRITE;
+    return CLEAN_HOLD;
+}
+
+// Reserve the entry for packet idx: a copy of b to patch, or a hold if b is
+// NULL. The caller fills it before the next call, so the vector cannot move.
+static uint8_t *clean_add(std::vector<SCleanPacket> &out, int idx, uint8_t *b) {
+    out.emplace_back();
+    SCleanPacket &s = out.back();
+    s.idx = idx;
+    s.hold = b ? 0 : 1;
+    if (b)
+        memcpy(s.pkt, b, DVB_FRAME);
+    return s.pkt;
+}
+
+// Decide what happens to the PMT pids in this buffer. Runs after the
+// descramblers and after process_filters(), so our own parser always sees the
+// original packets. probe asks to look for PMT pids of services that have not
+// been classified yet, which only a client still inside its window can use.
+void pmt_clean_prepare(adapter *ad, int probe) {
+    std::vector<SCleanPacket> &out = clean_list[ad->id];
+    SCleanPMT cp[MAX_PMT_FOR_ADAPTER];
+    int i, n = 0;
+
+    out.clear();
+    ad->clean_psi_packets = 0;
+    if (!opts.clean_psi)
+        return;
+
+    for (i = 0; i < ad->active_pmts && n < MAX_PMT_FOR_ADAPTER; i++) {
+        SPMT *pmt = get_pmt(ad->active_pmt[i]);
+        SCleanPMT *dup;
+        if (!pmt || !pmt->enabled || pmt->pid < 0 || pmt->pid >= 8192)
+            continue;
+        if ((dup = clean_find(cp, n, pmt->pid))) {
+            dup->action = CLEAN_PASS; // two services on one pid: leave it
+            continue;
+        }
+        cp[n].pmt = pmt;
+        cp[n].pid = pmt->pid;
+        cp[n].action = pmt_clean_action(pmt);
+        n++;
+    }
+    if (!n && !probe)
+        return;
+
+    for (i = 0; i < ad->rlen; i += DVB_FRAME) {
+        uint8_t *b = ad->buf + i, *sec, *dst;
+        enum clean_action action = CLEAN_PASS;
+        int pid, pay, room, left, olen, slen, last = 0;
+        SCleanPMT *c;
+        SPMT *pmt;
+
+        if (b[0] != 0x47)
+            continue;
+        pid = PID_FROM_TS(b);
+        if ((c = clean_find(cp, n, pid)))
+            action = c->action;
+        else if (probe && pid && starts_pmt(b))
+            action = CLEAN_HOLD; // a PMT of a service not classified yet
+
+        if (action == CLEAN_HOLD) {
+            clean_add(out, i / DVB_FRAME, NULL);
+            continue;
+        }
+        if (action != CLEAN_WRITE) {
+            // The section went out as broadcast, so the rewrite starts again
+            // at the next section start rather than in the middle of this one.
+            if (c && (b[1] & 0x40))
+                c->pmt->clean_off = -1;
+            continue;
+        }
+
+        pay = ts_payload(b);
+        if (pay >= DVB_FRAME)
+            continue;
+        room = DVB_FRAME - pay;
+        pmt = c->pmt;
+
+        if ((b[1] & 0x40) && b[pay] != 0) {
+            // A pointer field ends the section being written in the bytes
+            // before it and starts the next one behind them, which is not
+            // ours: finish here, and only inside those bytes. A section that
+            // was never begun is left to the clean_off check below.
+            if (b[pay] >= room) {
+                pmt->clean_off = -1;
+                continue;
+            }
+            room = b[pay];
+            pay++;
+            last = 1;
+        } else if (b[1] & 0x40) {
+            // Only the section pmt->clean was built from is replaced: same
+            // table, length, service, version and section number. Anything
+            // else on the pid is passed on untouched.
+            sec = b + pay + 1;
+            if (room < 1 + (int)sizeof(pmt->clean_hdr) ||
+                memcmp(sec, pmt->clean_hdr, sizeof(pmt->clean_hdr))) {
+                LOGM("%s: pid %d carries a section this does not cover, "
+                     "passing it on",
+                     __FUNCTION__, pid);
+                pmt->clean_off = -1;
+                continue;
+            }
+            // A shorter rewrite would free bytes that already hold the start
+            // of the next section, and stuffing over it would lose it.
+            olen = 3 + (((sec[1] & 0x0F) << 8) | sec[2]);
+            if (sec + olen < b + DVB_FRAME && sec[olen] != 0xFF) {
+                LOGM("%s: pid %d packs table %02X behind the PMT, passing it "
+                     "on",
+                     __FUNCTION__, pid, sec[olen]);
+                pmt->clean_off = -1;
+                continue;
+            }
+            pay++; // the pointer field stays 0
+            room--;
+            pmt->clean_off = 0;
+        }
+        if (pmt->clean_off < 0)
+            continue; // a continuation of a section that was passed on
+
+        // The rewrite is never longer than the original, so it fits into the
+        // packets the original occupied and every TS header, the continuity
+        // counter included, reaches the client as broadcast.
+        slen = pmt->clean.size();
+        dst = clean_add(out, i / DVB_FRAME, b);
+        if (pmt->clean_off > slen)
+            pmt->clean_off = slen;
+        left = slen - pmt->clean_off;
+        if (left > room)
+            left = room;
+        if (left > 0) {
+            memcpy(dst + pay, pmt->clean.data() + pmt->clean_off, left);
+            pmt->clean_off = (int16_t)(pmt->clean_off + left);
+        }
+        if (left < room) // stuffing, as the original carried past its section
+            memset(dst + pay + left, 0xFF, room - left);
+        if (last)
+            pmt->clean_off = -1;
+    }
+    ad->clean_psi_packets = out.size();
+}
+
+// What this client gets for the packet at idx: the rebuilt section, the
+// original, or NULL to withhold it while the service is undecided and the
+// client is still inside its window. idx grows with the caller's loop, so pos
+// walks the list instead of searching it.
+uint8_t *pmt_clean_packet(adapter *ad, int idx, uint8_t *b, int in_grace,
+                          int *pos) {
+    std::vector<SCleanPacket> &l = clean_list[ad->id];
+    int n = l.size();
+
+    while (*pos < n && l[*pos].idx < idx)
+        (*pos)++;
+    if (*pos >= n || l[*pos].idx != idx)
+        return b;
+    if (!l[*pos].hold)
+        return l[*pos].pkt;
+    return in_grace ? NULL : b;
 }
 
 int pmt_add(int adapter, int sid, int pmt_pid) {
@@ -1302,6 +1655,7 @@ int pmt_add(int adapter, int sid, int pmt_pid) {
     pmt->enabled = 1;
     pmt->version = -1;
     pmt->state = PMT_STOPPED;
+    pmt_clean_reset(pmt);
     pmt->cw = NULL;
     pmt->opaque = NULL;
     pmt->ca_mask = pmt->disabled_ca_mask = 0;
@@ -1310,6 +1664,7 @@ int pmt_add(int adapter, int sid, int pmt_pid) {
     memset(pmt->provider, 0, sizeof(pmt->provider));
     pmt->caids = 0;
     pmt->descriptors.clear();
+    pmt->clean.clear();
 
     if (i >= npmts)
         npmts = i + 1;
@@ -1970,6 +2325,9 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
                          pmt->ca[i]->private_data_len);
     }
 
+    if (opts.clean_psi)
+        pmt_clean_build(pmt, b, len);
+
     if (!pmt->state)
         set_filter_flags(filter, 0);
 
@@ -2029,6 +2387,7 @@ void start_pmt(SPMT *pmt, adapter *ad) {
          pmt->id, pmt->master_pmt, pmt->pid, pmt->sid, pmt->filter, pmt->name);
     pmt->state = PMT_STARTING;
     pmt->start_time = getTick();
+    pmt_clean_reset(pmt);
 
     // do not call send_pmt_to_cas to allow all the slave PMTs to be read
     // when the master PMT is being sent next time, it will actually making

--- a/src/pmt.h
+++ b/src/pmt.h
@@ -155,6 +155,13 @@ typedef struct struct_pmt {
     int filter;
     int64_t start_time;
     std::unordered_map<uint64_t, int> *global_start, *local_start;
+    // --clean-psi
+    uint8_t ever_decrypted;     // a validated CW decrypted this service (master)
+    uint8_t arrives_clear;      // the source hands it over descrambled (master)
+    uint16_t clear_run;         // unscrambled PCR stream packets in a row
+    int16_t clean_off;          // bytes of the rewrite emitted, -1 = not writing
+    uint8_t clean_hdr[8];       // header of the section that clean replaces
+    std::vector<uint8_t> clean; // that section without its CA descriptors
 } SPMT;
 
 // filters can be setup for specific pids and masks
@@ -237,6 +244,18 @@ int test_decrypt_packet(SCW *cw, SPMT_batch *start, int len);
 void init_algo();
 void update_cw(SPMT *pmt);
 int pmt_decrypt_stream(adapter *ad);
+#define CLEAN_PSI_GRACE 3000 // ms a client may wait for the PMT
+// Unscrambled payload packets of the PCR stream in a row that make a service
+// count as one the source descrambles. A scrambled service sends that stream
+// scrambled, so a run this long is only reached once it arrives in the clear.
+#define CLEAN_PSI_CLEAR_PACKETS 100
+
+void pmt_clean_build(SPMT *pmt, uint8_t *b, int len);
+void pmt_clean_prepare(adapter *ad, int probe);
+uint8_t *pmt_clean_packet(adapter *ad, int idx, uint8_t *b, int in_grace,
+                          int *pos);
+void pmt_clean_reset(SPMT *pmt);
+void pmt_clean_count_clear(adapter *ad, uint8_t *b, SPid *p);
 int wait_pusi(adapter *ad, int len);
 int pmt_add_ca_descriptor(SPMT *pmt, uint8_t *buf, int sca_id);
 void free_filters();

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -301,6 +301,11 @@ int start_play(streams *sid, sockets *s) {
     if (pids_empty_or_zero)
         s->flush_enqued_data = 1;
     sid->do_play = 1;
+    // --clean-psi: this client asked for a different set of pids, so a PMT it
+    // has not been given a verdict on yet must be held back again. Zero arms
+    // the window at the first buffer the client is served: it has to cover the
+    // ECM round trip, and a cold tune alone would outlast it.
+    sid->clean_since = 0;
     if (s->type != TYPE_HTTP)
         sid->start_streaming = 0;
 
@@ -593,6 +598,7 @@ int streams_add() {
     /* coverity[DC.WEAK_CRYPTO] */
     ss->ssrc = random();
     ss->timeout = opts.timeout_sec;
+    ss->clean_since = 0;
     ss->wtime = ss->rtcp_wtime = getTick();
 
     return i;
@@ -975,6 +981,23 @@ void check_cc2(adapter *ad) {
     }
 }
 
+// --clean-psi: is any client of this adapter still waiting for a verdict on
+// the service it asked for? Only then is it worth looking for PMT pids that no
+// SPMT covers yet. A stream that has not been served a buffer counts, its
+// window is armed by the first one. Read without the stream locks, which would
+// invert the socket -> stream -> adapter order: the answer only decides how
+// hard this one buffer is looked at.
+static int clean_grace_open(adapter *ad) {
+    if (!opts.clean_psi)
+        return 0;
+    for (int i = 0; i < MAX_STREAMS; i++)
+        if (st[i] && st[i]->enabled && st[i]->adapter == ad->id &&
+            (!st[i]->clean_since ||
+             ad->rtime - st[i]->clean_since < opts.clean_psi_grace))
+            return 1;
+    return 0;
+}
+
 // Locks the used structs in order to avoid race conditions (sockets ->
 // stream
 // -> adapter) Requires the adapter lock to not be held before calling
@@ -1042,6 +1065,15 @@ int process_packets_for_stream(streams *sid, adapter *ad) {
         max_pack = 0;
     }
 
+    // --clean-psi: pmt_clean_prepare() decided what the PMT pids carry, this
+    // client decides whether it is still willing to wait for one.
+    int clean_n = ad->clean_psi_packets, clean_pos = 0, in_grace = 0;
+    if (opts.clean_psi) {
+        if (!sid->clean_since)
+            sid->clean_since = rtime;
+        in_grace = rtime - sid->clean_since < opts.clean_psi_grace;
+    }
+
     for (i = 0; i < ad->rlen; i += DVB_FRAME) {
         int rtp_added = 0;
         b = ad->buf + i;
@@ -1051,6 +1083,9 @@ int process_packets_for_stream(streams *sid, adapter *ad) {
         }
         int _pid = PID_FROM_TS(b);
         if (!pids[_pid] && !pids[8192])
+            continue;
+        if (clean_n &&
+            !(b = pmt_clean_packet(ad, i / DVB_FRAME, b, in_grace, &clean_pos)))
             continue;
 
         if (total_len && max_pack && (total_len / DVB_FRAME % max_pack == 0)) {
@@ -1134,6 +1169,8 @@ int process_dmx(sockets *s) {
 
 #ifndef DISABLE_TABLES
     pmt_process_stream(ad);
+    // After the descramblers, so this buffer already counts as decrypted
+    pmt_clean_prepare(ad, clean_grace_open(ad));
 #endif
 
     check_cc2(ad);

--- a/src/stream.h
+++ b/src/stream.h
@@ -42,7 +42,8 @@ typedef struct struct_streams {
     uint16_t seq; // rtp seq id
     int ssrc;     // rtp seq id
     int64_t wtime;
-    int64_t rtime; // stream timeout
+    int64_t rtime;       // stream timeout
+    int64_t clean_since; // --clean-psi window start, 0 = arm at the next buffer
     int64_t rtcp_wtime;
     int64_t last_init_hw;
     int do_play;

--- a/tests/test_pmt.cpp
+++ b/tests/test_pmt.cpp
@@ -23,6 +23,7 @@
 #include "socketworks.h"
 #include "utils.h"
 #include "utils/testing.h"
+#include "utils/ticks.h"
 #include <arpa/inet.h>
 #include <ctype.h>
 #include <errno.h>
@@ -335,10 +336,568 @@ int test_emulate_add_all_pids() {
     return 0;
 }
 
+// A broadcast PMT: CA descriptors on the program level and on the audio
+// stream when ca is set, a private descriptor, a video, an audio and a teletext
+// stream with their descriptors.
+static int build_broadcast_pmt(uint8_t *s, int sid, int version, int cni,
+                               int ca) {
+    static const uint8_t pca[] = {0x09, 0x04, 0x09, 0x8C, 0xE0, 0xCC};
+    static const uint8_t priv[] = {0x5F, 0x04, 0x00, 0x00, 0x00, 0x2A};
+    static const uint8_t aca[] = {0x09, 0x04, 0x09, 0x8D, 0xE0, 0xCD};
+    static const uint8_t lang[] = {0x0A, 0x04, 'd', 'e', 'u', 0x00};
+    static const uint8_t ttx[] = {0x56, 0x05, 'd',  'e', 'u',
+                                  0x10, 0x00, 0x52, 0x01, 0x03};
+    uint8_t *b = s, *l;
+    auto put = [&](const uint8_t *d, int n) {
+        memcpy(b, d, n);
+        b += n;
+    };
+    auto stream = [&](int type, int pid) {
+        *b++ = type;
+        copy16(b, 0, 0xE000 | pid);
+        b += 2;
+        l = b;
+        b += 2;
+    };
+    auto close = [&]() { copy16(l, 0, 0xF000 | (b - l - 2)); };
+
+    *b++ = 0x02;
+    b += 2; // section_length
+    copy16(b, 0, sid);
+    b += 2;
+    *b++ = 0xC0 | ((version & 0x1F) << 1) | (cni ? 1 : 0);
+    *b++ = 0; // section number
+    *b++ = 0; // last section number
+    copy16(b, 0, 0xE000 | 1279);
+    b += 2;
+    l = b;
+    b += 2;
+    if (ca)
+        put(pca, sizeof(pca));
+    put(priv, sizeof(priv));
+    close();
+    stream(27, 1279);
+    close();
+    stream(3, 1283);
+    if (ca)
+        put(aca, sizeof(aca));
+    put(lang, sizeof(lang));
+    close();
+    stream(6, 34);
+    put(ttx, sizeof(ttx));
+    close();
+
+    copy16(s, 1, 0xB000 | ((b - s) + 4 - 3));
+    copy32(b, 0, crc_32(s, b - s));
+    return (b - s) + 4;
+}
+
+// The rewrite is the broadcast section minus its CA descriptors: every stream
+// and every other descriptor stays, byte for byte and in its order.
+int test_clean_pmt() {
+    SPMT pmt = {};
+    uint8_t want[256], *sec;
+    int slen, wlen;
+
+    // Sized exactly, so that a read past the section is caught
+    slen = build_broadcast_pmt(want, 0x0083, 5, 1, 1);
+    sec = (uint8_t *)malloc(slen);
+
+    build_broadcast_pmt(sec, 0x0083, 5, 1, 1);
+    wlen = build_broadcast_pmt(want, 0x0083, 6, 1, 0);
+    pmt_clean_build(&pmt, sec, slen);
+    ASSERT((int)pmt.clean.size() == wlen &&
+               !memcmp(pmt.clean.data(), want, wlen),
+           "the rewrite is not the broadcast without its CA descriptors");
+    ASSERT(!memcmp(pmt.clean_hdr, sec, sizeof(pmt.clean_hdr)),
+           "the header of the broadcast section was not kept");
+
+    // The version is five bits wide and wraps
+    build_broadcast_pmt(sec, 0x0083, 31, 1, 1);
+    wlen = build_broadcast_pmt(want, 0x0083, 0, 1, 0);
+    pmt_clean_build(&pmt, sec, slen);
+    ASSERT((int)pmt.clean.size() == wlen &&
+               !memcmp(pmt.clean.data(), want, wlen),
+           "the version did not wrap");
+
+    // Nothing to strip, or a section that is not on the wire yet
+    pmt_clean_build(&pmt, sec, build_broadcast_pmt(sec, 0x0083, 5, 1, 0));
+    ASSERT(pmt.clean.empty(), "a free to air PMT was rewritten");
+    build_broadcast_pmt(sec, 0x0083, 5, 0, 1);
+    pmt_clean_build(&pmt, sec, slen);
+    ASSERT(pmt.clean.empty(), "a section that is not current was rewritten");
+
+    // A descriptor that runs past its loop leaves nothing half built
+    build_broadcast_pmt(sec, 0x0083, 5, 1, 1);
+    sec[13] = 0xFF;
+    pmt_clean_build(&pmt, sec, slen);
+    ASSERT(pmt.clean.empty(), "a broken descriptor loop was rewritten");
+
+    free(sec);
+    return 0;
+}
+
+// Wrap a section into one TS packet. pusi 0 makes it a continuation packet,
+// adaptation shrinks the payload to that many bytes.
+static void build_ts(uint8_t *p, int pid, int pusi, const uint8_t *payload,
+                     int len, int payload_room) {
+    int pay = 4;
+    memset(p, 0xFF, DVB_FRAME);
+    p[0] = 0x47;
+    p[1] = (pusi ? 0x40 : 0) | ((pid >> 8) & 0x1F);
+    p[2] = pid & 0xFF;
+    p[3] = 0x10;
+    if (payload_room > 0 && payload_room < DVB_FRAME - 4) {
+        int af = DVB_FRAME - 4 - payload_room - 1;
+        p[3] |= 0x20;
+        p[4] = af;
+        if (af > 0) {
+            p[5] = 0;
+            memset(p + 6, 0xFF, af - 1);
+        }
+        pay = 5 + af;
+    }
+    if (pusi)
+        p[pay++] = 0; // pointer field
+    if (len > DVB_FRAME - pay)
+        len = DVB_FRAME - pay;
+    if (len > 0)
+        memcpy(p + pay, payload, len);
+}
+
+// The real reset, plus the proof of descrambling that puts the PMT into
+// CLEAN_WRITE. Anything the rewriter then leaves alone, it leaves alone on
+// purpose.
+static void arm_clean(SPMT *pmt) {
+    pmt_clean_reset(pmt);
+    pmt->ever_decrypted = 1;
+}
+
+// Set up an adapter whose buffer holds exactly npkt packets, so that a read or
+// a write past the buffer is caught.
+static adapter *clean_adapter(int npkt) {
+    adapter *ad = adapter_alloc();
+    free(ad->buf);
+    ad->buf = (uint8_t *)malloc(npkt * DVB_FRAME);
+    ad->rlen = npkt * DVB_FRAME;
+    a[0] = ad;
+    ad->id = 0;
+    ad->enabled = 1;
+    return ad;
+}
+
+// The service under test, descrambled, with CA descriptors on the program
+// level and on the audio stream.
+static void clean_pmt_setup(SPMT *pmt, adapter *ad) {
+    uint8_t sec[256];
+    pmts[0] = pmt;
+    npmts = 1; // get_pmt() refuses anything at or above this
+    pmt->id = 0;
+    pmt->enabled = 1;
+    pmt->adapter = 0;
+    pmt->master_pmt = 0;
+    pmt->sid = 0x0083;
+    pmt->pid = 100;
+    pmt->pcr_pid = 1279;
+    pmt->version = 5;
+    pmt->state = PMT_RUNNING;
+    pmt->ever_decrypted = 1;
+    pmt_clean_build(pmt, sec, build_broadcast_pmt(sec, 0x0083, 5, 1, 1));
+    ad->active_pmts = 1;
+    ad->active_pmt[0] = 0;
+    mark_pid_add(0, ad->id, 100);
+    update_pids(ad->id);
+}
+
+static void clean_teardown(adapter *ad) {
+    ad->active_pmts = 0;
+    pmts[0] = NULL;
+    pmts[1] = NULL;
+    npmts = 0;
+    free(ad->buf);
+    delete ad;
+    a[0] = NULL;
+}
+
+// What a client is handed for packet idx of the buffer. pos is the client's
+// cursor, so a caller that walks the whole buffer keeps it across the calls.
+static uint8_t *clean_get(adapter *ad, int idx, int in_grace, int *pos) {
+    return pmt_clean_packet(ad, idx, ad->buf + idx * DVB_FRAME, in_grace, pos);
+}
+
+// The single packet in the buffer, as a client with an open window sees it.
+static uint8_t *clean_one(adapter *ad) {
+    int pos = 0;
+    pmt_clean_prepare(ad, 1);
+    return clean_get(ad, 0, 1, &pos);
+}
+
+// pmt_clean_prepare() decides per packet; these are the shapes it must not
+// touch. Whatever it decides, the adapter buffer stays as it was read: it is
+// shared with every other client and with the CA layer.
+int test_clean_psi_packets() {
+    adapter *ad = clean_adapter(1);
+    SPMT pmt = {}, other = {};
+    uint8_t sec[512], before[DVB_FRAME], *out;
+    int slen, saved_clean = opts.clean_psi;
+    int saved_grace = opts.clean_psi_grace;
+
+    clean_pmt_setup(&pmt, ad);
+    opts.clean_psi = 1;
+    opts.clean_psi_grace = CLEAN_PSI_GRACE;
+
+    slen = build_broadcast_pmt(sec, pmt.sid, pmt.version, 1, 1);
+
+    // 1. A continuation packet arriving first must be passed on: clean_off
+    //    starts at -1, so nothing may be written into the middle of a section
+    arm_clean(&pmt);
+    build_ts(ad->buf, 100, 0, sec, slen, 0);
+    ASSERT(clean_one(ad) == ad->buf, "a continuation packet was rewritten");
+
+    // 2. The real thing is rewritten, and the CA descriptors are gone
+    arm_clean(&pmt);
+    build_ts(ad->buf, 100, 1, sec, slen, 0);
+    memcpy(before, ad->buf, DVB_FRAME);
+    out = clean_one(ad);
+    ASSERT(out && out != ad->buf, "the PMT of a descrambled service was kept");
+    ASSERT(!memcmp(before, ad->buf, DVB_FRAME),
+           "the rewrite changed the adapter buffer");
+    ASSERT(!memcmp(before, out, 4), "the rewrite changed the TS header");
+    // payload at 4, pointer field 0, so the section starts at 5 and its
+    // version byte is the sixth byte of the section
+    ASSERT(out[4] == 0 && out[5] == 0x02,
+           "the rewritten packet lost its pointer field or table id");
+    ASSERT(((out[8] << 8) | out[9]) == pmt.sid,
+           "the rewritten section changed the service id");
+    ASSERT(((out[10] & 0x3E) >> 1) == ((pmt.version + 1) & 0x1F),
+           "the rewritten section kept the broadcast version");
+    ASSERT(!memcmp(out + 5, pmt.clean.data(), pmt.clean.size()),
+           "the packet does not carry the section without CA descriptors");
+    for (int i = 5 + pmt.clean.size(); i < DVB_FRAME; i++)
+        ASSERT(out[i] == 0xFF, "the freed bytes were not stuffed");
+
+    // 3. Another service on the pid must not be replaced with ours
+    arm_clean(&pmt);
+    slen = build_broadcast_pmt(sec, 0x0084, pmt.version, 1, 1);
+    build_ts(ad->buf, 100, 1, sec, slen, 0);
+    ASSERT(clean_one(ad) == ad->buf, "a foreign service id was rewritten");
+
+    // 4. A version that was never parsed, and a not-yet-current section
+    arm_clean(&pmt);
+    slen = build_broadcast_pmt(sec, pmt.sid, pmt.version + 1, 1, 1);
+    build_ts(ad->buf, 100, 1, sec, slen, 0);
+    ASSERT(clean_one(ad) == ad->buf, "an unparsed version was rewritten");
+
+    arm_clean(&pmt);
+    slen = build_broadcast_pmt(sec, pmt.sid, pmt.version, 0, 1);
+    build_ts(ad->buf, 100, 1, sec, slen, 0);
+    ASSERT(clean_one(ad) == ad->buf,
+           "a current_next_indicator of 0 was made current");
+
+    // 5. A second section packed behind ours would be stuffed over
+    arm_clean(&pmt);
+    slen = build_broadcast_pmt(sec, pmt.sid, pmt.version, 1, 1);
+    sec[slen] = 0x02; // a further table starts right here
+    sec[slen + 1] = 0xB0;
+    build_ts(ad->buf, 100, 1, sec, slen + 2, 0);
+    ASSERT(clean_one(ad) == ad->buf,
+           "a section packed behind the PMT was overwritten");
+
+    // 6. A payload too short to hold a PMT header: the diagnostics must not
+    //    read past the end of the packet
+    arm_clean(&pmt);
+    build_ts(ad->buf, 100, 1, sec, 4, 6);
+    ASSERT(clean_one(ad) == ad->buf, "a truncated PSI header was rewritten");
+
+    // 7. Two services on one PMT pid: neither is ours to replace
+    arm_clean(&pmt);
+    slen = build_broadcast_pmt(sec, pmt.sid, pmt.version, 1, 1);
+    build_ts(ad->buf, 100, 1, sec, slen, 0);
+    other = pmt;
+    other.id = 1;
+    other.sid = 0x0084;
+    pmts[1] = &other;
+    npmts = 2;
+    ad->active_pmts = 2;
+    ad->active_pmt[1] = 1;
+    ASSERT(clean_one(ad) == ad->buf,
+           "a pid carrying two services was rewritten");
+    ad->active_pmts = 1;
+    pmts[1] = NULL;
+    npmts = 1;
+
+    // 8. With the option off there is nothing to hand a client
+    arm_clean(&pmt);
+    opts.clean_psi = 0;
+    build_ts(ad->buf, 100, 1, sec, slen, 0);
+    ASSERT(clean_one(ad) == ad->buf && ad->clean_psi_packets == 0,
+           "--clean-psi is off but a packet was replaced");
+
+    opts.clean_psi = saved_clean;
+    opts.clean_psi_grace = saved_grace;
+    clean_teardown(ad);
+    return 0;
+}
+
+// A PMT that does not end on a packet boundary: the packet it ends in carries
+// a pointer field and the start of the next section behind it.
+int test_clean_psi_spanning_section() {
+    adapter *ad = clean_adapter(3);
+    SPMT pmt = {};
+    uint8_t sec[512], before[3 * DVB_FRAME], asmb[512], *first, *last;
+    int i, slen, head, tail, olen, pos = 0;
+    int saved_clean = opts.clean_psi, saved_grace = opts.clean_psi_grace;
+    uint32_t crc;
+
+    clean_pmt_setup(&pmt, ad);
+    opts.clean_psi = 1;
+    opts.clean_psi_grace = CLEAN_PSI_GRACE;
+    arm_clean(&pmt);
+
+    // 20 payload bytes in the first packet: the pointer field and 19 of the
+    // section, so the rest of it ends inside the second one
+    slen = build_broadcast_pmt(sec, pmt.sid, pmt.version, 1, 1);
+    head = 19;
+    tail = slen - head;
+    ASSERT(tail > 0 && tail < DVB_FRAME - 6,
+           "the test section does not end inside the second packet");
+    build_ts(ad->buf, 100, 1, sec, slen, head + 1);
+    last = ad->buf + DVB_FRAME;
+    build_ts(last, 100, 1, sec + head, tail, 0);
+    last[4] = (uint8_t)tail; // pointer field: the rest of the PMT comes first
+    last[5 + tail] = 0x42;   // and a table of whoever sent it behind that
+    last[6 + tail] = 0xF0;
+    // that table continues in the packet after it, which is none of ours
+    build_ts(ad->buf + 2 * DVB_FRAME, 100, 0, sec, slen, 0);
+    memcpy(before, ad->buf, sizeof(before));
+
+    pmt_clean_prepare(ad, 0);
+    first = clean_get(ad, 0, 1, &pos);
+    ASSERT(first && first != ad->buf, "the start of the PMT was not rewritten");
+    last = clean_get(ad, 1, 1, &pos);
+    ASSERT(last && last != ad->buf + DVB_FRAME,
+           "the end of the PMT reached the client as broadcast");
+    ASSERT(clean_get(ad, 2, 1, &pos) == ad->buf + 2 * DVB_FRAME,
+           "the section behind the PMT was written into");
+
+    // The TS header, the pointer field and the table behind it are the
+    // sender's; only the bytes the PMT occupied are ours
+    ASSERT(!memcmp(last, before + DVB_FRAME, 5),
+           "the TS header or the pointer field of the last packet changed");
+    ASSERT(!memcmp(last + 5 + tail, before + DVB_FRAME + 5 + tail,
+                   DVB_FRAME - 5 - tail),
+           "the section behind the pointer field was overwritten");
+
+    // What the client reassembles has to be one PMT, not half of two
+    ASSERT(first[DVB_FRAME - head - 1] == 0,
+           "the rewrite did not start at a zero pointer field");
+    memcpy(asmb, first + DVB_FRAME - head, head);
+    memcpy(asmb + head, last + 5, tail);
+    olen = 3 + (((asmb[1] & 0x0F) << 8) | asmb[2]);
+    ASSERT(asmb[0] == 0x02 && olen >= 4 && olen <= head + tail,
+           "the reassembled section is not a PMT");
+    crc = ((uint32_t)asmb[olen - 4] << 24) | (asmb[olen - 3] << 16) |
+          (asmb[olen - 2] << 8) | asmb[olen - 1];
+    ASSERT(crc_32(asmb, olen - 4) == crc,
+           "the reassembled section fails its CRC");
+    for (i = 12; i < olen - 4; i++)
+        ASSERT(!(asmb[i] == 0x09 && asmb[i + 1] == 0x04),
+               "a CA descriptor survived the rewrite");
+    ASSERT(!memcmp(before, ad->buf, sizeof(before)),
+           "the adapter buffer was modified");
+
+    // A pointer field that runs past the payload is not one to write into
+    arm_clean(&pmt);
+    ad->buf[DVB_FRAME + 4] = DVB_FRAME;
+    pmt_clean_prepare(ad, 0);
+    pos = 0;
+    ASSERT(clean_get(ad, 1, 1, &pos) == ad->buf + DVB_FRAME,
+           "a pointer field past the payload was written into");
+    ad->buf[DVB_FRAME + 4] = (uint8_t)tail;
+
+    // And neither is one that arrives with no section of ours in progress
+    arm_clean(&pmt);
+    ad->buf[1] = 0; // the first packet is now a pid nobody asked about
+    ad->buf[2] = 200;
+    pmt_clean_prepare(ad, 0);
+    pos = 0;
+    ASSERT(clean_get(ad, 1, 1, &pos) == ad->buf + DVB_FRAME,
+           "a pointer field was followed with no section to finish");
+
+    opts.clean_psi = saved_clean;
+    opts.clean_psi_grace = saved_grace;
+    clean_teardown(ad);
+    return 0;
+}
+
+// The verdict is the adapter's, the waiting is the client's: two clients read
+// the same buffer and only the one still inside its window holds the pid back.
+int test_clean_psi_streams() {
+    adapter *ad = clean_adapter(3);
+    SPMT pmt = {};
+    uint8_t sec[512], before[3 * DVB_FRAME], *out;
+    int slen, pos, saved_clean = opts.clean_psi;
+    int saved_grace = opts.clean_psi_grace;
+
+    clean_pmt_setup(&pmt, ad);
+    opts.clean_psi = 1;
+    opts.clean_psi_grace = CLEAN_PSI_GRACE;
+    slen = build_broadcast_pmt(sec, pmt.sid, pmt.version, 1, 1);
+
+    // The PMT of the descrambled service, a video packet, and the PMT of a
+    // service nothing is known about yet
+    build_ts(ad->buf, 100, 1, sec, slen, 0);
+    build_ts(ad->buf + DVB_FRAME, 1279, 0, sec, 0, 0);
+    build_ts(ad->buf + 2 * DVB_FRAME, 200, 1, sec, slen, 0);
+    memcpy(before, ad->buf, sizeof(before));
+
+    // 1. A client inside its window: the rewrite, the video untouched, and
+    //    nothing at all for the service that has no verdict
+    arm_clean(&pmt);
+    pmt_clean_prepare(ad, 1);
+    pos = 0;
+    out = clean_get(ad, 0, 1, &pos);
+    ASSERT(out && out != ad->buf, "the descrambled PMT was not rewritten");
+    ASSERT(clean_get(ad, 1, 1, &pos) == ad->buf + DVB_FRAME,
+           "a video packet was replaced");
+    ASSERT(clean_get(ad, 2, 1, &pos) == NULL,
+           "an unclassified PMT was handed to a waiting client");
+
+    // 2. A client past its window sees the same rewrite, but is no longer
+    //    willing to wait for the service that has no verdict
+    pos = 0;
+    ASSERT(clean_get(ad, 0, 0, &pos) == out,
+           "the rewrite depends on the client");
+    ASSERT(clean_get(ad, 2, 0, &pos) == ad->buf + 2 * DVB_FRAME,
+           "an unclassified PMT was withheld after the window closed");
+
+    // 3. Without a client waiting, an unknown PMT pid is not looked at
+    arm_clean(&pmt);
+    pmt_clean_prepare(ad, 0);
+    pos = 0;
+    ASSERT(clean_get(ad, 2, 1, &pos) == ad->buf + 2 * DVB_FRAME,
+           "an unknown PMT pid was held with no client waiting");
+
+    // 4. An encrypted service that nothing has decrypted is held, never
+    //    announced as free to air
+    pmt_clean_reset(&pmt); // no ever_decrypted this time
+    pmt_clean_prepare(ad, 0);
+    pos = 0;
+    ASSERT(clean_get(ad, 0, 1, &pos) == NULL,
+           "an undecrypted service was passed on to a waiting client");
+    pos = 0;
+    ASSERT(clean_get(ad, 0, 0, &pos) == ad->buf,
+           "an undecrypted service was still held after the window closed");
+
+    ASSERT(!memcmp(before, ad->buf, sizeof(before)),
+           "the adapter buffer was modified");
+
+    opts.clean_psi = saved_clean;
+    opts.clean_psi_grace = saved_grace;
+    clean_teardown(ad);
+    return 0;
+}
+
+// A service can reach us already descrambled, from an upstream SAT>IP server
+// or a CAM, and still carry the CA descriptors of the broadcast. No control
+// word is validated here then, so the rewrite is gated on the stream itself
+// arriving unscrambled.
+int test_clean_psi_arrives_clear() {
+    adapter *ad = clean_adapter(2);
+    SPMT pmt = {};
+    uint8_t sec[512], *v;
+    int slen, pos, i, saved_clean = opts.clean_psi;
+    int saved_grace = opts.clean_psi_grace;
+    SPid *p;
+
+    clean_pmt_setup(&pmt, ad);
+    opts.clean_psi = 1;
+    opts.clean_psi_grace = CLEAN_PSI_GRACE;
+    slen = build_broadcast_pmt(sec, pmt.sid, pmt.version, 1, 1);
+    build_ts(ad->buf, 100, 1, sec, slen, 0);
+    v = ad->buf + DVB_FRAME;
+    build_ts(v, 1279, 0, sec, 0, 0);
+
+    mark_pid_add(0, ad->id, 1279);
+    update_pids(ad->id);
+    p = find_pid(ad->id, 1279);
+    ASSERT(p != NULL, "no pid entry for the video stream");
+    p->pmt = pmt.id;
+
+    // 1. Nothing has decrypted this service and nothing has been seen of it:
+    //    the pid is withheld, not announced free to air
+    pmt_clean_reset(&pmt);
+    pmt_clean_prepare(ad, 0);
+    pos = 0;
+    ASSERT(clean_get(ad, 0, 1, &pos) == NULL,
+           "a service with no verdict was handed to a waiting client");
+
+    // 2. A packet without payload is clear in a scrambled service too
+    v[3] = 0x20;
+    for (i = 0; i < 2 * CLEAN_PSI_CLEAR_PACKETS; i++)
+        pmt_clean_count_clear(ad, v, p);
+    ASSERT(!pmt.arrives_clear,
+           "packets without payload were counted as a clear stream");
+
+    // 3. Nor does a stream that is not the one carrying the PCR: a service
+    //    may broadcast its teletext in the clear and scramble the rest
+    mark_pid_add(0, ad->id, 1283);
+    update_pids(ad->id);
+    SPid *tt = find_pid(ad->id, 1283);
+    ASSERT(tt != NULL, "no pid entry for the teletext stream");
+    tt->pmt = pmt.id;
+    v[3] = 0x10;
+    for (i = 0; i < 2 * CLEAN_PSI_CLEAR_PACKETS; i++)
+        pmt_clean_count_clear(ad, v, tt);
+    ASSERT(!pmt.arrives_clear,
+           "a clear stream that is not the PCR one decided the service");
+    mark_pid_deleted(ad->id, 0, 1283, NULL);
+    update_pids(ad->id);
+
+    // 4. One scrambled payload packet ends the run
+    v[3] = 0x10;
+    for (i = 0; i < CLEAN_PSI_CLEAR_PACKETS - 1; i++)
+        pmt_clean_count_clear(ad, v, p);
+    v[3] = 0x90;
+    pmt_clean_count_clear(ad, v, p);
+    ASSERT(pmt.clear_run == 0, "a scrambled packet did not end the run");
+    v[3] = 0x10;
+    for (i = 0; i < CLEAN_PSI_CLEAR_PACKETS - 1; i++)
+        pmt_clean_count_clear(ad, v, p);
+    ASSERT(!pmt.arrives_clear, "the run was not counted from the start again");
+
+    // 5. The packet that completes the run decides it, and the PMT is rebuilt
+    //    without a control word ever having been validated
+    pmt_clean_count_clear(ad, v, p);
+    ASSERT(pmt.arrives_clear, "a stream that arrives in the clear was missed");
+    ASSERT(!pmt.ever_decrypted, "nothing decrypted this service here");
+    pmt_clean_prepare(ad, 0);
+    pos = 0;
+    ASSERT(clean_get(ad, 0, 1, &pos) != NULL &&
+               clean_get(ad, 0, 1, &pos) != ad->buf,
+           "the PMT of a service that arrives in the clear was not rewritten");
+
+    opts.clean_psi = saved_clean;
+    opts.clean_psi_grace = saved_grace;
+    mark_pid_deleted(ad->id, 0, 1279, NULL);
+    update_pids(ad->id);
+    clean_teardown(ad);
+    return 0;
+}
+
 int main() {
     opts.log = 255;
     opts.debug = 255;
     strcpy(thread_info[thread_index].thread_name, "test_pmt");
+    TEST_FUNC(test_clean_psi_packets(),
+              "testing which packets pmt_clean_prepare rewrites");
+    TEST_FUNC(test_clean_psi_streams(),
+              "testing the PMT each client is handed");
+    TEST_FUNC(test_clean_psi_arrives_clear(),
+              "testing a service that arrives already descrambled");
+    TEST_FUNC(test_clean_psi_spanning_section(),
+              "testing a PMT that ends inside a packet with a pointer field");
+    TEST_FUNC(test_clean_pmt(), "testing PMT rewrite without CA descriptors");
     TEST_FUNC(test_descriptor_equality(),
               "testing descriptor equality operator");
     TEST_FUNC(test_descriptor_caid_capid_getters(),


### PR DESCRIPTION
A service minisatip descrambles reaches the client in the clear, but its PMT
still carries the CA descriptors of the broadcast, so a client that decides from
the PMT keeps treating it as encrypted. VDR refuses such a channel on a SAT>IP
device and drops a running recording when the CA descriptors change:

```
ZDF HD (FTA)         -> 250 2 ZDF HD
RTL HD (descrambled) -> 554 Error switching to channel "3"
```

`--clean-psi` hands the client the broadcast PMT section minus its CA
descriptors. Every stream and every other descriptor stays as sent; only the
lengths, the version and the CRC change. It is built once per PMT version from
the section `process_pmt()` already has, so the parser is not touched and this
no longer depends on #1428.

The rewrite waits until the service is known to be in the clear: a control word
that passed `test_decrypt_packet()`, or the PCR stream arriving unscrambled
because another SAT>IP server, a CAM or a hardware descrambler already did the
work. Until then the PMT pid is withheld for up to `--clean-psi=seconds` (3 by
default, 0 never), so a client never sees two PMTs for one service. The adapter
buffer itself is left alone; the replacement packets are picked per client.
Off by default.

Tested live on RTL HD (Nagra, 11 CAIDs, 7 streams), with a second minisatip as a
SAT>IP client of the first:

| | PMT the client gets |
|---|---|
| upstream descrambles, downstream `--clean-psi` | v1, 111 bytes, no CAIDs |
| tuner + OSCam, `--clean-psi` | v1, 111 bytes, no CAIDs |
| no card server | v0, 655 bytes, 11 CAIDs |
| upstream can't descramble, downstream relays | v0, 655 bytes, 11 CAIDs |

In both rewritten cases the section is byte for byte the broadcast one without
its CA descriptors, checked with a separate script. `ctest` 13/13 with and
without sanitizers, plus a minimal build.
