### PR TITLE
fix(pmt): clear the program level descriptors on a PMT version change

### DIFF
--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -1903,6 +1903,7 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
     pi = b + 12;
     pmt_b = b + 3;
 
+    pmt->descriptors.clear();
     pmt->stream_pids.clear();
 
     // Add PMT level desciptors from program info


### PR DESCRIPTION
`process_pmt()` clears `stream_pids` when a new version arrives but not
`descriptors`, so the program level descriptors of the previous version stay in
the parsed PMT. Anything that reads them back afterwards - `ddci_create_pmt()`,
or `--clean-psi` in #1425 - then sees a table that was never broadcast.

Earlier revisions of this PR also bounds checked the two descriptor loops,
`is_ac3_es()` and the section lengths, and refused a CA descriptor too short to
hold a CAID. @Jalle19 pointed out that the PMT filter is registered with
`FILTER_CRC` and that `assemble_packet()` verifies the CRC before
`process_pmt()` is ever called, and that a CA descriptor of abnormal length is
not something that occurs, the field being standardized. Both are dropped, so
what is left is the one line above.
