### PR TITLE
fix(pmt): parse every elementary stream the same way

### DIFF
--- a/src/ca.cpp
+++ b/src/ca.cpp
@@ -764,15 +764,32 @@ void disable_cws_for_all_pmts(ca_device_t *d) {
 
 int CAPMT_add_PMT(uint8_t *capmt, int len, SPMT *pmt, int cmd_id,
                   int added_only, int ca_id) {
-    int pos = 0;
+    // Every stream is given the same CA descriptors, so they are built once
+    uint8_t ca_desc[MAX_CAID * (6 + 256)];
+    int pos = 0, ca_len = 0;
+
+    if (pmt->caids)
+        ca_len = pmt_add_ca_descriptor(pmt, ca_desc, ca_id);
+
     for (const auto &stream_pid : pmt->stream_pids) {
         if (added_only && !find_pid(pmt->adapter, stream_pid.pid)) {
             LOGM("%s: skipping pmt %d (ad %d) pid %d from CAPMT", __FUNCTION__,
                  pmt->id, pmt->adapter, stream_pid.pid);
             continue;
         }
-        if (!stream_pid.is_audio && !stream_pid.is_video)
-            continue;
+        if (!stream_pid.type)
+            continue; // a PCR pid of its own, not an elementary stream
+
+        // stream_type, pid and ES_info_length, then the cmd_id and the
+        // descriptors. A CAPMT that does not fit is truncated here rather
+        // than written past the buffer it was given.
+        int need = 5 + (pmt->caids ? 1 + ca_len : 0);
+        if (pos + need > len)
+            LOG_AND_RETURN(pos,
+                           "%s: pmt %d (ad %d) does not fit the CAPMT, %d "
+                           "bytes left of %d",
+                           __FUNCTION__, pmt->id, pmt->adapter, len - pos, len);
+
         capmt[pos++] = stream_pid.type;
         copy16(capmt, pos, stream_pid.pid);
         pos += 2;
@@ -783,7 +800,8 @@ int CAPMT_add_PMT(uint8_t *capmt, int len, SPMT *pmt, int cmd_id,
         // append the stream descriptors
         if (pmt->caids) {
             capmt[pos++] = cmd_id;
-            pi_len = pmt_add_ca_descriptor(pmt, capmt + pos, ca_id);
+            memcpy(capmt + pos, ca_desc, ca_len);
+            pi_len = ca_len;
             pos += pi_len;
             copy16(capmt, pi_len_pos, pi_len + 1);
         }

--- a/src/ddci.cpp
+++ b/src/ddci.cpp
@@ -756,18 +756,30 @@ int ddci_create_pmt(ddci_device_t *d, SPMT *pmt, uint8_t *new_pmt, int pmt_size,
 
         // ES info length
         int es_info_len = 0;
-        for (const auto &d : stream_pid.descriptors) {
-            es_info_len += d.len + 2;
+        for (const auto &desc : stream_pid.descriptors) {
+            es_info_len += desc.len + 2;
         }
         copy16(b, 0, es_info_len);
         b += 2;
 
         // Descriptors
-        for (const auto &d : stream_pid.descriptors) {
-            *b++ = d.type;
-            *b++ = d.len;
-            memcpy(b, d.data.data(), d.len);
-            b += d.len;
+        for (const auto &desc : stream_pid.descriptors) {
+            *b++ = desc.type;
+            *b++ = desc.len;
+            memcpy(b, desc.data.data(), desc.len);
+            // The ECM pid of a CA descriptor on a stream is a pid of this
+            // adapter like the program level ones and is mapped the same way,
+            // or the CAM is pointed at a pid that does not reach it
+            if (desc.is_ca_descriptor() && desc.len >= 4) {
+                int capid = safe_get_pid_mapping(
+                    d, pmt->adapter, desc.get_ca_descriptor_capid());
+                b[2] = (b[2] & 0xE0) | ((capid >> 8) & 0x1F);
+                b[3] = capid & 0xFF;
+                LOGM("%s: pmt %d stream %d caid %04X mapped ECM pid %04X",
+                     __FUNCTION__, pmt->id, stream_pid.pid,
+                     desc.get_ca_descriptor_caid(), capid);
+            }
+            b += desc.len;
         }
 
         LOGM("%s: pmt %d added pid %04X, type %02X, es_len %d", __FUNCTION__,

--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -1023,9 +1023,10 @@ void start_active_pmts(adapter *ad) {
         int first = 0;
         int pmt_started = 0;
         for (const auto &stream_pid : pmt->stream_pids) {
-            // for all audio and video streams start the PMT containing them
-            if ((stream_pid.is_audio || stream_pid.is_video) &&
-                pids[stream_pid.pid] && pmt->id == pmt->master_pmt) {
+            // a requested stream of this service starts the PMT that carries
+            // it; the entry of a PCR pid of its own is not one
+            if (stream_pid.type && pids[stream_pid.pid] &&
+                pmt->id == pmt->master_pmt) {
                 is_active = 1;
 #ifndef DISABLE_TABLES
                 if (!first) {
@@ -1834,8 +1835,7 @@ int get_master_pmt_for_pid(adapter *ad, int pid) {
                    ad->id, pmt->id, pmt->stream_pids.size());
             for (const auto &stream_pid : pmt->stream_pids) {
                 DEBUGM("comparing with pid %d", stream_pid.pid);
-                if (stream_pid.pid == pid &&
-                    (stream_pid.is_video || stream_pid.is_audio)) {
+                if (stream_pid.pid == pid && stream_pid.type) {
                     LOGM("%s: ad %d found pid %d in master pmt %d",
                          __FUNCTION__, ad->id, pid, pmt->master_pmt);
                     return pmt->master_pmt;
@@ -1847,10 +1847,8 @@ int get_master_pmt_for_pid(adapter *ad, int pid) {
     return -1;
 }
 
-int pmt_add_stream_pid(SPMT *pmt, int pid, int type, bool is_audio,
-                       bool is_video) {
-    pmt->stream_pids.push_back(
-        {.type = type, .pid = pid, .is_audio = is_audio, .is_video = is_video});
+int pmt_add_stream_pid(SPMT *pmt, int pid, int type) {
+    pmt->stream_pids.push_back({.type = type, .pid = pid});
 
     return pmt->stream_pids.size() - 1;
 }
@@ -1959,12 +1957,7 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
         if (pcr_pid == spid)
             pcr_pid = 0;
 
-        bool is_video =
-            (stype == 2) || (stype == 27) || (stype == 36) || (stype == 15);
-        bool is_audio = isAC3 || (stype == 3) || (stype == 4) || (stype == 17);
-
-        int stream_pid_id =
-            pmt_add_stream_pid(pmt, spid, stype, is_audio, is_video);
+        int stream_pid_id = pmt_add_stream_pid(pmt, spid, stype);
         int opmt = get_master_pmt_for_pid(ad, spid);
 
         LOG("PMT pid %d - stream pid %04X (%d), type %d%s, es_len %d, pos "
@@ -1973,10 +1966,7 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
             pid, spid, spid, stype, isAC3 ? " [AC3]" : "", es_len, i,
             pmt->caids);
 
-        if (!is_audio && !is_video)
-            continue;
-
-        // Add stream-level descriptors from elementary stream info
+        // Every stream, so that the parsed PMT describes what was broadcast
         if (stream_pid_id >= 0)
             pmt_add_stream_pid_descriptors(pmt, pmt->stream_pids[stream_pid_id],
                                            pmt_b + i + 5, es_len);
@@ -1988,7 +1978,7 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
     }
     // Add the PCR pid if it's independent
     if (pcr_pid > 0 && pcr_pid < 8191)
-        pmt_add_stream_pid(pmt, pcr_pid, 0, false, false);
+        pmt_add_stream_pid(pmt, pcr_pid, 0);
 
     SPMT *master = get_pmt(pmt->master_pmt);
     if (pmt->caids && master && master != pmt) {

--- a/src/pmt.cpp
+++ b/src/pmt.cpp
@@ -1698,8 +1698,11 @@ int pmt_caid_exist(SPMT *pmt, uint16_t caid, uint16_t capid) {
 
 int is_ac3_es(unsigned char *es, int len) {
     int i, es_len, isAC3 = 0;
-    for (i = 0; i < len; i += es_len) {
+    for (i = 0; i + 1 < len; i += es_len) {
         es_len = es[i + 1] + 2;
+        // A descriptor whose body is not there is not one to classify from
+        if (es_len > len - i)
+            break;
         if (es[i] == 0x6A || es[i] == 0x7A)
             isAC3 = 1;
     }
@@ -1756,6 +1759,11 @@ void pmt_add_descriptors(SPMT *pmt, unsigned char *pi, int len) {
     int pi_len;
 
     for (int i = 0; i < len; i += pi_len + 2) {
+        // A length that runs past the section would read foreign memory
+        if (len - i < 2 || pi[i + 1] > len - i - 2) {
+            LOG("PMT %d has a truncated program descriptor at %d", pmt->id, i);
+            return;
+        }
         pi_len = pi[i + 1];
 
         // Store all descriptors (skipping already existing)
@@ -1770,8 +1778,10 @@ void pmt_add_descriptors(SPMT *pmt, unsigned char *pi, int len) {
 
         pmt->descriptors.push_back(d);
 
-        // Handle CA descriptors separately
-        if (d.is_ca_descriptor()) {
+        // Handle CA descriptors separately. Below four bytes there is no
+        // CAID and no CA pid to read, and the private data length would be
+        // negative.
+        if (d.is_ca_descriptor() && pi_len >= 4) {
             int caid = pi[i + 2] * 256 + pi[i + 3];
             int capid = (pi[i + 4] & 0x1F) * 256 + pi[i + 5];
             pmt_add_caid(pmt, caid, capid, pi + i + 6, pi_len - 4);
@@ -1784,6 +1794,12 @@ void pmt_add_stream_pid_descriptors(SPMT *pmt, SStreamPid &sp,
     int es_len;
 
     for (int i = 0; i < len; i += es_len + 2) {
+        // A length that runs past the section would read foreign memory
+        if (len - i < 2 || es[i + 1] > len - i - 2) {
+            LOG("PMT %d pid %d has a truncated ES descriptor at %d", pmt->id,
+                sp.pid, i);
+            return;
+        }
         es_len = es[i + 1];
 
         descriptor_t d = create_descriptor(es + i);
@@ -1797,8 +1813,10 @@ void pmt_add_stream_pid_descriptors(SPMT *pmt, SStreamPid &sp,
 
         sp.descriptors.push_back(d);
 
-        // Handle CA descriptors separately
-        if (d.is_ca_descriptor()) {
+        // Handle CA descriptors separately. Below four bytes there is no
+        // CAID and no CA pid to read, and the private data length would be
+        // negative.
+        if (d.is_ca_descriptor() && es_len >= 4) {
             int caid = es[i + 2] * 256 + es[i + 3];
             int capid = (es[i + 4] & 0x1F) * 256 + es[i + 5];
             pmt_add_caid(pmt, caid, capid, es + i + 6, es_len - 4);
@@ -1846,7 +1864,9 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
     adapter *ad = NULL;
     SPMT *pmt = (SPMT *)opaque;
 
-    if (b[0] != 2)
+    // Twelve bytes of header and four of CRC: below that the fields read here
+    // are not in the section at all
+    if (b[0] != 2 || len < 16)
         return 0;
 
     f = get_filter(filter);
@@ -1854,6 +1874,16 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
         LOG_AND_RETURN(0, "%s: filter %d not found", __FUNCTION__, filter);
 
     pid = f->pid;
+    pmt_len = ((b[1] & 0xF) << 8) + b[2];
+    pi_len = ((b[10] & 0xF) << 8) + b[11];
+    // Before anything is changed, because stop_pmt() below cannot be undone.
+    // The program info ends where the first stream begins, and the streams end
+    // before the CRC.
+    if (pi_len > pmt_len - 13)
+        LOG_AND_RETURN(0,
+                       "PMT pid %d: a program info length of %d does not fit "
+                       "a section of %d",
+                       pid, pi_len, pmt_len);
     ver = (b[5] & 0x3e) >> 1;
     sid = b[3] * 256 + b[4];
 
@@ -1884,8 +1914,6 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
     if (!(p = find_pid(ad->id, pid)))
         return -1;
 
-    pmt_len = ((b[1] & 0xF) << 8) + b[2];
-    pi_len = ((b[10] & 0xF) << 8) + b[11];
     pcr_pid = ((b[8] & 0x1F) << 8) + b[9];
 
     pmt->sid = sid;
@@ -1907,13 +1935,20 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
     pmt->stream_pids.clear();
 
     // Add PMT level desciptors from program info
-    if (pi_len > 0 && pi_len < pmt_len)
+    if (pi_len > 0)
         pmt_add_descriptors(pmt, pi, pi_len);
 
     es_len = 0;
-    for (i = 9 + pi_len; i < pmt_len - 4; i += (es_len) + 5) // reading streams
+    for (i = 9 + pi_len; i + 5 <= pmt_len - 4;
+         i += (es_len) + 5) // reading streams
     {
         es_len = (pmt_b[i + 3] & 0xF) * 256 + pmt_b[i + 4];
+        // Before es_len is used to read the descriptors or to record a stream
+        if (es_len > pmt_len - 4 - i - 5) {
+            LOGM("pmt processing complete, es_len + i %d, len %d, es_len %d",
+                 es_len + i, pmt_len, es_len);
+            break;
+        }
         stype = pmt_b[i];
         spid = (pmt_b[i + 1] & 0x1F) * 256 + pmt_b[i + 2];
         isAC3 = 0;
@@ -1937,12 +1972,6 @@ int process_pmt(int filter, unsigned char *b, int len, void *opaque) {
             "caids %d",
             pid, spid, spid, stype, isAC3 ? " [AC3]" : "", es_len, i,
             pmt->caids);
-
-        if ((es_len + i + 5 > pmt_len) || (es_len < 0)) {
-            LOGM("pmt processing complete, es_len + i %d, len %d, es_len %d",
-                 es_len + i, pmt_len, es_len);
-            break;
-        }
 
         if (!is_audio && !is_video)
             continue;

--- a/src/pmt.h
+++ b/src/pmt.h
@@ -114,10 +114,10 @@ typedef struct descriptor {
 } descriptor_t;
 
 typedef struct struct_stream_pid {
+    // The stream_type as broadcast. Zero is not one: it marks the entry that
+    // carries a PCR pid of its own, which is not an elementary stream.
     int type;
     int pid;
-    bool is_audio;
-    bool is_video;
     std::vector<descriptor_t> descriptors;
 } SStreamPid;
 
@@ -241,8 +241,7 @@ int wait_pusi(adapter *ad, int len);
 int pmt_add_ca_descriptor(SPMT *pmt, uint8_t *buf, int sca_id);
 void free_filters();
 void stop_pmt(SPMT *pmt, adapter *ad);
-int pmt_add_stream_pid(SPMT *pmt, int pid, int type, bool is_audio,
-                       bool is_video);
+int pmt_add_stream_pid(SPMT *pmt, int pid, int type);
 void emulate_add_all_pids(adapter *ad);
 void pmt_add_caid(SPMT *pmt, uint16_t caid, uint16_t capid, uint8_t *data,
                   int len);

--- a/tests/test_ca.cpp
+++ b/tests/test_ca.cpp
@@ -82,8 +82,8 @@ int test_multiple_pmt() {
 int test_create_capmt_single_clear() {
     int pmt_id = pmt_add(0, 0x100, 0x101);
     SPMT *pmt = get_pmt(pmt_id);
-    pmt_add_stream_pid(pmt, 0x501, 2, false, true);
-    pmt_add_stream_pid(pmt, 0x502, 3, true, false);
+    pmt_add_stream_pid(pmt, 0x501, 2);
+    pmt_add_stream_pid(pmt, 0x502, 3);
 
     SCAPMT scampt = {.pmt_id = pmt->id,
                      .other_id = PMT_INVALID,
@@ -116,8 +116,8 @@ int test_create_capmt_single_pmt_scrambled() {
     int pmt_id = pmt_add(0, 0x100, 0x101);
     SPMT *pmt = get_pmt(pmt_id);
     pmt_add_caid(pmt, 0x0B00, 0x573, nullptr, 0);
-    pmt_add_stream_pid(pmt, 0x501, 2, false, true);
-    pmt_add_stream_pid(pmt, 0x502, 3, true, false);
+    pmt_add_stream_pid(pmt, 0x501, 2);
+    pmt_add_stream_pid(pmt, 0x502, 3);
 
     SCAPMT scampt = {.pmt_id = pmt->id,
                      .other_id = PMT_INVALID,
@@ -148,14 +148,14 @@ int test_create_capmt_multiple_pmt_scrambled() {
     int pmt_id = pmt_add(0, 0x100, 0x101);
     SPMT *pmt = get_pmt(pmt_id);
     pmt_add_caid(pmt, 0x0B00, 0x573, nullptr, 0);
-    pmt_add_stream_pid(pmt, 0x501, 2, false, true);
-    pmt_add_stream_pid(pmt, 0x502, 3, true, false);
+    pmt_add_stream_pid(pmt, 0x501, 2);
+    pmt_add_stream_pid(pmt, 0x502, 3);
 
     pmt_id = pmt_add(0, 0x200, 0x201);
     SPMT *other = get_pmt(pmt_id);
     pmt_add_caid(other, 0x0B01, 0xABC, nullptr, 0);
-    pmt_add_stream_pid(other, 0x601, 2, false, true);
-    pmt_add_stream_pid(other, 0x602, 3, true, false);
+    pmt_add_stream_pid(other, 0x601, 2);
+    pmt_add_stream_pid(other, 0x602, 3);
 
     SCAPMT scampt = {
         .pmt_id = pmt->id, .other_id = other->id, .version = 1, .sid = 0x1234};
@@ -190,7 +190,7 @@ int test_create_capmt_multiple_pmt_scrambled() {
 int test_create_capmt_different_listmgmt() {
     int pmt_id = pmt_add(0, 0x100, 0x101);
     SPMT *pmt = get_pmt(pmt_id);
-    pmt_add_stream_pid(pmt, 0x501, 2, false, true);
+    pmt_add_stream_pid(pmt, 0x501, 2);
 
     SCAPMT scampt = {.pmt_id = pmt->id,
                      .other_id = PMT_INVALID,
@@ -237,7 +237,7 @@ int test_create_capmt_different_cmd_ids() {
     int pmt_id = pmt_add(0, 0x100, 0x101);
     SPMT *pmt = get_pmt(pmt_id);
     pmt_add_caid(pmt, 0x0B00, 0x573, nullptr, 0);
-    pmt_add_stream_pid(pmt, 0x501, 2, false, true);
+    pmt_add_stream_pid(pmt, 0x501, 2);
 
     SCAPMT scampt = {.pmt_id = pmt->id,
                      .other_id = PMT_INVALID,
@@ -288,7 +288,7 @@ int test_create_capmt_invalid_pmt() {
 int test_create_capmt_max_version() {
     int pmt_id = pmt_add(0, 0x100, 0x101);
     SPMT *pmt = get_pmt(pmt_id);
-    pmt_add_stream_pid(pmt, 0x501, 2, false, true);
+    pmt_add_stream_pid(pmt, 0x501, 2);
 
     SCAPMT scampt = {.pmt_id = pmt->id,
                      .other_id = PMT_INVALID,
@@ -309,7 +309,7 @@ int test_create_capmt_max_version() {
 int test_create_capmt_large_sid() {
     int pmt_id = pmt_add(0, 0x100, 0x101);
     SPMT *pmt = get_pmt(pmt_id);
-    pmt_add_stream_pid(pmt, 0x501, 2, false, true);
+    pmt_add_stream_pid(pmt, 0x501, 2);
 
     SCAPMT scampt = {.pmt_id = pmt->id,
                      .other_id = PMT_INVALID,
@@ -334,16 +334,16 @@ int test_create_capmt_both_pmt_and_other_with_caids() {
     for (int i = 0; i < 8; i++) {
         pmt_add_caid(pmt, 0x0B00 + i, 0x570 + i, nullptr, 0);
     }
-    pmt_add_stream_pid(pmt, 0x501, 2, false, true);
-    pmt_add_stream_pid(pmt, 0x502, 3, true, false);
+    pmt_add_stream_pid(pmt, 0x501, 2);
+    pmt_add_stream_pid(pmt, 0x502, 3);
 
     int other_pmt_id = pmt_add(0, 0x200, 0x201);
     SPMT *other = get_pmt(other_pmt_id);
     for (int i = 0; i < 8; i++) {
         pmt_add_caid(other, 0x0C00 + i, 0x670 + i, nullptr, 0);
     }
-    pmt_add_stream_pid(other, 0x601, 2, false, true);
-    pmt_add_stream_pid(other, 0x602, 3, true, false);
+    pmt_add_stream_pid(other, 0x601, 2);
+    pmt_add_stream_pid(other, 0x602, 3);
 
     SCAPMT scampt = {
         .pmt_id = pmt->id, .other_id = other->id, .version = 1, .sid = 0x1234};
@@ -374,8 +374,7 @@ int test_create_capmt_both_pmt_and_other_many_streams() {
         pmt_add_caid(pmt, 0x0B00 + i, 0x570 + i, nullptr, 0);
     }
     for (int i = 0; i < 8; i++) {
-        pmt_add_stream_pid(pmt, 0x500 + i, (i % 2 == 0) ? 2 : 3, (i % 2 == 1),
-                           (i % 2 == 0));
+        pmt_add_stream_pid(pmt, 0x500 + i, (i % 2 == 0) ? 2 : 3);
     }
 
     int other_pmt_id = pmt_add(0, 0x200, 0x201);
@@ -384,8 +383,7 @@ int test_create_capmt_both_pmt_and_other_many_streams() {
         pmt_add_caid(other, 0x0C00 + i, 0x670 + i, nullptr, 0);
     }
     for (int i = 0; i < 8; i++) {
-        pmt_add_stream_pid(other, 0x600 + i, (i % 2 == 0) ? 2 : 3, (i % 2 == 1),
-                           (i % 2 == 0));
+        pmt_add_stream_pid(other, 0x600 + i, (i % 2 == 0) ? 2 : 3);
     }
 
     SCAPMT scampt = {
@@ -415,8 +413,7 @@ int test_create_capmt_size_near_limit() {
     }
     // Add 11 streams to primary PMT
     for (int i = 0; i < 11; i++) {
-        pmt_add_stream_pid(pmt, 0x500 + i, (i % 2 == 0) ? 2 : 3, (i % 2 == 1),
-                           (i % 2 == 0));
+        pmt_add_stream_pid(pmt, 0x500 + i, (i % 2 == 0) ? 2 : 3);
     }
 
     int other_pmt_id = pmt_add(0, 0x200, 0x201);
@@ -427,8 +424,7 @@ int test_create_capmt_size_near_limit() {
     }
     // Add 11 streams to other PMT
     for (int i = 0; i < 11; i++) {
-        pmt_add_stream_pid(other, 0x600 + i, (i % 2 == 0) ? 2 : 3, (i % 2 == 1),
-                           (i % 2 == 0));
+        pmt_add_stream_pid(other, 0x600 + i, (i % 2 == 0) ? 2 : 3);
     }
 
     SCAPMT scampt = {
@@ -530,6 +526,34 @@ int test_set_ca_channels_parsing() {
     return 0;
 }
 
+// A CAPMT describes the service, not just its audio and video: a subtitle
+// stream belongs in it, the entry that only carries a PCR pid does not.
+int test_create_capmt_all_stream_types() {
+    int pmt_id = pmt_add(0, 0x100, 0x101);
+    SPMT *pmt = get_pmt(pmt_id);
+    pmt_add_stream_pid(pmt, 0x501, 2);  // video
+    pmt_add_stream_pid(pmt, 0x503, 6);  // subtitles
+    pmt_add_stream_pid(pmt, 0x504, 0);  // a PCR pid of its own
+
+    SCAPMT scampt = {.pmt_id = pmt->id,
+                     .other_id = PMT_INVALID,
+                     .version = 1,
+                     .sid = 0x1234};
+
+    uint8_t capmt[1500];
+    int len = create_capmt(&scampt, CLM_ONLY, capmt, sizeof(capmt),
+                           CMD_ID_OK_DESCRAMBLING, 0);
+
+    ASSERT(len > 0, "create_capmt failed");
+    hexdump("CAPMT: ", capmt, len);
+    // 6 bytes of header, then 5 per stream with no CAIDs to add
+    ASSERT(len == 6 + 2 * 5, "the CAPMT does not hold exactly two streams");
+    ASSERT(capmt[6] == 2, "the video stream is missing from the CAPMT");
+    ASSERT(capmt[11] == 6, "the subtitle stream is missing from the CAPMT");
+
+    return 0;
+}
+
 int main() {
     opts.log = 1;
     opts.debug = 255;
@@ -548,6 +572,8 @@ int main() {
     TEST_FUNC(test_multiple_pmt(), "testing CA multiple pmt");
     memset(d.capmt, -1, sizeof(d.capmt));
     TEST_FUNC(test_get_authdata_filename(), "testing filename helper function");
+    TEST_FUNC(test_create_capmt_all_stream_types(),
+              "testing the CAPMT carries every elementary stream");
     TEST_FUNC(test_create_capmt_single_clear(),
               "testing create_capmt with single PMT without CA descriptors");
     TEST_FUNC(test_create_capmt_single_pmt_scrambled(),

--- a/tests/test_ddci.cpp
+++ b/tests/test_ddci.cpp
@@ -496,6 +496,11 @@ int test_create_pmt() {
     int capid = 0x100;
     int dpid = add_pid_mapping_table(0, pid, 0, &d, 0);
     int dcapid = add_pid_mapping_table(0, capid, 0, &d, 0);
+    // The ECM pid of the CA descriptor that sits on the second stream. Another
+    // adapter holds 0x0573 on this DDCI already, so the mapping has to move it
+    // and a pid that was not mapped is visible as such.
+    add_pid_mapping_table(1, 0x0573, 0, &d, 0);
+    int descapid = add_pid_mapping_table(0, 0x0573, 0, &d, 0);
     f.flags = FILTER_CRC;
     f.id = 0;
     f.adapter = 0;
@@ -543,7 +548,10 @@ int test_create_pmt() {
     int ca_descriptor_caid = packet[41] * 256 + packet[42];
     int ca_descriptor_capid = (packet[43] & 0x1F) * 256 + packet[44];
     ASSERT_EQUAL(0x0B00, ca_descriptor_caid, "descriptor CA system mismatch");
-    ASSERT_EQUAL(0x0573, ca_descriptor_capid, "descriptor CA PID mismatch");
+    // A stream level ECM pid is mapped like a program level one, or it names
+    // a pid of the source adapter that the CAM never sees
+    ASSERT_EQUAL(descapid, ca_descriptor_capid,
+                 "descriptor CA PID was not mapped");
 
     SPMT *new_pmt = get_pmt(pmt_add(0, 200, 200));
     ad.id = 0;

--- a/tests/test_ddci.cpp
+++ b/tests/test_ddci.cpp
@@ -78,8 +78,8 @@ SPMT *create_pmt(int ad, int sid, int pid1, int pid2, int caid1, int caid2) {
     int pmt_id = pmt_add(ad, sid, 1000);
     SPMT *pmt = get_pmt(pmt_id);
     pmt->pid = pmt_id * 1000;
-    pmt_add_stream_pid(pmt, pid1, 2, false, true);
-    pmt_add_stream_pid(pmt, pid2, 6, true, false);
+    pmt_add_stream_pid(pmt, pid1, 2);
+    pmt_add_stream_pid(pmt, pid2, 6);
     pmt_add_caid(pmt, caid1, caid1, NULL, 0);
     pmt_add_caid(pmt, caid2, caid2, NULL, 0);
     // Add a CA descriptor to the second stream PID so we can test that it
@@ -199,7 +199,7 @@ int test_add_del_pmt() {
     c->locked = 1;
     c->ddci[c->ddcis++].ddci = 1;
 
-    pmt_add_stream_pid(pmt2, 0xFF, 2, false, true);
+    pmt_add_stream_pid(pmt2, 0xFF, 2);
     pmt_add_caid(pmt2, 0x502, 0xFE, NULL, 0);
 
     ASSERT(ddci_process_pmt(&ad, pmt2) == TABLES_RESULT_OK,

--- a/tests/test_hw_descrambler.cpp
+++ b/tests/test_hw_descrambler.cpp
@@ -88,7 +88,7 @@ static int test_hw_descrambler_disabled_when_opts_enigma_zero() {
     int pmt_id = pmt_add(0, 100, 1000);
     SPMT *pmt = get_pmt(pmt_id);
     ASSERT(pmt != nullptr, "pmt_add failed");
-    pmt_add_stream_pid(pmt, 1001, 2, false, true);
+    pmt_add_stream_pid(pmt, 1001, 2);
 
     SCW cw{};
     cw.id = 10;
@@ -120,19 +120,19 @@ static int test_multi_channel_slot_allocation() {
     // Add PMT 100 (HBO HD)
     int pmt_id1 = pmt_add(0, 100, 1000);
     SPMT *pmt1 = get_pmt(pmt_id1);
-    pmt_add_stream_pid(pmt1, 1001, 27, false, true); // Video PID
-    pmt_add_stream_pid(pmt1, 1002, 3, false, true);  // Audio PID
+    pmt_add_stream_pid(pmt1, 1001, 27); // Video PID
+    pmt_add_stream_pid(pmt1, 1002, 3);  // Audio PID
 
     // Add PMT 200 (FILM NOW HD)
     int pmt_id2 = pmt_add(0, 200, 2000);
     SPMT *pmt2 = get_pmt(pmt_id2);
-    pmt_add_stream_pid(pmt2, 2001, 27, false, true); // Video PID
-    pmt_add_stream_pid(pmt2, 2002, 4, false, true);  // Audio PID
+    pmt_add_stream_pid(pmt2, 2001, 27); // Video PID
+    pmt_add_stream_pid(pmt2, 2002, 4);  // Audio PID
 
     // Add PMT 300 (AXN White)
     int pmt_id3 = pmt_add(0, 300, 3000);
     SPMT *pmt3 = get_pmt(pmt_id3);
-    pmt_add_stream_pid(pmt3, 3001, 2, false, true);
+    pmt_add_stream_pid(pmt3, 3001, 2);
 
     // Create EVEN and ODD CWs for PMT 1
     SCW cw1_even{}, cw1_odd{};
@@ -174,7 +174,7 @@ static int test_multi_channel_slot_allocation() {
     // Re-allocate PMT 4 (Nickelodeon starts)
     int pmt_id4 = pmt_add(0, 400, 4000);
     SPMT *pmt4 = get_pmt(pmt_id4);
-    pmt_add_stream_pid(pmt4, 4001, 2, false, true);
+    pmt_add_stream_pid(pmt4, 4001, 2);
 
     SCW cw4{};
     cw4.id = 5;
@@ -213,8 +213,8 @@ static int test_aes128_key_programming() {
 
     int pmt_id = pmt_add(0, 680, 6800);
     SPMT *pmt = get_pmt(pmt_id);
-    pmt_add_stream_pid(pmt, 6801, 36, false, true); // 4K HEVC Video PID
-    pmt_add_stream_pid(pmt, 6802, 15, false, true); // AAC Audio PID
+    pmt_add_stream_pid(pmt, 6801, 36); // 4K HEVC Video PID
+    pmt_add_stream_pid(pmt, 6802, 15); // AAC Audio PID
 
     // 16-byte AES Key and IV
     uint8_t aes_key[16] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,

--- a/tests/test_pmt.cpp
+++ b/tests/test_pmt.cpp
@@ -80,6 +80,11 @@ uint8_t cw_invalid[] = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77};
 extern adapter *a[MAX_ADAPTERS];
 extern SCW *cws[MAX_CW];
 
+int is_ac3_es(unsigned char *es, int len);
+void pmt_add_descriptors(SPMT *pmt, unsigned char *pi, int len);
+void pmt_add_stream_pid_descriptors(SPMT *pmt, SStreamPid &sp,
+                                    unsigned char *es, int len);
+
 int test_descriptor_equality() {
     const uint8_t descr1_data[] = {0x09, 0x04, 0x0B, 0x00, 0x05, 0x73};
     descriptor_t descr1 = create_descriptor(descr1_data);
@@ -335,10 +340,152 @@ int test_emulate_add_all_pids() {
     return 0;
 }
 
+int test_truncated_descriptors() {
+    SPMT pmt = {};
+    SStreamPid sp;
+    // ISO_639_language, then one that claims 20 bytes with none left
+    uint8_t src[] = {0x0A, 0x04, 'd', 'e', 'u', 0x00, 0x52, 0x14};
+    uint8_t *desc = (uint8_t *)malloc(sizeof(src));
+
+    memcpy(desc, src, sizeof(src));
+    sp.pid = 34;
+    pmt_add_stream_pid_descriptors(&pmt, sp, desc, sizeof(src));
+    ASSERT(sp.descriptors.size() == 1,
+           "a truncated ES descriptor was accepted");
+
+    pmt_add_descriptors(&pmt, desc, sizeof(src));
+    ASSERT(pmt.descriptors.size() == 1,
+           "a truncated program descriptor was accepted");
+
+    // The same length, used to classify a stream rather than to walk a loop
+    uint8_t ac3[] = {0x6A, 0x14};
+    ASSERT(!is_ac3_es(ac3, sizeof(ac3)),
+           "a truncated AC-3 descriptor was accepted");
+
+    free(desc);
+    return 0;
+}
+
+// A CA descriptor with no room for a CAID must not be registered as one.
+int test_short_ca_descriptor() {
+    SPMT pmt = {};
+    SStreamPid sp;
+    uint8_t src[] = {0x09, 0x02, 0x09, 0x8D};
+    uint8_t *desc = (uint8_t *)malloc(sizeof(src));
+
+    memcpy(desc, src, sizeof(src));
+    sp.pid = 34;
+    pmt_add_stream_pid_descriptors(&pmt, sp, desc, sizeof(src));
+    pmt_add_descriptors(&pmt, desc, sizeof(src));
+    ASSERT(pmt.caids == 0, "a CA descriptor shorter than 4 bytes made a CAID");
+
+    free(desc);
+    return 0;
+}
+
+// A PMT of one stream, with program_info_length and ES_info_length as given
+// rather than as they should be.
+static int build_pmt_section(uint8_t *s, int pi_len, int es_len) {
+    uint8_t *b = s;
+    *b++ = 0x02;
+    b += 2; // section_length, filled in below
+    copy16(b, 0, 0x0083);
+    b += 2;
+    *b++ = 0xC1; // version 0, current
+    *b++ = 0;    // section number
+    *b++ = 0;    // last section number
+    copy16(b, 0, 0xE000 | 1279);
+    b += 2;
+    copy16(b, 0, 0xF000 | pi_len);
+    b += 2;
+    *b++ = 6; // an AC-3 candidate, so es_len is followed into is_ac3_es()
+    copy16(b, 0, 0xE000 | 1283);
+    b += 2;
+    copy16(b, 0, 0xF000 | es_len);
+    b += 2;
+    copy16(s, 1, 0xB000 | ((b - s) - 3 + 4));
+    copy32(b, 0, crc_32(s, b - s));
+    return (b - s) + 4;
+}
+
+// process_pmt() may read and record only what the section really contains.
+int test_pmt_section_bounds() {
+    adapter *ad = adapter_alloc();
+    SPMT pmt = {};
+    SFilter f = {};
+    uint8_t s[64], *sec;
+    int len;
+
+    a[0] = ad;
+    ad->id = 0;
+    ad->enabled = 1;
+    filters[0] = &f;
+    f.id = 0;
+    f.enabled = 1;
+    f.adapter = 0;
+    f.pid = 100;
+    f.master_filter = 0;
+    f.next_filter = -1; // or the filter list walks onto itself
+    pmts[0] = &pmt;
+    npmts = 1;
+    pmt.id = 0;
+    pmt.enabled = 1;
+    pmt.adapter = 0;
+    pmt.master_pmt = 0;
+    pmt.pid = 100;
+    pmt.version = -1;
+    pmt.state = PMT_STOPPED;
+    mark_pid_add(0, ad->id, 100);
+    update_pids(ad->id);
+
+    // A section too short to hold the header fields that are read from it
+    sec = (uint8_t *)malloc(6);
+    memset(sec, 0, 6);
+    sec[0] = 0x02;
+    sec[2] = 3;
+    ASSERT(process_pmt(0, sec, 6, &pmt) == 0 && pmt.version == -1,
+           "a section shorter than a PMT header was parsed");
+    free(sec);
+
+    // Sized exactly, so that a read past the section is caught as well
+    len = build_pmt_section(s, 10, 0);
+    sec = (uint8_t *)malloc(len);
+    memcpy(sec, s, len);
+    ASSERT(process_pmt(0, sec, len, &pmt) == 0 && pmt.version == -1,
+           "a program info length past the end of the section was parsed");
+    free(sec);
+
+    len = build_pmt_section(s, 0, 40);
+    sec = (uint8_t *)malloc(len);
+    memcpy(sec, s, len);
+    process_pmt(0, sec, len, &pmt);
+    // Only the entry the independent PCR pid adds after the loop
+    ASSERT(pmt.stream_pids.size() == 1 && pmt.stream_pids[0].type == 0,
+           "a stream whose descriptors are not in the section was recorded");
+    free(sec);
+
+    ad->active_pmts = 0;
+    filters[0] = NULL;
+    pmts[0] = NULL;
+    npmts = 0;
+    free(ad->buf);
+    delete ad;
+    a[0] = NULL;
+    return 0;
+}
+
+// Every stream keeps its descriptors, but only audio and video register their
+
 int main() {
     opts.log = 255;
     opts.debug = 255;
     strcpy(thread_info[thread_index].thread_name, "test_pmt");
+    TEST_FUNC(test_pmt_section_bounds(),
+              "testing the PMT section lengths are validated");
+    TEST_FUNC(test_truncated_descriptors(),
+              "testing truncated descriptor loops are not followed");
+    TEST_FUNC(test_short_ca_descriptor(),
+              "testing a CA descriptor without a CAID is not registered");
     TEST_FUNC(test_descriptor_equality(),
               "testing descriptor equality operator");
     TEST_FUNC(test_descriptor_caid_capid_getters(),

--- a/tests/test_pmt.cpp
+++ b/tests/test_pmt.cpp
@@ -476,10 +476,33 @@ int test_pmt_section_bounds() {
 
 // Every stream keeps its descriptors, but only audio and video register their
 
+// The parser does not classify streams: a subtitle or teletext stream keeps
+// its descriptors and registers its CAIDs like any other.
+int test_stream_pid_descriptors() {
+    SPMT pmt = {};
+    SStreamPid sp;
+    unsigned char es[] = {0x0A, 0x04, 'd',  'e',  'u',  0x00, 0x56,
+                          0x05, 'd',  'e',  'u',  0x10, 0x00, 0x09,
+                          0x04, 0x09, 0x8D, 0xE0, 0xCC};
+
+    sp.pid = 34;
+    pmt_add_stream_pid_descriptors(&pmt, sp, es, sizeof(es));
+    ASSERT(sp.descriptors.size() == 3,
+           "a stream that is neither audio nor video lost its descriptors");
+    ASSERT(pmt.caids == 1, "a teletext stream did not register its CAID");
+    ASSERT(pmt.ca[0]->id == 0x098D && pmt.ca[0]->pid == 0xCC,
+           "the CAID or its pid is wrong");
+
+    free(pmt.ca[0]);
+    return 0;
+}
+
 int main() {
     opts.log = 255;
     opts.debug = 255;
     strcpy(thread_info[thread_index].thread_name, "test_pmt");
+    TEST_FUNC(test_stream_pid_descriptors(),
+              "testing descriptors are kept for every stream type");
     TEST_FUNC(test_pmt_section_bounds(),
               "testing the PMT section lengths are validated");
     TEST_FUNC(test_truncated_descriptors(),


### PR DESCRIPTION
`process_pmt()` decided per stream whether it was audio or video and treated
everything else as second class: `pmt_add_stream_pid_descriptors()` was skipped
for it, so a teletext or subtitle stream ended up in the parsed PMT with no
descriptors at all. `ddci_create_pmt()` rebuilds the PMT from exactly that and
emits those streams bare.

What that costs, on RTL HD, measured through the PMT rebuild in #1425 because
it is the same parsed data:

```
without this PR                      with it
section_len=69                       section_len=111
  0x1B 255: 28/4                       0x1B 255: 28/4
  0x06 259: 0A/4 6A/4                  0x06 259: 0A/4 6A/4
  0x06  32: -                          0x06  32: 52/1 56/5        teletext
  0x05 261: -                          0x05 261: 6F/3
  0x06  48: -                          0x06  48: 59/8             subtitling
  0x0B 262: -                          0x0B 262: 52/1 13/5 66/2
  0x0C 263: -                          0x0C 263: 52/1
```

The client is told those streams exist but not that one is subtitles, nor in
which language.

## is_audio and is_video

@Jalle19 they are gone rather than carried further by a new flag. The three
places that asked for them want the same thing, and it is not a stream type:
skip the one entry in `stream_pids` that is not an elementary stream, the PCR
pid of a service that has one of its own. It already carries `type == 0`, which
no broadcast uses, so that is what they test now.

What changes for a stream that is neither audio nor video:

| | |
|---|---|
| its descriptors | recorded, so a rebuilt PMT still describes it |
| a CA descriptor on it | registers its CAID |
| a client requesting only that pid | starts the PMT that carries it |
| the CAPMT | lists it, as the DDCI PMT already did |
| `get_master_pmt_for_pid()` | matches on it, so two services sharing one can end up master and slave |

The last row is the one worth an opinion. Two services that share a data pid
but not a control word would now be linked, where before only shared audio or
video linked them. I have not seen it on 19.2E, and the alternative is keeping
a stream classifier alive for that one call, but say the word and it can test
something narrower there.

## DDCI

`ddci_create_pmt()` maps every pid it writes into the PMT it hands the CAM: the
stream pids, and the ECM pids of the program level CA descriptors it rebuilds
from `pmt->ca[]`. A CA descriptor inside a stream's descriptor list was copied
out byte for byte, ECM pid included, so it named a pid of the source adapter -
one the CAM never sees, because nothing is routed to it under that number. That
is true on master already for audio and video; this PR would extend it to every
other stream, so it is fixed here. `test_create_pmt()` asserted the unmapped
pid, so it described the bug; it now maps that ECM pid to a number already
taken on the DDCI, which makes an unmapped one visible.

The CAIDs are the other half. `pmt_add_caid()` already skips a CAID and pid it
has, and in practice an ES level CA descriptor repeats what the program level
carries, so the list usually does not grow at all. `CAPMT_add_PMT()` writes into
a caller supplied buffer whose length it was passed and never looked at; now
that more streams reach it, it stops at the end of that buffer instead of
writing past it, and the CA descriptors - identical for every stream of a PMT -
are built once rather than per stream.

## Bounds

The first commit is a prerequisite, not a drive by. The parser follows the
descriptor loops with the lengths the section itself carries and never checks
them, and `is_ac3_es()` is already called with an `es_len` that is validated
only afterwards. Parsing the streams that used to be skipped means following
more of those lengths, so they are checked first: the section against the header
fields read from it, `program_info_length` against the room left for the
streams, each `ES_info_length` against the end of the loop, and each descriptor
against the end of the loop it sits in. `pmt_len` and `pi_len` are read before
`stop_pmt()`, so a section that fails the check leaves the running PMT alone.

## Testing

Fedora 44, gcc 16, OSCam over dvbapi, Digital Devices DVB-S2, RTL/Nagra on
Astra 19.2E. `ctest` 13/13 with `TEST_SANITIZERS=ON` and `OFF`. The section and
descriptor loop tests are driven over buffers sized to their exact content, so
a read past one is an ASan error rather than slack.

Live, RTL HD: descrambling unchanged, and a client asking for the subtitle pid
and nothing else now starts the PMT and gets it sent to the card server, which
on master it did not. No DDCI hardware here, so that path is covered by
`test_create_pmt()` only.
