### PR TITLE
feat: add --hw-descrambler option and decouple from enigma

### DIFF
--- a/src/hw_descrambler.cpp
+++ b/src/hw_descrambler.cpp
@@ -216,8 +216,8 @@ void hw_delete_key(SCW *cw) {
 }
 
 void hw_set_cw(SCW *cw, SPMT *pmt) {
-    if (!opts.enigma) {
-        LOG("hw_descrambler: opts.enigma is 0, skipping hw_set_cw");
+    if (!opts.hw_descrambler) {
+        LOG("hw_descrambler: --hw-descrambler not enabled, skipping hw_set_cw");
         return;
     }
 
@@ -343,7 +343,7 @@ void hw_decrypt_stream(SCW *cw, SPMT_batch *batch, int batch_len) {
 }
 
 int hw_ca_del_pmt(adapter *ad, SPMT *pmt) {
-    if (!opts.enigma || !ad || !pmt)
+    if (!opts.hw_descrambler || !ad || !pmt)
         return 0;
 
     const int pmt_id = (pmt->master_pmt >= 0) ? pmt->master_pmt : pmt->id;
@@ -403,10 +403,9 @@ SCW_op hw_aes_cbc_op = {
 static SCA_op hw_ca_op{};
 
 void init_hw_descrambler() {
-    if (opts.enigma) {
-        LOG("hw_descrambler: Initializing Hardware Descrambler for Enigma2 "
-            "(opts.enigma = %d)",
-            opts.enigma);
+    if (opts.hw_descrambler) {
+        LOG("hw_descrambler: Initializing Hardware Descrambler "
+            "(--hw-descrambler enabled)");
         register_algo(&hw_csa_op);
         register_algo(&hw_aes_ecb_op);
         register_algo(&hw_aes_cbc_op);
@@ -417,6 +416,7 @@ void init_hw_descrambler() {
             reinterpret_cast<ca_device_action>(hw_ca_close_dev);
         add_ca(&hw_ca_op);
     } else {
-        LOG("hw_descrambler: opts.enigma is 0, hardware descrambler disabled");
+        LOG("hw_descrambler: --hw-descrambler not enabled, hardware "
+            "descrambler disabled");
     }
 }

--- a/src/minisatip.cpp
+++ b/src/minisatip.cpp
@@ -138,6 +138,7 @@ int rtsp, http, si, si1, ssdp1;
 #define SENDALLECM_OPT (LONG_OPT_ONLY_START + 2)
 #define SATIPC_RECV_BUFFER_OPT (LONG_OPT_ONLY_START + 3)
 #define CLIENT_SEND_BUFFER_OPT (LONG_OPT_ONLY_START + 4)
+#define HW_DESCRAMBLER_OPT (LONG_OPT_ONLY_START + 5)
 
 static const struct option long_options[] = {
     {"adapters", required_argument, NULL, ADAPTERS_OPT},
@@ -207,6 +208,7 @@ static const struct option long_options[] = {
     {"ci", required_argument, NULL, FORCE_CI_OPT},
     {"ca-channels", required_argument, NULL, CA_CHANNELS_OPT},
 #endif
+    {"hw-descrambler", no_argument, NULL, HW_DESCRAMBLER_OPT},
 
     {0, 0, 0, 0}};
 
@@ -541,6 +543,8 @@ Help\n\
 \n\
 * -9 --disable-pmt-scan: Disables scanning PMTs and only reads the PMTs that are requested by the client\n\
 \t* Provides more reliable decrypting for channels included in multiple providers\n\
+\n\
+* --hw-descrambler: Enable hardware descrambler (Enigma2 CA ioctl). Disabled by default\n\
 \n"
 #ifndef DISABLE_DVBCA
         "\
@@ -1074,6 +1078,9 @@ void set_options(int argc, char *argv[]) {
             break;
 
 #endif
+        case HW_DESCRAMBLER_OPT:
+            opts.hw_descrambler = 1;
+            break;
         }
     }
 

--- a/src/opts.h
+++ b/src/opts.h
@@ -52,6 +52,7 @@ typedef struct struct_opts {
     int use_demux_device;
     float strength_multiplier, snr_multiplier;
     char enigma;
+    char hw_descrambler;
 #ifndef DISABLE_SATIPCLIENT
     char *satip_servers;
     char *satip_xml;

--- a/tests/test_hw_descrambler.cpp
+++ b/tests/test_hw_descrambler.cpp
@@ -77,9 +77,10 @@ static int test_hw_key_lifecycle() {
     return 0;
 }
 
-// Test 2: PMT Creation and Hardware Descrambler Binding (opts.enigma checks)
+// Test 2: PMT Creation and Hardware Descrambler Binding (opts.hw_descrambler
+// checks)
 static int test_hw_descrambler_disabled_when_opts_enigma_zero() {
-    opts.enigma = 0;
+    opts.hw_descrambler = 0;
 
     adapter *ad = setup_mock_adapter(0, 0, 0);
     ASSERT(ad != nullptr, "setup_mock_adapter failed");
@@ -96,10 +97,10 @@ static int test_hw_descrambler_disabled_when_opts_enigma_zero() {
     std::fill_n(cw.cw, 8, 0xAA);
     hw_create_key(&cw);
 
-    // Call hw_set_cw when opts.enigma == 0
+    // Call hw_set_cw when opts.hw_descrambler == 0
     hw_set_cw(&cw, pmt);
 
-    // Verify hw_ca_del_pmt when opts.enigma == 0 returns safely
+    // Verify hw_ca_del_pmt when opts.hw_descrambler == 0 returns safely
     int res = hw_ca_del_pmt(ad, pmt);
     ASSERT(res == 0, "hw_ca_del_pmt should return 0");
 
@@ -111,7 +112,7 @@ static int test_hw_descrambler_disabled_when_opts_enigma_zero() {
 
 // Test 3: Multi-Channel Parallel Slot Allocation and Parity Sharing
 static int test_multi_channel_slot_allocation() {
-    opts.enigma = 1;
+    opts.hw_descrambler = 1;
 
     adapter *ad = setup_mock_adapter(0, 0, 0);
     ASSERT(ad != nullptr, "setup_mock_adapter failed");
@@ -205,7 +206,7 @@ static int test_multi_channel_slot_allocation() {
 
 // Test 4: AES-128 ECB & CBC Mode Key Programming Simulation
 static int test_aes128_key_programming() {
-    opts.enigma = 1;
+    opts.hw_descrambler = 1;
 
     adapter *ad = setup_mock_adapter(0, 0, 0);
     ASSERT(ad != nullptr, "setup_mock_adapter failed");
@@ -269,7 +270,7 @@ static int test_hw_ca_close_dev_and_null_guards() {
 
 // Test 6: CSA vs CSA-ICAM routing and Enigma hardware rejection of ICAM
 static int test_csa_vs_csa_icam_routing() {
-    opts.enigma = 1;
+    opts.hw_descrambler = 1;
 
     SCW_op *csa_op_res = get_op_for_algo(CA_ALGO_DVBCSA);
     ASSERT(csa_op_res != nullptr, "get_op_for_algo failed for CA_ALGO_DVBCSA");
@@ -322,7 +323,7 @@ int main() {
     TEST_FUNC(test_hw_key_lifecycle(),
               "testing hw_create_key and hw_delete_key lifecycle");
     TEST_FUNC(test_hw_descrambler_disabled_when_opts_enigma_zero(),
-              "testing hw_descrambler disabled when opts.enigma == 0");
+              "testing hw_descrambler disabled when opts.hw_descrambler == 0");
     TEST_FUNC(test_multi_channel_slot_allocation(),
               "testing multi-channel parallel slot allocation and unbinding");
     TEST_FUNC(test_aes128_key_programming(),


### PR DESCRIPTION
Decouple hardware descrambler from Enigma auto-detection.

- add opts.hw_descrambler flag and --hw-descrambler long option (no short letter, LONG_OPT_ONLY)
- hw_descrambler now initialized/used only when --hw-descrambler is passed, not when opts.enigma==1
- update hw_set_cw/hw_ca_del_pmt/init_hw_descrambler to check opts.hw_descrambler with updated log messages
- add help text for --hw-descrambler
- update tests/test_hw_descrambler to use opts.hw_descrambler
- pmt: add diagnostic LOG when validated CW search tests N CWs with M PUSI packets but none produces PES header 00 00 01 (explains found CW: -1)

Fixes the case where CAM/HW decrypts the stream (ffmpeg -c copy produces valid HEVC) but PMT validation logs found CW: -1 without showing tested count.
