### PR TITLE
fix(stream): account SRT bytes in BW calculation

### DIFF
--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -753,10 +753,11 @@ int flush_stream(streams *sid, struct iovec *iov, int iiov, int64_t ctime) {
     if (sid->type == STREAM_RTSP_SRT) {
         // Send raw TS data over SRT, chunked to max MAX_UDP_PACKET_SIZE bytes
         // (7 * 188)
-        for (int i = 0; i < iiov; i++) {
+        int srt_failed = 0;
+        for (int i = 0; i < iiov && !srt_failed; i++) {
             const char *data = (const char *)iov[i].iov_base;
             int remaining = iov[i].iov_len;
-            while (remaining > 0) {
+            while (remaining > 0 && !srt_failed) {
                 int chunk = remaining > MAX_UDP_PACKET_SIZE
                                 ? MAX_UDP_PACKET_SIZE
                                 : remaining;
@@ -769,11 +770,16 @@ int flush_stream(streams *sid, struct iovec *iov, int iiov, int64_t ctime) {
                     LOG("SRT send failed for sid %d: %s", sid->sid,
                         srt_getlasterror_str());
                     sid->timeout = 1;
-                    goto srt_done;
+                    srt_failed = 1;
                 }
             }
         }
-    srt_done:;
+        if (rv > 0) {
+            bw += rv;
+            writes++;
+        } else if (srt_failed) {
+            failed_writes++;
+        }
     } else
 #endif
     {

--- a/tests/test_stream.cpp
+++ b/tests/test_stream.cpp
@@ -18,7 +18,24 @@
 
 #include <linux/dvb/frontend.h>
 #include <string.h>
+#include <sys/uio.h>
 #include <unistd.h>
+
+#ifndef DISABLE_SRT
+#include "srt.h"
+// Mock srt_send: interposes the libsrt symbol in this test binary so
+// flush_stream() can be exercised without a real SRT connection.
+static int mock_srt_fail = 0;
+static int mock_srt_calls = 0;
+extern "C" int srt_send(SRTSOCKET u, const char *buf, int len) {
+    (void)u;
+    (void)buf;
+    mock_srt_calls++;
+    if (mock_srt_fail)
+        return SRT_ERROR;
+    return len;
+}
+#endif
 
 int mock_adapter_tune(int aid, transponder *tp) { return 0; }
 
@@ -210,6 +227,58 @@ int test_setup_stream_unspecified_vs_empty_pids() {
     return 0;
 }
 
+#ifndef DISABLE_SRT
+extern int64_t bw;
+extern uint32_t writes, failed_writes;
+int flush_stream(streams *sid, struct iovec *iov, int iiov, int64_t ctime);
+
+int test_flush_stream_srt_accounts_bw() {
+    setup_test_env();
+
+    int s_id = streams_add();
+    ASSERT(s_id >= 0, "streams_add failed");
+    streams *sid = get_sid(s_id);
+    ASSERT(sid != NULL, "get_sid returned NULL");
+    sid->type = STREAM_RTSP_SRT;
+    sid->srt_sock = 12345;
+    sid->rsock = -1;
+    sid->rsock_id = -1;
+
+    // Larger than MAX_UDP_PACKET_SIZE to exercise multi-chunk accounting
+    char buf[10 * DVB_FRAME];
+    memset(buf, 0, sizeof(buf));
+    struct iovec iov[1];
+    iov[0].iov_base = buf;
+    iov[0].iov_len = sizeof(buf);
+
+    mock_srt_fail = 0;
+    mock_srt_calls = 0;
+    int64_t bw0 = bw;
+    uint32_t w0 = writes;
+    uint32_t sb0 = sid->sb, sp0 = sid->sp;
+
+    int rv = flush_stream(sid, iov, 1, 0);
+    ASSERT(rv == (int)sizeof(buf), "SRT flush_stream should return sent bytes");
+    ASSERT(mock_srt_calls > 1, "expected chunked srt_send calls");
+    ASSERT(bw == bw0 + (int64_t)sizeof(buf), "bw not updated for SRT send");
+    ASSERT(writes == w0 + 1, "writes not updated for SRT send");
+    ASSERT(sid->sb == sb0 + sizeof(buf), "stream sb not updated");
+    ASSERT(sid->sp == sp0 + 1, "stream sp not updated");
+
+    mock_srt_fail = 1;
+    int64_t bw1 = bw;
+    uint32_t fw1 = failed_writes;
+    sid->timeout = 0;
+    rv = flush_stream(sid, iov, 1, 0);
+    ASSERT(sid->timeout == 1, "timeout not set on SRT send failure");
+    ASSERT(failed_writes == fw1 + 1,
+           "failed_writes not updated on SRT failure");
+    ASSERT(bw == bw1, "bw should not change on failed SRT send");
+    mock_srt_fail = 0;
+    return 0;
+}
+#endif
+
 int main() {
     opts.log = 1;
     opts.debug = 255;
@@ -223,6 +292,10 @@ int main() {
     TEST_FUNC(test_start_play_no_transport(),
               "test start_play returns error when transport is missing");
     TEST_FUNC(test_start_play_success(), "test start_play success under HTTP");
+#ifndef DISABLE_SRT
+    TEST_FUNC(test_flush_stream_srt_accounts_bw(),
+              "test SRT flush_stream updates bw counters");
+#endif
 
     fflush(stdout);
     free_all();


### PR DESCRIPTION
## Summary

The periodic status line always reported `BW 0 KB/s` while `DMX` showed the real demux rate whenever all clients used SRT transport, e.g.:

`BW 0 KB/s, DMX 2689 KB/s, ... r: 30, w: 4 fw: 0`

## Root cause

`flush_stream()` in `src/stream.cpp` sends SRT traffic (`STREAM_RTSP_SRT`) via `srt_send()` directly, bypassing `sockets_writev()`/`my_writev()` where the `bw` and `writes` counters are updated (added by the SRT support in #1388). With only SRT clients active, `bw` stayed 0 while `bw_dmx` (updated in `process_dmx()`) kept counting, hence `BW 0` next to a large `DMX`.

## Fix

Count successfully sent SRT bytes in `bw`/`writes` and empty failed SRT sends in `failed_writes`, mirroring the `my_writev()` accounting in `src/socketworks.cpp`.

## Tests

- New `test_flush_stream_srt_accounts_bw` in `tests/test_stream.cpp` (mocks `srt_send`): verifies `bw`/`writes`/`sb`/`sp` advance on multi-chunk SRT sends and that a send failure sets `timeout` and bumps `failed_writes` without touching `bw`. Fails on the unfixed code (`bw not updated for SRT send`), passes with the fix.
- Full native suite: 13/13 `ctest` tests pass; ARMv7 build also passes `test_stream` under qemu-arm.

## Live verification (Enigma2 ARMv7 STB, DVB-C over SRT)

Cross-compiled for armv7 (`arm-linux-gnueabihf`, static) and ran on the box: the status line now tracks the stream, e.g. `BW 1321 KB/s, DMX 1321 KB/s, ... w: 18 fw: 0` instead of `BW 0 KB/s`.